### PR TITLE
feat: implement PKCE (RFC 7636)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,7 @@
 # Autentico - OIDC Identity Provider
 
 [![Test Coverage](https://img.shields.io/badge/coverage-78.1%25-green.svg)](https://github.com/eugenioenko/autentico)
-[![Tests](https://img.shields.io/badge/tests-347-blue.svg)](https://github.com/eugenioenko/autentico)
+[![Tests](https://img.shields.io/badge/tests-358-blue.svg)](https://github.com/eugenioenko/autentico)
 [![Go Version](https://img.shields.io/badge/go-1.23+-blue.svg)](https://golang.org/dl/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
@@ -45,7 +45,7 @@ Autentico provides a full-featured OIDC Identity Provider with the following cap
 - **ID Token Issuance**: Issues RS256-signed ID tokens containing standard OIDC claims (`sub`, `iss`, `aud`, `exp`, `iat`, `nonce`).
 - **UserInfo Endpoint**: Serves authenticated identity claims via `/oauth2/userinfo` per the OIDC Core specification.
 - **JWK Set Endpoint**: Exposes public signing keys at `/oauth2/certs` for token verification by relying parties.
-- **Authorization Code Flow**: Implements the recommended secure flow for web and mobile applications.
+- **Authorization Code Flow with PKCE**: Implements the recommended secure flow for web and mobile applications, with Proof Key for Code Exchange (RFC 7636) support for public clients.
 - **Dynamic Client Registration**: Register and manage OAuth2 clients (relying parties) via REST API with support for confidential and public client types.
 - **Client Authentication**: Supports `client_secret_basic` (HTTP Basic Auth) and `client_secret_post` (form parameters) authentication methods.
 - **Refresh Token Support**: Allows relying parties to obtain new access tokens without re-authenticating the user.
@@ -287,7 +287,7 @@ Relying parties (OAuth2 clients) are managed via these endpoints. All require ad
 
 Autentico supports the following OAuth 2.0 / OIDC grant types:
 
-- **Authorization Code** — The recommended flow for web and native applications. The IdP authenticates the user, issues an authorization code, and the relying party exchanges it for ID + access tokens.
+- **Authorization Code (with PKCE)** — The recommended flow for web and native applications. The IdP authenticates the user, issues an authorization code, and the relying party exchanges it for ID + access tokens. PKCE (RFC 7636) is supported for public clients using S256 or plain challenge methods.
 - **Resource Owner Password Credentials** — Direct credential exchange. Provided for trusted or legacy clients; not recommended for new applications.
 - **Refresh Token** — Obtain new access tokens without re-authenticating the user.
 
@@ -371,16 +371,39 @@ curl -X POST http://localhost:9999/users/create \
 
 Redirect the user to the `/oauth2/authorize` endpoint to start the login process.
 
-**Using JavaScript:**
+**Using JavaScript (with PKCE):**
 
 ```javascript
+// Generate PKCE code_verifier and code_challenge
+function generateCodeVerifier() {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  return btoa(String.fromCharCode(...array))
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function generateCodeChallenge(verifier) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(verifier);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+const codeVerifier = generateCodeVerifier();
+const codeChallenge = await generateCodeChallenge(codeVerifier);
+// Store codeVerifier for the token exchange step
+sessionStorage.setItem("code_verifier", codeVerifier);
+
 const authServerUrl = "http://localhost:9999/oauth2/authorize";
 const params = new URLSearchParams({
-  response_type: "code", // For Authorization Code Flow
-  redirect_uri: "https://your-client-app.com/callback", // Must be in AuthAllowedRedirectURIs
-  scope: "openid profile email", // Standard OIDC scopes
-  state: "callback_state", // Recommended
-  nonce: crypto.randomUUID(), // Recommended: included in id_token for replay protection
+  response_type: "code",
+  redirect_uri: "https://your-client-app.com/callback",
+  scope: "openid profile email",
+  state: "callback_state",
+  nonce: crypto.randomUUID(),
+  code_challenge: codeChallenge,
+  code_challenge_method: "S256",
 });
 
 window.location.href = `${authServerUrl}?${params.toString()}`;
@@ -433,7 +456,7 @@ curl -X POST http://localhost:9999/oauth2/token \
   -d "client_secret=your_client_secret"
 ```
 
-**For Public Clients (no secret required):**
+**For Public Clients with PKCE (recommended):**
 
 ```bash
 curl -X POST http://localhost:9999/oauth2/token \
@@ -441,7 +464,8 @@ curl -X POST http://localhost:9999/oauth2/token \
   -d "grant_type=authorization_code" \
   -d "code=your_received_authorization_code" \
   -d "redirect_uri=https://your-client-app.com/callback" \
-  -d "client_id=your_client_id"
+  -d "client_id=your_client_id" \
+  -d "code_verifier=your_stored_code_verifier"
 ```
 
 A successful response will contain `access_token`, `id_token`, `refresh_token`, `token_type`, and `expires_in`.
@@ -592,12 +616,12 @@ The dev server runs at `http://localhost:5173/admin/` and proxies API requests t
 
 ## Testing
 
-Autentico maintains comprehensive test coverage with **347+ test functions** across unit, integration, and end-to-end tests.
+Autentico maintains comprehensive test coverage with **358+ test functions** across unit, integration, and end-to-end tests.
 
 ### Test Coverage
 
 ![Test Coverage](https://img.shields.io/badge/coverage-78.1%25-green.svg)
-![Test Count](https://img.shields.io/badge/tests-347-blue.svg)
+![Test Count](https://img.shields.io/badge/tests-358-blue.svg)
 ![Packages Tested](https://img.shields.io/badge/packages-15-lightgrey.svg)
 
 | Package          | Coverage | Test Count | Focus Area               |

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 ## High Priority (Core OIDC Gaps)
 
-- [ ] **PKCE** — Implement `code_challenge`/`code_verifier` validation. Parameters are already parsed in the authorize handler but marked TODO. Essential for SPAs and mobile clients.
+- [x] **PKCE** — Implement `code_challenge`/`code_verifier` validation (RFC 7636). Supports S256 and plain methods.
 - [x] **ID Token** — Return an `id_token` in the token response. JWT access tokens are already issued; `nonce` is captured but unused.
 - [ ] **Account Lockout** — Wire up lockout logic using existing `failed_login_attempts` and `locked_until` DB columns.
 

--- a/pkg/auth_code/create.go
+++ b/pkg/auth_code/create.go
@@ -8,8 +8,9 @@ func CreateAuthCode(code AuthCode) error {
 	query := `
 		INSERT INTO auth_codes (
 			code, user_id, client_id, redirect_uri, scope, nonce,
+			code_challenge, code_challenge_method,
 			expires_at, used, created_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 	`
 	_, err := db.GetDB().Exec(query,
 		code.Code,
@@ -18,6 +19,8 @@ func CreateAuthCode(code AuthCode) error {
 		code.RedirectURI,
 		code.Scope,
 		code.Nonce,
+		code.CodeChallenge,
+		code.CodeChallengeMethod,
 		code.ExpiresAt,
 		code.Used,
 		code.CreatedAt,

--- a/pkg/auth_code/model.go
+++ b/pkg/auth_code/model.go
@@ -3,13 +3,15 @@ package authcode
 import "time"
 
 type AuthCode struct {
-	Code        string
-	UserID      string
-	ClientID    string
-	RedirectURI string
-	Scope       string
-	Nonce       string
-	ExpiresAt   time.Time
-	Used        bool
-	CreatedAt   time.Time
+	Code                string
+	UserID              string
+	ClientID            string
+	RedirectURI         string
+	Scope               string
+	Nonce               string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	ExpiresAt           time.Time
+	Used                bool
+	CreatedAt           time.Time
 }

--- a/pkg/auth_code/read.go
+++ b/pkg/auth_code/read.go
@@ -10,7 +10,9 @@ import (
 
 func AuthCodeByCode(code string) (*AuthCode, error) {
 	query := `
-        SELECT code, user_id, client_id, redirect_uri, scope, nonce, expires_at, used, created_at
+        SELECT code, user_id, client_id, redirect_uri, scope, nonce,
+               code_challenge, code_challenge_method,
+               expires_at, used, created_at
         FROM auth_codes
         WHERE code = ?;
     `
@@ -23,6 +25,8 @@ func AuthCodeByCode(code string) (*AuthCode, error) {
 		&authCode.RedirectURI,
 		&authCode.Scope,
 		&authCode.Nonce,
+		&authCode.CodeChallenge,
+		&authCode.CodeChallengeMethod,
 		&authCode.ExpiresAt,
 		&authCode.Used,
 		&authCode.CreatedAt,

--- a/pkg/authorize/handler.go
+++ b/pkg/authorize/handler.go
@@ -40,9 +40,9 @@ func HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 		RedirectURI:         q.Get("redirect_uri"),
 		Scope:               q.Get("scope"),
 		State:               q.Get("state"),
-		Nonce:               q.Get("nonce"),                 // TODO
-		CodeChallenge:       q.Get("code_challenge"),        // TODO
-		CodeChallengeMethod: q.Get("code_challenge_method"), // TODO
+		Nonce:               q.Get("nonce"),
+		CodeChallenge:       q.Get("code_challenge"),
+		CodeChallengeMethod: q.Get("code_challenge_method"),
 	}
 
 	err := ValidateAuthorizeRequest(request)
@@ -96,14 +96,16 @@ func HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 				code, err := authcode.GenerateSecureCode()
 				if err == nil {
 					ac := authcode.AuthCode{
-						Code:        code,
-						UserID:      session.UserID,
-						ClientID:    request.ClientID,
-						RedirectURI: request.RedirectURI,
-						Scope:       request.Scope,
-						Nonce:       request.Nonce,
-						ExpiresAt:   time.Now().Add(cfg.AuthAuthorizationCodeExpiration),
-						Used:        false,
+						Code:                code,
+						UserID:              session.UserID,
+						ClientID:            request.ClientID,
+						RedirectURI:         request.RedirectURI,
+						Scope:               request.Scope,
+						Nonce:               request.Nonce,
+						CodeChallenge:       request.CodeChallenge,
+						CodeChallengeMethod: request.CodeChallengeMethod,
+						ExpiresAt:           time.Now().Add(cfg.AuthAuthorizationCodeExpiration),
+						Used:                false,
 					}
 					if authcode.CreateAuthCode(ac) == nil {
 						redirectURL := fmt.Sprintf("%s?code=%s&state=%s", request.RedirectURI, ac.Code, request.State)
@@ -122,12 +124,14 @@ func HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := map[string]any{
-		"State":          request.State,
-		"Redirect":       request.RedirectURI,
-		"ClientID":       request.ClientID,
-		"Scope":          request.Scope,
-		"Nonce":          request.Nonce,
-		csrf.TemplateTag: csrf.TemplateField(r),
+		"State":               request.State,
+		"Redirect":            request.RedirectURI,
+		"ClientID":            request.ClientID,
+		"Scope":               request.Scope,
+		"Nonce":               request.Nonce,
+		"CodeChallenge":       request.CodeChallenge,
+		"CodeChallengeMethod": request.CodeChallengeMethod,
+		csrf.TemplateTag:      csrf.TemplateField(r),
 	}
 
 	err = tmpl.Execute(w, data)

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -69,6 +69,8 @@ var createTableSQL = `
     redirect_uri TEXT NOT NULL,               -- Must match the one used in the initial request
     scope TEXT,                               -- Scopes associated with this code
     nonce TEXT NOT NULL DEFAULT '',            -- OIDC nonce for ID token replay protection
+    code_challenge TEXT NOT NULL DEFAULT '',   -- PKCE code challenge
+    code_challenge_method TEXT NOT NULL DEFAULT '', -- PKCE method (S256 or plain)
     expires_at DATETIME NOT NULL,             -- Expiration time (typically short-lived)
     used BOOLEAN DEFAULT FALSE,               -- To prevent reuse
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/pkg/login/handler.go
+++ b/pkg/login/handler.go
@@ -39,13 +39,15 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	request := LoginRequest{
-		Username: r.FormValue("username"),
-		Password: r.FormValue("password"),
-		Redirect: r.FormValue("redirect"),
-		State:    r.FormValue("state"),
-		ClientID: r.FormValue("client_id"),
-		Scope:    r.FormValue("scope"),
-		Nonce:    r.FormValue("nonce"),
+		Username:            r.FormValue("username"),
+		Password:            r.FormValue("password"),
+		Redirect:            r.FormValue("redirect"),
+		State:               r.FormValue("state"),
+		ClientID:            r.FormValue("client_id"),
+		Scope:               r.FormValue("scope"),
+		Nonce:               r.FormValue("nonce"),
+		CodeChallenge:       r.FormValue("code_challenge"),
+		CodeChallengeMethod: r.FormValue("code_challenge_method"),
 	}
 
 	err = ValidateLoginRequest(request)
@@ -89,14 +91,16 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	code := authcode.AuthCode{
-		Code:        authCode,
-		UserID:      usr.ID,
-		ClientID:    request.ClientID,
-		RedirectURI: request.Redirect,
-		Scope:       request.Scope,
-		Nonce:       request.Nonce,
-		ExpiresAt:   time.Now().Add(config.Get().AuthAuthorizationCodeExpiration),
-		Used:        false,
+		Code:                authCode,
+		UserID:              usr.ID,
+		ClientID:            request.ClientID,
+		RedirectURI:         request.Redirect,
+		Scope:               request.Scope,
+		Nonce:               request.Nonce,
+		CodeChallenge:       request.CodeChallenge,
+		CodeChallengeMethod: request.CodeChallengeMethod,
+		ExpiresAt:           time.Now().Add(config.Get().AuthAuthorizationCodeExpiration),
+		Used:                false,
 	}
 
 	err = authcode.CreateAuthCode(code)

--- a/pkg/login/model.go
+++ b/pkg/login/model.go
@@ -10,13 +10,15 @@ import (
 )
 
 type LoginRequest struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
-	State    string `json:"state"`
-	Redirect string `json:"redirect"`
-	ClientID string `json:"client_id"`
-	Scope    string `json:"scope"`
-	Nonce    string `json:"nonce"`
+	Username            string `json:"username"`
+	Password            string `json:"password"`
+	State               string `json:"state"`
+	Redirect            string `json:"redirect"`
+	ClientID            string `json:"client_id"`
+	Scope               string `json:"scope"`
+	Nonce               string `json:"nonce"`
+	CodeChallenge       string `json:"code_challenge"`
+	CodeChallengeMethod string `json:"code_challenge_method"`
 }
 
 func ValidateLoginRequest(input LoginRequest) error {

--- a/pkg/token/authorization_code.go
+++ b/pkg/token/authorization_code.go
@@ -1,6 +1,8 @@
 package token
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"time"
@@ -34,6 +36,18 @@ func UserByAuthorizationCode(w http.ResponseWriter, request TokenRequest) (*user
 		return nil, nil, fmt.Errorf("client ID mismatch")
 	}
 
+	// PKCE validation
+	if code.CodeChallenge != "" {
+		if request.CodeVerifier == "" {
+			utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_grant", "code_verifier is required")
+			return nil, nil, fmt.Errorf("code_verifier is required")
+		}
+		if !verifyCodeChallenge(code.CodeChallenge, code.CodeChallengeMethod, request.CodeVerifier) {
+			utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_grant", "PKCE verification failed")
+			return nil, nil, fmt.Errorf("PKCE verification failed")
+		}
+	}
+
 	err = authcode.MarkAuthCodeAsUsed(request.Code)
 	if err != nil {
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", fmt.Sprintf("Failed to mark authorization code as used: %v", err))
@@ -46,4 +60,21 @@ func UserByAuthorizationCode(w http.ResponseWriter, request TokenRequest) (*user
 		return nil, nil, err
 	}
 	return usr, code, nil
+}
+
+// verifyCodeChallenge validates the PKCE code_verifier against the stored code_challenge.
+// For S256: BASE64URL(SHA256(code_verifier)) must equal code_challenge.
+// For plain: code_verifier must equal code_challenge.
+func verifyCodeChallenge(codeChallenge, method, codeVerifier string) bool {
+	switch method {
+	case "S256", "":
+		// S256 is the default if no method specified but challenge exists
+		hash := sha256.Sum256([]byte(codeVerifier))
+		computed := base64.RawURLEncoding.EncodeToString(hash[:])
+		return computed == codeChallenge
+	case "plain":
+		return codeVerifier == codeChallenge
+	default:
+		return false
+	}
 }

--- a/pkg/token/handler.go
+++ b/pkg/token/handler.go
@@ -57,6 +57,7 @@ func HandleToken(w http.ResponseWriter, r *http.Request) {
 		RedirectURI:  r.FormValue("redirect_uri"),
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
+		CodeVerifier: r.FormValue("code_verifier"),
 		Username:     r.FormValue("username"),
 		Password:     r.FormValue("password"),
 		RefreshToken: r.FormValue("refresh_token"),

--- a/view/login.html
+++ b/view/login.html
@@ -180,6 +180,8 @@
         <input type="hidden" name="client_id" value="{{.ClientID}}" />
         <input type="hidden" name="scope" value="{{.Scope}}" />
         <input type="hidden" name="nonce" value="{{.Nonce}}" />
+        <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}" />
+        <input type="hidden" name="code_challenge_method" value="{{.CodeChallengeMethod}}" />
         <div class="control">
           <label for="username">Username</label>
           <input type="text" id="username" name="username" required />


### PR DESCRIPTION
## Summary
- Add PKCE (Proof Key for Code Exchange, RFC 7636) support to the authorization code flow
- Supports S256 (default) and plain challenge methods
- Stores `code_challenge` and `code_challenge_method` in auth codes, validates `code_verifier` at token exchange
- Fixes missing `code_verifier` parsing in token handler
- 11 new tests (unit + handler + E2E), all 358 tests pass

## Test plan
- [x] Unit tests for `verifyCodeChallenge` (S256, plain, default, unsupported method)
- [x] Handler tests for PKCE success, missing verifier, wrong verifier, no-PKCE backwards compatibility
- [x] E2E tests for full PKCE S256 flow, wrong verifier rejection, missing verifier rejection
- [x] All existing tests continue to pass (358 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)