### PR TITLE
fix: show login errors inline instead of raw JSON

### DIFF
--- a/pkg/authorize/handler.go
+++ b/pkg/authorize/handler.go
@@ -131,6 +131,7 @@ func HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 		"Nonce":               request.Nonce,
 		"CodeChallenge":       request.CodeChallenge,
 		"CodeChallengeMethod": request.CodeChallengeMethod,
+		"Error":               q.Get("error"),
 		csrf.TemplateTag:      csrf.TemplateField(r),
 	}
 

--- a/pkg/login/handler_test.go
+++ b/pkg/login/handler_test.go
@@ -114,8 +114,10 @@ func TestHandleLoginUser_WrongCredentials(t *testing.T) {
 
 	HandleLoginUser(rr, req)
 
-	assert.Equal(t, http.StatusInternalServerError, rr.Code)
-	assert.Contains(t, rr.Body.String(), "login failed")
+	assert.Equal(t, http.StatusFound, rr.Code)
+	location := rr.Header().Get("Location")
+	assert.Contains(t, location, "/oauth2/authorize")
+	assert.Contains(t, location, "error=")
 }
 
 func TestHandleLoginUser_NonExistentUser(t *testing.T) {
@@ -133,8 +135,10 @@ func TestHandleLoginUser_NonExistentUser(t *testing.T) {
 
 	HandleLoginUser(rr, req)
 
-	assert.Equal(t, http.StatusInternalServerError, rr.Code)
-	assert.Contains(t, rr.Body.String(), "login failed")
+	assert.Equal(t, http.StatusFound, rr.Code)
+	location := rr.Header().Get("Location")
+	assert.Contains(t, location, "/oauth2/authorize")
+	assert.Contains(t, location, "error=")
 }
 
 func TestValidateLoginRequest_InvalidPassword(t *testing.T) {

--- a/view/login.html
+++ b/view/login.html
@@ -182,6 +182,9 @@
         <input type="hidden" name="nonce" value="{{.Nonce}}" />
         <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}" />
         <input type="hidden" name="code_challenge_method" value="{{.CodeChallengeMethod}}" />
+        {{if .Error}}
+        <div class="error" role="alert">{{.Error}}</div>
+        {{end}}
         <div class="control">
           <label for="username">Username</label>
           <input type="text" id="username" name="username" required />


### PR DESCRIPTION
On failed login, redirect back to the authorize page with an error query param so the login form re-renders with the error message displayed to the user.