### PR TITLE
refactor: remove redundant theme font config fields

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -234,14 +234,12 @@ The login page can be customized via the `theme` object in `autentico.json`.
 
 **Theme Options:**
 
-| Field              | Description                                                    | Default                                                              |
-|--------------------|----------------------------------------------------------------|----------------------------------------------------------------------|
-| `themeTitle`       | Page title shown in browser tab                                | `Autentico Login`                                                    |
-| `themeLogoUrl`     | URL to a logo image (replaces default SVG)                     | _(default SVG logo)_                                                 |
-| `themeFontUrl`     | URL to load a web font (e.g., Google Fonts)                    | Fira Sans from Google Fonts                                          |
-| `themeFontFamily`  | CSS `font-family` value                                        | `"Fira Sans", "Helvetica Neue", Helvetica, Arial, sans-serif`       |
-| `themeCssFile`     | Path to an external CSS file (read once at startup)            | _(none)_                                                             |
-| `themeCssInline`   | Inline CSS string (overrides `themeCssFile` if both are set)   | _(none)_                                                             |
+| Field              | Description                                                    | Default              |
+|--------------------|----------------------------------------------------------------|----------------------|
+| `themeTitle`       | Page title shown in browser tab                                | `Autentico`          |
+| `themeLogoUrl`     | URL to a logo image (replaces default SVG)                     | _(default SVG logo)_ |
+| `themeCssFile`     | Path to an external CSS file (read once at startup)            | _(none)_             |
+| `themeCssInline`   | Inline CSS string (overrides `themeCssFile` if both are set)   | _(none)_             |
 
 **Example configuration:**
 
@@ -250,9 +248,19 @@ The login page can be customized via the `theme` object in `autentico.json`.
   "theme": {
     "themeTitle": "My App Login",
     "themeLogoUrl": "https://example.com/logo.png",
-    "themeFontUrl": "https://fonts.googleapis.com/css2?family=Inter:wght@300;700&display=swap",
-    "themeFontFamily": "\"Inter\", sans-serif",
     "themeCssFile": "/etc/autentico/custom-theme.css"
+  }
+}
+```
+
+Custom fonts can be loaded via `@import` in your CSS.
+You can also customize theme directly with `themeCssInline`:
+
+```json
+{
+  "theme": {
+    "themeTitle": "My App Login",
+    "themeCssInline": "@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;700&display=swap'); :root { --font-family: 'Inter', sans-serif; }"
   }
 }
 ```
@@ -265,7 +273,7 @@ Override these in your custom CSS file or `themeCssInline`:
 :root {
   /* Typography */
   --font-size: 16px;
-  --font-family: "Fira Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 
   /* Colors - Light Mode */
   --color-primary: #2e5bff;

--- a/pkg/authorize/handler.go
+++ b/pkg/authorize/handler.go
@@ -133,11 +133,9 @@ func HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 		"CodeChallengeMethod": request.CodeChallengeMethod,
 		"Error":               q.Get("error"),
 		csrf.TemplateTag:      csrf.TemplateField(r),
-		"ThemeTitle":          cfg.Theme.Title,
-		"ThemeFontUrl":        cfg.Theme.FontUrl,
-		"ThemeFontFamily":     template.CSS(cfg.Theme.FontFamily),
-		"ThemeLogoUrl":        cfg.Theme.LogoUrl,
-		"ThemeCssResolved":    template.CSS(cfg.ThemeCssResolved),
+		"ThemeTitle":       cfg.Theme.Title,
+		"ThemeLogoUrl":     cfg.Theme.LogoUrl,
+		"ThemeCssResolved": template.CSS(cfg.ThemeCssResolved),
 	}
 
 	err = tmpl.Execute(w, data)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,12 +8,10 @@ import (
 )
 
 type ThemeConfig struct {
-	CssFile    string `json:"themeCssFile"`
-	CssInline  string `json:"themeCssInline"`
-	LogoUrl    string `json:"themeLogoUrl"`
-	Title      string `json:"themeTitle"`
-	FontUrl    string `json:"themeFontUrl"`
-	FontFamily string `json:"themeFontFamily"`
+	CssFile   string `json:"themeCssFile"`
+	CssInline string `json:"themeCssInline"`
+	LogoUrl   string `json:"themeLogoUrl"`
+	Title     string `json:"themeTitle"`
 }
 
 type Config struct {
@@ -107,9 +105,7 @@ var defaultConfig = Config{
 	AuthAccountLockoutDuration:      15 * time.Minute,
 	AuthAccountLockoutDurationStr:   "15m",
 	Theme: ThemeConfig{
-		Title:      "Autentico",
-		FontUrl:    "https://fonts.googleapis.com/css2?family=Fira+Sans:wght@300;700&display=swap",
-		FontFamily: `"Fira Sans", "Helvetica Neue", Helvetica, Arial, sans-serif`,
+		Title: "Autentico",
 	},
 }
 

--- a/view/login.html
+++ b/view/login.html
@@ -4,16 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{{.ThemeTitle}}</title>
-    {{if .ThemeFontUrl}}
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="{{.ThemeFontUrl}}" rel="stylesheet" />
-    {{end}}
     <style>
       :root {
         /* Typography */
         --font-size: 16px;
-        --font-family: {{.ThemeFontFamily}};
+        --font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
         --h1-font-size: 2rem;
 
         /* Layout */


### PR DESCRIPTION
## Summary
- Removed `themeFontUrl` and `themeFontFamily` config fields — redundant since custom fonts can be loaded via `@import` in `themeCssFile` or `themeCssInline`
- Default font stack changed from Fira Sans (Google Fonts) to `system-ui` (no external request)
- Updated README with example showing how to load custom fonts via CSS `@import`

## Test plan
- [x] All tests pass
- [x] No remaining references to removed fields
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)