### PR TITLE
feat: add "trust this device" MFA bypass

### DIFF
--- a/autentico.json
+++ b/autentico.json
@@ -38,6 +38,8 @@
   "authAccountLockoutDuration": "15m",
   "auth_mode": "password",
   "passkey_rp_name": "Autentico",
+  "trust_device_enabled": false,
+  "trust_device_expiration": "720h",
   "mfaEnabled": true,
   "mfaMethod": "totp",
   "smtpHost": "",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,9 @@ type Config struct {
 	AuthAccountLockoutDurationStr      string        `json:"authAccountLockoutDuration"`
 	AuthMode                           string        `json:"auth_mode"`
 	PasskeyRPName                      string        `json:"passkey_rp_name"`
+	TrustDeviceEnabled                 bool          `json:"trust_device_enabled"`
+	TrustDeviceExpiration              time.Duration `json:"-"`
+	TrustDeviceExpirationStr           string        `json:"trust_device_expiration"`
 	MfaEnabled                         bool          `json:"mfaEnabled"`
 	MfaMethod                          string        `json:"mfaMethod"`
 	SmtpHost                           string        `json:"smtpHost"`
@@ -115,6 +118,9 @@ var defaultConfig = Config{
 	AuthAccountLockoutDurationStr:   "15m",
 	AuthMode:      "password",
 	PasskeyRPName: "Autentico",
+	TrustDeviceEnabled:       false,
+	TrustDeviceExpiration:    30 * 24 * time.Hour,
+	TrustDeviceExpirationStr: "720h",
 	MfaEnabled: false,
 	MfaMethod:  "totp",
 	SmtpPort:   "587",
@@ -157,6 +163,7 @@ func InitConfig(path string) error {
 	cfg.AuthAuthorizationCodeExpiration = parseDuration(cfg.AuthAuthorizationCodeExpirationStr, defaultConfig.AuthAuthorizationCodeExpiration)
 	cfg.AuthSsoSessionIdleTimeout = parseDuration(cfg.AuthSsoSessionIdleTimeoutStr, defaultConfig.AuthSsoSessionIdleTimeout)
 	cfg.AuthAccountLockoutDuration = parseDuration(cfg.AuthAccountLockoutDurationStr, defaultConfig.AuthAccountLockoutDuration)
+	cfg.TrustDeviceExpiration = parseDuration(cfg.TrustDeviceExpirationStr, defaultConfig.TrustDeviceExpiration)
 
 	// Resolve theme CSS: file first, inline overrides
 	if cfg.Theme.CssFile != "" {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -102,6 +102,16 @@ var createTableSQL = `
 		FOREIGN KEY (user_id) REFERENCES users(id)
 	);
 
+	CREATE TABLE IF NOT EXISTS trusted_devices (
+		id TEXT PRIMARY KEY,
+		user_id TEXT NOT NULL,
+		device_name TEXT NOT NULL DEFAULT '',
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		last_used_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		expires_at DATETIME NOT NULL,
+		FOREIGN KEY (user_id) REFERENCES users(id)
+	);
+
 	CREATE TABLE IF NOT EXISTS passkey_challenges (
 		id TEXT PRIMARY KEY,
 		user_id TEXT NOT NULL,
@@ -148,6 +158,7 @@ var dropTableSQL = `
 		DROP TABLE IF EXISTS auth_codes;
 		DROP TABLE IF EXISTS idp_sessions;
 		DROP TABLE IF EXISTS mfa_challenges;
+		DROP TABLE IF EXISTS trusted_devices;
 		DROP TABLE IF EXISTS passkey_challenges;
 		DROP TABLE IF EXISTS passkey_credentials;
 		DROP TABLE IF EXISTS clients;

--- a/pkg/login/handler.go
+++ b/pkg/login/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/idpsession"
 	"github.com/eugenioenko/autentico/pkg/mfa"
+	"github.com/eugenioenko/autentico/pkg/trusteddevice"
 	"github.com/eugenioenko/autentico/pkg/user"
 	"github.com/eugenioenko/autentico/pkg/utils"
 )
@@ -83,7 +84,8 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 
 	// MFA check: if enabled globally, redirect to MFA verification
 	cfg := config.Get()
-	if cfg.MfaEnabled {
+	skipMfa := cfg.TrustDeviceEnabled && trusteddevice.IsDeviceTrusted(usr.ID, r)
+	if cfg.MfaEnabled && !skipMfa {
 		method := cfg.MfaMethod
 		// If method is "both", prefer TOTP if user is enrolled, otherwise email
 		if method == "both" {

--- a/pkg/trusteddevice/create.go
+++ b/pkg/trusteddevice/create.go
@@ -1,0 +1,14 @@
+package trusteddevice
+
+import (
+	"github.com/eugenioenko/autentico/pkg/db"
+)
+
+func CreateTrustedDevice(device TrustedDevice) error {
+	query := `
+		INSERT INTO trusted_devices (id, user_id, device_name, expires_at)
+		VALUES (?, ?, ?, ?)
+	`
+	_, err := db.GetDB().Exec(query, device.ID, device.UserID, device.DeviceName, device.ExpiresAt)
+	return err
+}

--- a/pkg/trusteddevice/model.go
+++ b/pkg/trusteddevice/model.go
@@ -1,0 +1,12 @@
+package trusteddevice
+
+import "time"
+
+type TrustedDevice struct {
+	ID         string    // token stored in cookie
+	UserID     string
+	DeviceName string
+	CreatedAt  time.Time
+	LastUsedAt time.Time
+	ExpiresAt  time.Time
+}

--- a/pkg/trusteddevice/read.go
+++ b/pkg/trusteddevice/read.go
@@ -1,0 +1,25 @@
+package trusteddevice
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/eugenioenko/autentico/pkg/db"
+)
+
+func TrustedDeviceByID(id string) (*TrustedDevice, error) {
+	var d TrustedDevice
+	query := `
+		SELECT id, user_id, device_name, created_at, last_used_at, expires_at
+		FROM trusted_devices WHERE id = ?
+	`
+	row := db.GetDB().QueryRow(query, id)
+	err := row.Scan(&d.ID, &d.UserID, &d.DeviceName, &d.CreatedAt, &d.LastUsedAt, &d.ExpiresAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("trusted device not found")
+		}
+		return nil, fmt.Errorf("failed to get trusted device: %w", err)
+	}
+	return &d, nil
+}

--- a/pkg/trusteddevice/service.go
+++ b/pkg/trusteddevice/service.go
@@ -1,0 +1,54 @@
+package trusteddevice
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/eugenioenko/autentico/pkg/config"
+)
+
+const CookieName = "autentico_trusted_device"
+
+// SetCookie writes the trusted device cookie with the given token and expiry.
+func SetCookie(w http.ResponseWriter, deviceID string, expiry time.Duration) {
+	cfg := config.Get()
+	http.SetCookie(w, &http.Cookie{
+		Name:     CookieName,
+		Value:    deviceID,
+		Path:     cfg.AppOAuthPath,
+		HttpOnly: true,
+		Secure:   cfg.AuthIdpSessionSecureCookie,
+		SameSite: http.SameSiteStrictMode,
+		MaxAge:   int(expiry.Seconds()),
+	})
+}
+
+// ReadCookie returns the trusted device token from the request, or "" if absent.
+func ReadCookie(r *http.Request) string {
+	cookie, err := r.Cookie(CookieName)
+	if err != nil {
+		return ""
+	}
+	return cookie.Value
+}
+
+// IsDeviceTrusted returns true if the request carries a valid, non-expired trusted
+// device token that belongs to the given user.
+func IsDeviceTrusted(userID string, r *http.Request) bool {
+	token := ReadCookie(r)
+	if token == "" {
+		return false
+	}
+	device, err := TrustedDeviceByID(token)
+	if err != nil {
+		return false
+	}
+	if device.UserID != userID {
+		return false
+	}
+	if time.Now().After(device.ExpiresAt) {
+		return false
+	}
+	_ = UpdateLastUsed(token)
+	return true
+}

--- a/pkg/trusteddevice/trusteddevice_test.go
+++ b/pkg/trusteddevice/trusteddevice_test.go
@@ -1,0 +1,159 @@
+package trusteddevice
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	testutils "github.com/eugenioenko/autentico/tests/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sampleDevice(id, userID string) TrustedDevice {
+	return TrustedDevice{
+		ID:         id,
+		UserID:     userID,
+		DeviceName: "TestBrowser/1.0",
+		ExpiresAt:  time.Now().Add(24 * time.Hour),
+	}
+}
+
+// --- CreateTrustedDevice ---
+
+func TestCreateTrustedDevice(t *testing.T) {
+	testutils.WithTestDB(t)
+	dev := sampleDevice("dev-create-1", "user-1")
+	err := CreateTrustedDevice(dev)
+	require.NoError(t, err)
+}
+
+func TestCreateTrustedDeviceDuplicateID(t *testing.T) {
+	testutils.WithTestDB(t)
+	dev := sampleDevice("dev-dup-1", "user-1")
+	require.NoError(t, CreateTrustedDevice(dev))
+	err := CreateTrustedDevice(dev)
+	assert.Error(t, err)
+}
+
+// --- TrustedDeviceByID ---
+
+func TestTrustedDeviceByID(t *testing.T) {
+	testutils.WithTestDB(t)
+	dev := sampleDevice("dev-read-1", "user-read-1")
+	require.NoError(t, CreateTrustedDevice(dev))
+
+	got, err := TrustedDeviceByID("dev-read-1")
+	require.NoError(t, err)
+	assert.Equal(t, dev.ID, got.ID)
+	assert.Equal(t, dev.UserID, got.UserID)
+	assert.Equal(t, dev.DeviceName, got.DeviceName)
+}
+
+func TestTrustedDeviceByIDNotFound(t *testing.T) {
+	testutils.WithTestDB(t)
+	_, err := TrustedDeviceByID("does-not-exist")
+	assert.Error(t, err)
+}
+
+// --- UpdateLastUsed ---
+
+func TestUpdateLastUsed(t *testing.T) {
+	testutils.WithTestDB(t)
+	dev := sampleDevice("dev-update-1", "user-1")
+	require.NoError(t, CreateTrustedDevice(dev))
+
+	err := UpdateLastUsed("dev-update-1")
+	require.NoError(t, err)
+
+	got, err := TrustedDeviceByID("dev-update-1")
+	require.NoError(t, err)
+	assert.Equal(t, "dev-update-1", got.ID)
+}
+
+func TestUpdateLastUsedNonexistent(t *testing.T) {
+	testutils.WithTestDB(t)
+	// No row affected, but UPDATE should not return an error.
+	err := UpdateLastUsed("ghost-device")
+	assert.NoError(t, err)
+}
+
+// --- IsDeviceTrusted ---
+
+func TestIsDeviceTrustedValid(t *testing.T) {
+	testutils.WithTestDB(t)
+	dev := sampleDevice("dev-trusted-1", "user-trusted-1")
+	require.NoError(t, CreateTrustedDevice(dev))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: "dev-trusted-1"})
+
+	assert.True(t, IsDeviceTrusted("user-trusted-1", req))
+}
+
+func TestIsDeviceTrustedWrongUser(t *testing.T) {
+	testutils.WithTestDB(t)
+	dev := sampleDevice("dev-trusted-2", "user-a")
+	require.NoError(t, CreateTrustedDevice(dev))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: "dev-trusted-2"})
+
+	assert.False(t, IsDeviceTrusted("user-b", req))
+}
+
+func TestIsDeviceTrustedExpired(t *testing.T) {
+	testutils.WithTestDB(t)
+	dev := TrustedDevice{
+		ID:         "dev-expired-1",
+		UserID:     "user-exp-1",
+		DeviceName: "TestBrowser",
+		ExpiresAt:  time.Now().Add(-1 * time.Hour), // already expired
+	}
+	require.NoError(t, CreateTrustedDevice(dev))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: "dev-expired-1"})
+
+	assert.False(t, IsDeviceTrusted("user-exp-1", req))
+}
+
+func TestIsDeviceTrustedNoCookie(t *testing.T) {
+	testutils.WithTestDB(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	assert.False(t, IsDeviceTrusted("any-user", req))
+}
+
+func TestIsDeviceTrustedUnknownToken(t *testing.T) {
+	testutils.WithTestDB(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: "unknown-token"})
+	assert.False(t, IsDeviceTrusted("any-user", req))
+}
+
+// --- SetCookie / ReadCookie ---
+
+func TestSetCookieAndReadCookie(t *testing.T) {
+	w := httptest.NewRecorder()
+	SetCookie(w, "device-abc", 30*24*time.Hour)
+
+	resp := w.Result()
+	cookies := resp.Cookies()
+	require.Len(t, cookies, 1)
+	assert.Equal(t, CookieName, cookies[0].Name)
+	assert.Equal(t, "device-abc", cookies[0].Value)
+	assert.True(t, cookies[0].HttpOnly)
+	assert.Equal(t, int((30 * 24 * time.Hour).Seconds()), cookies[0].MaxAge)
+}
+
+func TestReadCookieMissing(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	assert.Equal(t, "", ReadCookie(req))
+}
+
+func TestReadCookiePresent(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: "tok123"})
+	assert.Equal(t, "tok123", ReadCookie(req))
+}

--- a/pkg/trusteddevice/update.go
+++ b/pkg/trusteddevice/update.go
@@ -1,0 +1,12 @@
+package trusteddevice
+
+import (
+	"github.com/eugenioenko/autentico/pkg/db"
+)
+
+func UpdateLastUsed(id string) error {
+	_, err := db.GetDB().Exec(
+		`UPDATE trusted_devices SET last_used_at = CURRENT_TIMESTAMP WHERE id = ?`, id,
+	)
+	return err
+}

--- a/view/mfa.html
+++ b/view/mfa.html
@@ -161,6 +161,18 @@
           .error {
             color: var(--color-danger);
           }
+
+          .trust-device {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+          }
+
+          .trust-device label {
+            padding: 0;
+            margin: 0;
+            cursor: pointer;
+          }
         </style>
     
     {{if .ThemeCssResolved}}
@@ -210,6 +222,12 @@
           <label for="code">Code</label>
           <input type="text" id="code" name="code" required maxlength="6" pattern="[0-9]{6}" autocomplete="one-time-code" inputmode="numeric" />
         </div>
+        {{if .TrustDeviceEnabled}}
+        <div class="control trust-device">
+          <input type="checkbox" id="trust_device" name="trust_device" />
+          <label for="trust_device">Trust this device for {{.TrustDeviceDays}} days</label>
+        </div>
+        {{end}}
         <button type="submit">Verify</button>
       </form>
     </main>


### PR DESCRIPTION
## Summary

- After successful MFA, users can check **"Trust this device"** to skip MFA on future logins from the same browser
- Trust stored server-side in a new `trusted_devices` table, identified by a secure random token in an HttpOnly cookie
- Configurable expiration (default 30 days via `trust_device_expiration`); feature is opt-in via `trust_device_enabled: false` by default

## Changes

- **Config**: `TrustDeviceEnabled` + `TrustDeviceExpiration` fields with defaults
- **DB**: new `trusted_devices` table (id, user_id, device_name, created_at, last_used_at, expires_at)
- **`pkg/trusteddevice`**: new package — model, CRUD, cookie set/read, `IsDeviceTrusted` helper
- **Login handler**: skips MFA redirect when device is trusted
- **MFA handler**: saves trusted device record + sets cookie when checkbox is submitted; passes `TrustDeviceEnabled`/`TrustDeviceDays` to template
- **MFA template**: shows "Trust this device for N days" checkbox (only when enabled)

## Test plan

- [ ] Set `trust_device_enabled: true` in config, enable MFA
- [ ] Log in → complete MFA → check "Trust this device" → redirected to client
- [ ] Log in again from same browser → MFA skipped, redirected directly
- [ ] Manually set `expires_at` to past in DB → MFA required again on next login
- [ ] `make test` — all 14 new trusteddevice tests pass, full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)