### PR TITLE
fix: remove realm_access roles claim and fix azp client ID

### DIFF
--- a/autentico.json
+++ b/autentico.json
@@ -30,7 +30,6 @@
   "authAccessTokenAudience": [
     "el_autentico_!"
   ],
-  "authRealmAccessRoles": [],
   "authSsoSessionIdleTimeout": "1h",
   "authIdpSessionCookieName": "autentico_idp_session",
   "authIdpSessionSecureCookie": false,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,7 +48,6 @@ type Config struct {
 	ValidationUsernameIsEmail          bool          `json:"validationUsernameIsEmail"`
 	ValidationEmailRequired            bool          `json:"validationEmailRequired"`
 	AuthAccessTokenAudience            []string      `json:"authAccessTokenAudience"`
-	AuthRealmAccessRoles               []string      `json:"authRealmAccessRoles"`
 	AuthSsoSessionIdleTimeout          time.Duration `json:"-"`
 	AuthSsoSessionIdleTimeoutStr       string        `json:"authSsoSessionIdleTimeout"`
 	AuthIdpSessionCookieName           string        `json:"authIdpSessionCookieName"`
@@ -112,7 +111,6 @@ var defaultConfig = Config{
 	AuthAccessTokenAudience: []string{
 		"el_autentico_!",
 	},
-	AuthRealmAccessRoles:         []string{},
 	AuthSsoSessionIdleTimeout:    0,
 	AuthSsoSessionIdleTimeoutStr: "0",
 	AuthIdpSessionCookieName:        "autentico_idp_session",

--- a/pkg/token/generate.go
+++ b/pkg/token/generate.go
@@ -14,7 +14,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/user"
 )
 
-func GenerateTokens(user user.User) (*AuthToken, error) {
+func GenerateTokens(user user.User, clientID string) (*AuthToken, error) {
 	sessionID := xid.New().String()
 	accessTokenExpiresAt := time.Now().Add(config.Get().AuthAccessTokenExpiration).UTC()
 	refreshTokenExpiresAt := time.Now().Add(config.Get().AuthRefreshTokenExpiration).UTC()
@@ -28,12 +28,9 @@ func GenerateTokens(user user.User) (*AuthToken, error) {
 		"aud":       config.Get().AuthAccessTokenAudience,
 		"sub":       user.ID,
 		"typ":       "Bearer",
-		"azp":       config.Get().AuthDefaultClientID,
+		"azp":       firstNonEmpty(clientID, config.Get().AuthDefaultClientID),
 		"sid":       sessionID,
 		"acr":       "password",
-		"realm_access": map[string]interface{}{
-			"roles": config.Get().AuthRealmAccessRoles,
-		},
 		"scope":              "openid profile email",
 		"email_verified":     false,
 		"name":               user.Username,
@@ -131,6 +128,15 @@ func containsScope(scopeStr string, target string) bool {
 		}
 	}
 	return false
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func SetRefreshTokenAsSecureCookie(w http.ResponseWriter, refreshToken string) {

--- a/pkg/token/generate_test.go
+++ b/pkg/token/generate_test.go
@@ -25,7 +25,7 @@ func TestGenerateTokens(t *testing.T) {
 		Email:    "testuser@example.com",
 	}
 
-	tokens, err := GenerateTokens(testUser)
+	tokens, err := GenerateTokens(testUser, "")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, tokens.AccessToken)
 	assert.NotEmpty(t, tokens.RefreshToken)

--- a/pkg/token/handler.go
+++ b/pkg/token/handler.go
@@ -132,7 +132,7 @@ func HandleToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	authToken, err := GenerateTokens(*usr)
+	authToken, err := GenerateTokens(*usr, request.ClientID)
 	if err != nil {
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", fmt.Sprintf("Token generation failed: %v", err))
 		return

--- a/pkg/token/handler_test.go
+++ b/pkg/token/handler_test.go
@@ -764,7 +764,7 @@ func TestUserByRefreshToken_SessionNotFound(t *testing.T) {
 	}
 
 	// Generate tokens to get a valid refresh token (session won't exist in DB)
-	authToken, err := GenerateTokens(usr)
+	authToken, err := GenerateTokens(usr, "")
 	assert.NoError(t, err)
 
 	rr := httptest.NewRecorder()

--- a/tests/auth/auth_test.go
+++ b/tests/auth/auth_test.go
@@ -75,7 +75,7 @@ func TestRevokeToken(t *testing.T) {
 	testutils.WithTestDB(t)
 	_, _ = user.CreateUser(testEmail, testPassword, testEmail)
 	authUser, _ := user.AuthenticateUser(testEmail, testPassword)
-	authToken, _ := token.GenerateTokens(*authUser)
+	authToken, _ := token.GenerateTokens(*authUser, "")
 	_ = token.CreateToken(token.Token{
 		UserID:       authToken.UserID,
 		AccessToken:  authToken.AccessToken,
@@ -146,7 +146,7 @@ func TestLogoutEndpoint(t *testing.T) {
 	_, _ = user.CreateUser(testEmail, testPassword, testEmail)
 	authUser, _ := user.AuthenticateUser(testEmail, testPassword)
 
-	authToken, _ := token.GenerateTokens(*authUser)
+	authToken, _ := token.GenerateTokens(*authUser, "")
 	_ = token.CreateToken(token.Token{
 		UserID:       authToken.UserID,
 		AccessToken:  authToken.AccessToken,


### PR DESCRIPTION
## Summary

- Remove `authRealmAccessRoles` config option and the `realm_access.roles` claim from access tokens — this was a Keycloak-specific non-standard claim that isn't needed
- Fix `azp` claim in access tokens to use the actual requesting client ID instead of the hardcoded default from config; falls back to `authDefaultClientID` when no client ID is provided

## Test plan

- [x] All existing tests pass (`make test`)
- [x] `GenerateTokens` signature updated and all callers fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)