### PR TITLE
docs: simplify installation and document init command

### DIFF
--- a/docs-web/src/content/docs/getting-started/installation.mdx
+++ b/docs-web/src/content/docs/getting-started/installation.mdx
@@ -45,6 +45,21 @@ Pre-built binaries for Linux, macOS, and Windows are available on the [GitHub Re
    ```bash
    autentico start
    ```
+   You should see output like this:
+   ```
+     Autentico OIDC Identity Provider
+
+     ONBOARDING: http://localhost:9999/admin/
+
+     Server:    http://localhost:9999
+     Admin UI:  http://localhost:9999/admin/
+     API Docs:  http://localhost:9999/admin/docs/
+     WellKnown: http://localhost:9999/.well-known/openid-configuration
+     JWKS:      http://localhost:9999/.well-known/jwks.json
+     Authorize: http://localhost:9999/oauth2/authorize
+     Token:     http://localhost:9999/oauth2/token
+   ```
+   The `ONBOARDING` line appears only on first run. Visit it to create the admin account.
 </Steps>
 
 </TabItem>
@@ -100,6 +115,7 @@ Requires Go 1.22 or later.
    ./autentico init
    ./autentico start
    ```
+   On first run you'll see an `ONBOARDING` URL — visit it to set up the admin account.
 </Steps>
 
 </TabItem>


### PR DESCRIPTION
## Summary

- Simplifies the binary download section to show one platform example (Linux amd64) with a note that all builds are on the GitHub Releases page
- Removes the non-existent `--version` command from installation steps
- Documents `autentico init` — generates `.env` with all crypto secrets, accepts `--url` flag
- Adds a CLI command reference table (`init` / `start`)

## Test plan

- [ ] Verify page renders correctly in `pnpm dev`
- [ ] Confirm `pnpm build` passes with no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)