### PR TITLE
feat: enforce PKCE S256 and reject plain code challenge method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Variables
 APP_NAME=autentico
+SWAG=$(shell go env GOPATH)/bin/swag
 
 # Default target
 all: build
@@ -32,7 +33,7 @@ lint:
 
 # Generate swagger docs
 generate-docs:
-	swag init
+	$(SWAG) init
 	npx @redocly/cli build-docs ./docs/swagger.yaml --output=./docs/index.html
 
 # Build admin UI and copy to pkg/admin/dist
@@ -49,5 +50,8 @@ docker-build:
 docker-compose:
 	docker compose up -d
 
-generate-key:
-	openssl genpkey -algorithm RSA -out ./db/private_key.pem -pkeyopt rsa_keygen_bits:2048
+# Fresh start: wipe local DB, rebuild, init, and launch
+fresh: build
+	rm -f ./db/autentico.db .env
+	./$(APP_NAME) init
+	./$(APP_NAME) start

--- a/admin-ui/src/pages/SettingsPage.tsx
+++ b/admin-ui/src/pages/SettingsPage.tsx
@@ -20,10 +20,14 @@ import { useEffect } from "react";
 
 const { Title, Text } = Typography;
 
+// getValueProps for Switch: API sends strings, Switch stores booleans after toggle
+const boolProp = (value: unknown) => ({ checked: value === true || value === "true" });
+
 export default function SettingsPage() {
   const { data: settings, isLoading, error } = useSettings();
   const updateSettings = useUpdateSettings();
   const [form] = Form.useForm();
+  const pkceEnforced = Form.useWatch("pkce_enforce_s256", form);
 
   useEffect(() => {
     if (settings) {
@@ -91,7 +95,7 @@ export default function SettingsPage() {
                     label="Allow Self Signup"
                     name="allow_self_signup"
                     valuePropName="checked"
-                    getValueProps={(value) => ({ checked: value === "true" })}
+                    getValueProps={boolProp}
                   >
                     <Switch />
                   </Form.Item>
@@ -103,7 +107,7 @@ export default function SettingsPage() {
                     label="Enable MFA"
                     name="mfa_enabled"
                     valuePropName="checked"
-                    getValueProps={(value) => ({ checked: value === "true" })}
+                    getValueProps={boolProp}
                   >
                     <Switch />
                   </Form.Item>
@@ -131,7 +135,7 @@ export default function SettingsPage() {
                     label="Trust Device Enabled"
                     name="trust_device_enabled"
                     valuePropName="checked"
-                    getValueProps={(value) => ({ checked: value === "true" })}
+                    getValueProps={boolProp}
                   >
                     <Switch />
                   </Form.Item>
@@ -174,7 +178,7 @@ export default function SettingsPage() {
                     label="Username is Email"
                     name="validation_username_is_email"
                     valuePropName="checked"
-                    getValueProps={(value) => ({ checked: value === "true" })}
+                    getValueProps={boolProp}
                   >
                     <Switch />
                   </Form.Item>
@@ -183,7 +187,7 @@ export default function SettingsPage() {
                     label="Email Required"
                     name="validation_email_required"
                     valuePropName="checked"
-                    getValueProps={(value) => ({ checked: value === "true" })}
+                    getValueProps={boolProp}
                   >
                     <Switch />
                   </Form.Item>
@@ -191,8 +195,8 @@ export default function SettingsPage() {
                   <Divider />
 
                   <Title level={5}>Account Lockout</Title>
-                  <Form.Item 
-                    label="Max Failed Attempts" 
+                  <Form.Item
+                    label="Max Failed Attempts"
                     name="account_lockout_max_attempts"
                     extra="0 to disable lockout"
                   >
@@ -201,6 +205,36 @@ export default function SettingsPage() {
                   <Form.Item label="Lockout Duration" name="account_lockout_duration">
                     <Input placeholder="15m" />
                   </Form.Item>
+
+                  <Divider />
+
+                  <Title level={5}>PKCE</Title>
+                  <Form.Item
+                    label="Enforce S256 Code Challenge"
+                    name="pkce_enforce_s256"
+                    valuePropName="checked"
+                    getValueProps={boolProp}
+                  >
+                    <Switch />
+                  </Form.Item>
+                  {(pkceEnforced === false || pkceEnforced === "false") && (
+                    <Alert
+                      type="warning"
+                      showIcon
+                      message="Security Warning"
+                      description={
+                        <>
+                          Clients may now use{" "}
+                          <code>code_challenge_method=plain</code>, which provides no
+                          security benefit — the verifier equals the challenge and is
+                          visible in the authorization request. Only disable for
+                          backward compatibility with legacy clients that cannot
+                          support S256 (RFC 7636).
+                        </>
+                      }
+                      style={{ marginBottom: 16 }}
+                    />
+                  )}
                 </Card>
               ),
             },

--- a/pkg/appsettings/load.go
+++ b/pkg/appsettings/load.go
@@ -30,6 +30,7 @@ var defaults = map[string]string{
 	"trust_device_expiration":        "720h",
 	"cleanup_interval":               "6h",
 	"cleanup_retention":              "24h",
+	"pkce_enforce_s256":              "true",
 	"mfa_enabled":                    "false",
 	"mfa_method":                     "totp",
 	"smtp_port":                      "587",
@@ -139,6 +140,9 @@ func LoadIntoConfig() error {
 	if v, ok := all["cleanup_retention"]; ok {
 		cfg.CleanupRetentionStr = v
 		cfg.CleanupRetention = config.ParseDuration(v, cfg.CleanupRetention)
+	}
+	if v, ok := all["pkce_enforce_s256"]; ok {
+		cfg.AuthPKCEEnforceSHA256 = parseBool(v, true)
 	}
 	if v, ok := all["mfa_enabled"]; ok {
 		cfg.MfaEnabled = parseBool(v, false)

--- a/pkg/authorize/handler.go
+++ b/pkg/authorize/handler.go
@@ -52,6 +52,12 @@ func HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Enforce S256 — reject plain per RFC 7636 §4.2 ("SHOULD NOT be used")
+	if request.CodeChallengeMethod == "plain" && config.Get().AuthPKCEEnforceSHA256 {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "code_challenge_method 'plain' is not allowed; use S256")
+		return
+	}
+
 	// Support prompt=signup to automatically go to the signup/onboarding page while preserving OIDC state
 	if q.Get("prompt") == "signup" {
 		target := "/signup"

--- a/pkg/authorize/handler_test.go
+++ b/pkg/authorize/handler_test.go
@@ -270,6 +270,48 @@ func TestHandleAuthorize_AutoLogin_DeactivatedSession(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "username")
 }
 
+func TestHandleAuthorize_PKCE_PlainRejected(t *testing.T) {
+	testutils.WithTestDB(t)
+	// AuthPKCEEnforceSHA256 defaults to true — plain must be rejected
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/authorize?response_type=code&client_id=test-client&redirect_uri=http://localhost/callback&state=xyz&code_challenge=abc&code_challenge_method=plain", nil)
+	rr := httptest.NewRecorder()
+
+	HandleAuthorize(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "invalid_request")
+	assert.Contains(t, rr.Body.String(), "plain")
+}
+
+func TestHandleAuthorize_PKCE_PlainAllowed_WhenFlagDisabled(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Values.AuthPKCEEnforceSHA256 = false
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/authorize?response_type=code&client_id=test-client&redirect_uri=http://localhost/callback&state=xyz&code_challenge=abc&code_challenge_method=plain", nil)
+	rr := httptest.NewRecorder()
+
+	HandleAuthorize(rr, req)
+
+	// Should render login form, not an error
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "form")
+}
+
+func TestHandleAuthorize_PKCE_S256Accepted(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/authorize?response_type=code&client_id=test-client&redirect_uri=http://localhost/callback&state=xyz&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256", nil)
+	rr := httptest.NewRecorder()
+
+	HandleAuthorize(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "form")
+}
+
 func TestHandleAuthorize_AutoLogin_NoCookie(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.WithConfigOverride(t, func() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,6 +74,7 @@ type Config struct {
 	CleanupIntervalStr                 string
 	CleanupRetention                   time.Duration
 	CleanupRetentionStr                string
+	AuthPKCEEnforceSHA256              bool
 	MfaEnabled                         bool
 	MfaMethod                          string
 	SmtpHost                           string
@@ -114,6 +115,7 @@ var defaultConfig = Config{
 	CleanupIntervalStr:                 "6h",
 	CleanupRetention:                   24 * time.Hour,
 	CleanupRetentionStr:                "24h",
+	AuthPKCEEnforceSHA256:              true,
 	MfaEnabled:                         false,
 	MfaMethod:                          "totp",
 	SmtpPort:                           "587",


### PR DESCRIPTION
## Summary

- Adds `AuthPKCEEnforceSHA256` config flag (default `true`) that rejects `code_challenge_method=plain` at `/oauth2/authorize` per RFC 7636 §4.2 — _"plain SHOULD NOT be used"_ / RFC 9700 — public clients MUST use PKCE with S256
- Flag is persisted in the `settings` table as `pkce_enforce_s256` and hot-reloadable via the admin API
- Admin UI exposes the toggle in **Security & Validation → PKCE** with a warning `Alert` that appears only when enforcement is disabled
- Fixes a pre-existing bug where all boolean `Switch` fields in Settings could not be re-enabled after being turned off (`getValueProps` only matched string `"true"`, not boolean `true` from `Switch.onChange`)
- Adds `make fresh` target: wipes local DB + `.env`, full rebuild, init, and start

## Test plan

- [ ] `go test -p 1 ./pkg/authorize/...` — 3 new cases: plain rejected by default, plain allowed when flag off, S256 always accepted
- [ ] Toggle **Enforce S256** off in admin UI → warning Alert appears; toggle back on → Alert disappears
- [ ] Send `code_challenge_method=plain` to `/oauth2/authorize` with flag on → `invalid_request`
- [ ] Send `code_challenge_method=plain` with flag off → login page renders normally
- [ ] `make fresh` — clean build + fresh init + server starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)