### PR TITLE
docs: move download link before commands in quickstart

### DIFF
--- a/docs-web/src/content/docs/index.mdx
+++ b/docs-web/src/content/docs/index.mdx
@@ -30,14 +30,14 @@ The simplicity is operational, not protocol-level. Autentico implements OAuth2 a
 
 ## Get running in 60 seconds
 
+[**Download the latest release →**](https://github.com/eugenioenko/autentico/releases)
+
 ```bash
 ./autentico init --url http://localhost:9999
 ./autentico start
 ```
 
 Open `http://localhost:9999/onboard`, set your admin username and password — you're in. No Docker, no database to provision, no config files to edit.
-
-[**Download the latest release →**](https://github.com/eugenioenko/autentico/releases)
 
 ## Try it live
 


### PR DESCRIPTION
Download link should come before the bash commands — you need the binary before you can run anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)