### PR TITLE
fix: graceful db error handling with full path in error message

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"os/signal"
 	"syscall"
 	"time"
@@ -60,7 +61,8 @@ func RunStart(c *cli.Context) error {
 	}
 
 	if _, err := db.InitDB(bs.DbFilePath); err != nil {
-		return fmt.Errorf("failed to initialize database: %w", err)
+		absPath, _ := filepath.Abs(bs.DbFilePath)
+		return fmt.Errorf("failed to initialize database at %s: %w", absPath, err)
 	}
 	defer db.CloseDB()
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 
 	_ "modernc.org/sqlite"
@@ -22,11 +23,11 @@ func openDB(dbFilePath string) (*sql.DB, error) {
 	database.SetMaxOpenConns(1)
 
 	if _, err = database.Exec("PRAGMA busy_timeout = 5000;"); err != nil {
-		panic("Failed to set SQLite busy timeout: " + err.Error())
+		return nil, fmt.Errorf("failed to set SQLite busy timeout: %w", err)
 	}
 
 	if _, err = database.Exec("PRAGMA foreign_keys = ON;"); err != nil {
-		panic("Failed to enable SQLite foreign keys: " + err.Error())
+		return nil, fmt.Errorf("failed to enable SQLite foreign keys: %w", err)
 	}
 
 	return database, nil
@@ -36,21 +37,18 @@ func InitDB(dbFilePath string) (*sql.DB, error) {
 	var err error
 	db, err = openDB(dbFilePath)
 	if err != nil {
-		log.Fatalf("Failed to connect to the database: %v", err)
 		return nil, err
 	}
 
 	var userVersion int
 	if err = db.QueryRow("PRAGMA user_version").Scan(&userVersion); err != nil {
-		log.Fatalf("Failed to read user_version: %v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to read schema version: %w", err)
 	}
 
 	// Fresh database — run all migrations to build the schema from scratch.
 	if userVersion == 0 {
 		if err = migrations.Run(db, false); err != nil {
-			log.Fatalf("Failed to initialize database schema: %v", err)
-			return nil, err
+			return nil, fmt.Errorf("failed to initialize database schema: %w", err)
 		}
 	}
 

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -85,11 +85,9 @@ func TestInitTestDB(t *testing.T) {
 	CloseDB()
 }
 
-func TestInitDB_Panic(t *testing.T) {
-	// Invalid path (e.g., a directory that doesn't exist and we can't create)
-	assert.Panics(t, func() {
-		_, _ = InitDB("/nonexistent/path/to/db.sqlite")
-	})
+func TestInitDB_InvalidPath(t *testing.T) {
+	_, err := InitDB("/nonexistent/path/to/db.sqlite")
+	assert.Error(t, err)
 }
 
 func TestCloseDB_Success(t *testing.T) {
@@ -127,7 +125,6 @@ func TestInitDB_ExistingDir(t *testing.T) {
 	_ = os.Mkdir(dbPath, 0755)
 
 	// InitDB should fail because it can't open a directory as a DB
-	assert.Panics(t, func() {
-		_, _ = InitDB(dbPath)
-	})
+	_, err := InitDB(dbPath)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## Summary
- Replace `panic` calls in `openDB` with proper error returns
- Remove `log.Fatalf` from `InitDB` so errors propagate to the caller instead of crashing with a stack trace
- `start.go` resolves the absolute path and includes it in the error message — users now see exactly which path failed, e.g. `failed to initialize database at /data/autentico.db: ...`
- Update tests: replace `assert.Panics` with `assert.Error` for invalid path cases

## Before
```
panic: Failed to set SQLite busy timeout: unable to open database file: out of memory (14)
goroutine 1 [running]: ...stack trace...
```

## After
```
failed to initialize database at /data/autentico.db: failed to set SQLite busy timeout: unable to open database file: out of memory
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)