### PR TITLE
feat: OIDC conformance testing setup and RFC compliance review plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,70 @@ make docs                     # Serves Swagger UI at localhost:8888
 make generate-docs            # Regenerate swagger files from handler annotations
 ```
 
+## OIDC Conformance Testing
+
+The OpenID Foundation conformance suite runs locally via Docker. Specs and review plan are in `rfc/`.
+
+### Setup
+
+1. **Start the conformance suite** (docker-compose in `/tmp/conformance-suite`):
+   ```bash
+   cd /tmp/conformance-suite && docker compose -f docker-compose-local.yml up -d
+   ```
+   Suite UI at **https://localhost:8444** (callbacks use port 8443 — both are exposed by docker-compose)
+
+2. **Start Autentico in conformance mode** (in a terminal — must stay running):
+   ```bash
+   make conformance-server
+   ```
+   Overrides `APP_URL=http://172.17.0.1:9999`, disables secure cookies and rate limiting.
+
+3. **Stop the suite:**
+   ```bash
+   cd /tmp/conformance-suite && docker compose -f docker-compose-local.yml down
+   ```
+
+### Notes
+
+- Access the admin UI at **http://localhost:9999/admin** (not `172.17.0.1` — browser blocks `Crypto.subtle` on non-localhost HTTP)
+- `AUTENTICO_APP_URL` in `.env` should stay as `http://localhost:9999`; `make conformance-server` overrides it for the conformance suite
+- If the admin client has wrong redirect URIs (after URL change), delete the DB and restart: `rm autentico.db && make conformance-server`
+- Conformance clients must be recreated after wiping the DB (see below)
+
+### Conformance Clients
+
+Create these 3 clients via the admin API after onboarding. Get a Bearer token from the admin UI first.
+
+```bash
+TOKEN="<admin bearer token>"
+
+curl -s -X POST http://localhost:9999/admin/api/clients \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"client_id":"openid1","client_name":"Conformance Client 1","client_secret":"openid1secret","redirect_uris":["https://localhost.emobix.co.uk:8443/test/*/callback"],"grant_types":["authorization_code","refresh_token"],"response_types":["code"],"scopes":"openid profile email offline_access address phone","client_type":"confidential","token_endpoint_auth_method":"client_secret_basic"}'
+
+curl -s -X POST http://localhost:9999/admin/api/clients \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"client_id":"openid2","client_name":"Conformance Client 2 (secret_post)","client_secret":"openid2secret","redirect_uris":["https://localhost.emobix.co.uk:8443/test/*/callback"],"grant_types":["authorization_code","refresh_token"],"response_types":["code"],"scopes":"openid profile email offline_access address phone","client_type":"confidential","token_endpoint_auth_method":"client_secret_post"}'
+
+curl -s -X POST http://localhost:9999/admin/api/clients \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"client_id":"openid3","client_name":"Conformance Client 3","client_secret":"openid3secret","redirect_uris":["https://localhost.emobix.co.uk:8443/test/*/callback"],"grant_types":["authorization_code","refresh_token"],"response_types":["code"],"scopes":"openid profile email offline_access address phone","client_type":"confidential","token_endpoint_auth_method":"client_secret_basic"}'
+```
+
+| Role | client_id | client_secret | auth method |
+|---|---|---|---|
+| client | `openid1` | `openid1secret` | `client_secret_basic` |
+| client_secret_post | `openid2` | `openid2secret` | `client_secret_post` |
+| client2 | `openid3` | `openid3secret` | `client_secret_basic` |
+
+Redirect URI for all clients: `https://localhost.emobix.co.uk:8443/test/*/callback` (wildcard — the suite uses a dynamic run ID in the path, which changes per test run).
+
+### Test Plans Run
+
+| Plan | Status |
+|---|---|
+| `oidcc-basic-certification-test-plan` | ✅ Passed (2026-03-24) — issues documented in `openid.md` |
+
 ## Architecture
 
 ### CLI Entry Points

--- a/README.md
+++ b/README.md
@@ -1,0 +1,94 @@
+# Autentico
+
+A self-contained OpenID Connect (OIDC) Identity Provider built with Go and SQLite.
+
+Implements the full authentication lifecycle: Authorization Code + PKCE, ROPC, Refresh Token grants, MFA (TOTP + email OTP), WebAuthn/passkeys, SSO sessions, trusted devices, token introspection/revocation, and an embedded React admin UI.
+
+## Quick Start
+
+```bash
+# Generate configuration
+./autentico init --url https://auth.example.com
+
+# Start the server
+./autentico start
+```
+
+Or with Docker:
+
+```bash
+docker run --rm -v "$(pwd)":/output \
+  ghcr.io/eugenioenko/autentico:latest \
+  init --url https://auth.example.com --output /output
+
+docker run \
+  --name autentico \
+  -p 9999:9999 \
+  -v autentico-data:/data \
+  --env-file .env \
+  ghcr.io/eugenioenko/autentico:latest
+```
+
+## Documentation
+
+Full documentation at [autentico.top](https://autentico.top)
+
+## OIDC Conformance Testing
+
+Autentico is tested against the [OpenID Foundation conformance suite](https://openid.net/certification/).
+
+### Certified Profiles
+
+| Profile | Status |
+|---|---|
+| Basic OP (`oidcc-basic-certification-test-plan`) | ✅ Passed |
+| Comprehensive (`oidcc-test-plan`) | ✅ Passed |
+
+### Running the Conformance Suite Locally
+
+**1. Start the conformance suite:**
+
+```bash
+cd /tmp/conformance-suite && docker compose -f docker-compose-local.yml up -d
+```
+
+Suite UI available at **https://localhost:8444** (callbacks use port 8443 — both are exposed)
+
+**2. Start Autentico in conformance mode** (in a terminal):
+
+```bash
+make conformance-server
+```
+
+This overrides `APP_URL=http://172.17.0.1:9999`, disables secure cookies and rate limiting so the suite can reach the server from inside Docker.
+
+**3. Create conformance clients** (once, after onboarding):
+
+```bash
+TOKEN="<admin bearer token>"
+REDIRECT="https://localhost.emobix.co.uk:8443/test/*/callback"
+
+curl -s -X POST http://localhost:9999/admin/api/clients \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "{\"client_id\":\"openid1\",\"client_name\":\"Conformance Client 1\",\"client_secret\":\"openid1secret\",\"redirect_uris\":[\"$REDIRECT\"],\"grant_types\":[\"authorization_code\",\"refresh_token\"],\"response_types\":[\"code\"],\"scopes\":\"openid profile email offline_access address phone\",\"client_type\":\"confidential\",\"token_endpoint_auth_method\":\"client_secret_basic\"}"
+
+curl -s -X POST http://localhost:9999/admin/api/clients \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "{\"client_id\":\"openid2\",\"client_name\":\"Conformance Client 2 (secret_post)\",\"client_secret\":\"openid2secret\",\"redirect_uris\":[\"$REDIRECT\"],\"grant_types\":[\"authorization_code\",\"refresh_token\"],\"response_types\":[\"code\"],\"scopes\":\"openid profile email offline_access address phone\",\"client_type\":\"confidential\",\"token_endpoint_auth_method\":\"client_secret_post\"}"
+
+curl -s -X POST http://localhost:9999/admin/api/clients \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "{\"client_id\":\"openid3\",\"client_name\":\"Conformance Client 3\",\"client_secret\":\"openid3secret\",\"redirect_uris\":[\"$REDIRECT\"],\"grant_types\":[\"authorization_code\",\"refresh_token\"],\"response_types\":[\"code\"],\"scopes\":\"openid profile email offline_access address phone\",\"client_type\":\"confidential\",\"token_endpoint_auth_method\":\"client_secret_basic\"}"
+```
+
+| Role | client_id | client_secret | auth method |
+|---|---|---|---|
+| client | `openid1` | `openid1secret` | `client_secret_basic` |
+| client_secret_post | `openid2` | `openid2secret` | `client_secret_post` |
+| client2 | `openid3` | `openid3secret` | `client_secret_basic` |
+
+**4. Configure the test plan:**
+
+- Discovery URL: `http://172.17.0.1:9999/oauth2/.well-known/openid-configuration`
+- Set alias to `conformance` (optional — the callback URL uses a dynamic run ID regardless)
+- Access the admin UI at **http://localhost:9999/admin** (not `172.17.0.1` — browser blocks `Crypto.subtle` on non-localhost HTTP)

--- a/rfc/openid-connect-core-1_0.html
+++ b/rfc/openid-connect-core-1_0.html
@@ -1,0 +1,10164 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en"><head><title>Final: OpenID Connect Core 1.0 incorporating errata set 2</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta name="description" content="OpenID Connect Core 1.0 incorporating errata set 2">
+<meta name="generator" content="xml2rfc v1.37pre1 (http://xml.resource.org/)">
+<style type='text/css'><!--
+        body {
+                font-family: verdana, charcoal, helvetica, arial, sans-serif;
+                font-size: small; color: #000; background-color: #FFF;
+                margin: 2em;
+        }
+        h1, h2, h3, h4, h5, h6 {
+                font-family: helvetica, monaco, "MS Sans Serif", arial, sans-serif;
+                font-weight: bold; font-style: normal;
+        }
+        h1 { color: #900; background-color: transparent; text-align: right; }
+        h3 { color: #333; background-color: transparent; }
+
+        td.RFCbug {
+                font-size: x-small; text-decoration: none;
+                width: 30px; height: 30px; padding-top: 2px;
+                text-align: justify; vertical-align: middle;
+                background-color: #000;
+        }
+        td.RFCbug span.RFC {
+                font-family: monaco, charcoal, geneva, "MS Sans Serif", helvetica, verdana, sans-serif;
+                font-weight: bold; color: #666;
+        }
+        td.RFCbug span.hotText {
+                font-family: charcoal, monaco, geneva, "MS Sans Serif", helvetica, verdana, sans-serif;
+                font-weight: normal; text-align: center; color: #FFF;
+        }
+
+        table.TOCbug { width: 30px; height: 15px; }
+        td.TOCbug {
+                text-align: center; width: 30px; height: 15px;
+                color: #FFF; background-color: #900;
+        }
+        td.TOCbug a {
+                font-family: monaco, charcoal, geneva, "MS Sans Serif", helvetica, sans-serif;
+                font-weight: bold; font-size: x-small; text-decoration: none;
+                color: #FFF; background-color: transparent;
+        }
+
+        td.header {
+                font-family: arial, helvetica, sans-serif; font-size: x-small;
+                vertical-align: top; width: 33%;
+                color: #FFF; background-color: #666;
+        }
+        td.author { font-weight: bold; font-size: x-small; margin-left: 4em; }
+        td.author-text { font-size: x-small; }
+
+        /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+        a.info {
+                /* This is the key. */
+                position: relative;
+                z-index: 24;
+                text-decoration: none;
+        }
+        a.info:hover {
+                z-index: 25;
+                color: #FFF; background-color: #900;
+        }
+        a.info span { display: none; }
+        a.info:hover span.info {
+                /* The span will display just on :hover state. */
+                display: block;
+                position: absolute;
+                font-size: smaller;
+                top: 2em; left: -5em; width: 15em;
+                padding: 2px; border: 1px solid #333;
+                color: #900; background-color: #EEE;
+                text-align: left;
+        }
+
+        a { font-weight: bold; }
+        a:link    { color: #900; background-color: transparent; }
+        a:visited { color: #633; background-color: transparent; }
+        a:active  { color: #633; background-color: transparent; }
+
+        p { margin-left: 2em; margin-right: 2em; }
+        p.copyright { font-size: x-small; }
+        p.toc { font-size: small; font-weight: bold; margin-left: 3em; }
+        table.toc { margin: 0 0 0 3em; padding: 0; border: 0; vertical-align: text-top; }
+        td.toc { font-size: small; font-weight: bold; vertical-align: text-top; }
+
+        ol.text { margin-left: 2em; margin-right: 2em; }
+        ul.text { margin-left: 2em; margin-right: 2em; }
+        li      { margin-left: 3em; }
+
+        /* RFC-2629 <spanx>s and <artwork>s. */
+        em     { font-style: italic; }
+        strong { font-weight: bold; }
+        dfn    { font-weight: bold; font-style: normal; }
+        cite   { font-weight: normal; font-style: normal; }
+        tt     { color: #036; }
+        tt, pre, pre dfn, pre em, pre cite, pre span {
+                font-family: "Courier New", Courier, monospace; font-size: small;
+        }
+        pre {
+                text-align: left; padding: 4px;
+                color: #000; background-color: #CCC;
+        }
+        pre dfn  { color: #900; }
+        pre em   { color: #66F; background-color: #FFC; font-weight: normal; }
+        pre .key { color: #33C; font-weight: bold; }
+        pre .id  { color: #900; }
+        pre .str { color: #000; background-color: #CFF; }
+        pre .val { color: #066; }
+        pre .rep { color: #909; }
+        pre .oth { color: #000; background-color: #FCF; }
+        pre .err { background-color: #FCC; }
+
+        /* RFC-2629 <texttable>s. */
+        table.all, table.full, table.headers, table.none {
+                font-size: small; text-align: center; border-width: 2px;
+                vertical-align: top; border-collapse: collapse;
+        }
+        table.all, table.full { border-style: solid; border-color: black; }
+        table.headers, table.none { border-style: none; }
+        th {
+                font-weight: bold; border-color: black;
+                border-width: 2px 2px 3px 2px;
+        }
+        table.all th, table.full th { border-style: solid; }
+        table.headers th { border-style: none none solid none; }
+        table.none th { border-style: none; }
+        table.all td {
+                border-style: solid; border-color: #333;
+                border-width: 1px 2px;
+        }
+        table.full td, table.headers td, table.none td { border-style: none; }
+
+        hr { height: 1px; }
+        hr.insert {
+                width: 80%; border-style: none; border-width: 0;
+                color: #CCC; background-color: #CCC;
+        }
+--></style>
+</head>
+<body>
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<table summary="layout" width="66%" border="0" cellpadding="0" cellspacing="0"><tr><td><table summary="layout" width="100%" border="0" cellpadding="2" cellspacing="1">
+<tr><td class="header">Final</td><td class="header">N. Sakimura</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">NAT.Consulting (was at NRI)</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">J. Bradley</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">Yubico (was at Ping Identity)</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">M. Jones</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">Self-Issued Consulting (was at</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">Microsoft)</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">B. de Medeiros</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">Google</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">C. Mortimore</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">Disney (was at Salesforce)</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">December 15, 2023</td></tr>
+</table></td></tr></table>
+<h1><br />OpenID Connect Core 1.0 incorporating errata set 2</h1>
+
+<h3>Abstract</h3>
+
+<p>OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0
+      protocol. It enables Clients to verify the identity of the End-User based
+      on the authentication performed by an Authorization Server, as well as to
+      obtain basic profile information about the End-User in an interoperable and
+      REST-like manner.
+</p>
+<p>
+	This specification defines
+	the core OpenID Connect functionality:
+	authentication built on top of OAuth 2.0 and
+	the use of Claims to communicate information about the End-User.
+	It also describes the security and privacy considerations for using OpenID Connect.
+      
+</p><a name="toc"></a><br /><hr />
+<h3>Table of Contents</h3>
+<p class="toc">
+<a href="#Introduction">1.</a>&nbsp;
+Introduction<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#rnc">1.1.</a>&nbsp;
+Requirements Notation and Conventions<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#Terminology">1.2.</a>&nbsp;
+Terminology<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#Overview">1.3.</a>&nbsp;
+Overview<br />
+<a href="#IDToken">2.</a>&nbsp;
+ID Token<br />
+<a href="#Authentication">3.</a>&nbsp;
+Authentication<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#CodeFlowAuth">3.1.</a>&nbsp;
+Authentication using the Authorization Code Flow<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#CodeFlowSteps">3.1.1.</a>&nbsp;
+Authorization Code Flow Steps<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#AuthorizationEndpoint">3.1.2.</a>&nbsp;
+Authorization Endpoint<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#AuthRequest">3.1.2.1.</a>&nbsp;
+Authentication Request<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#AuthRequestValidation">3.1.2.2.</a>&nbsp;
+Authentication Request Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#Authenticates">3.1.2.3.</a>&nbsp;
+Authorization Server Authenticates End-User<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#Consent">3.1.2.4.</a>&nbsp;
+Authorization Server Obtains End-User Consent/Authorization<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#AuthResponse">3.1.2.5.</a>&nbsp;
+Successful Authentication Response<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#AuthError">3.1.2.6.</a>&nbsp;
+Authentication Error Response<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#AuthResponseValidation">3.1.2.7.</a>&nbsp;
+Authentication Response Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#TokenEndpoint">3.1.3.</a>&nbsp;
+Token Endpoint<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#TokenRequest">3.1.3.1.</a>&nbsp;
+Token Request<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#TokenRequestValidation">3.1.3.2.</a>&nbsp;
+Token Request Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#TokenResponse">3.1.3.3.</a>&nbsp;
+Successful Token Response<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#TokenErrorResponse">3.1.3.4.</a>&nbsp;
+Token Error Response<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#TokenResponseValidation">3.1.3.5.</a>&nbsp;
+Token Response Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#CodeIDToken">3.1.3.6.</a>&nbsp;
+ID Token<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#IDTokenValidation">3.1.3.7.</a>&nbsp;
+ID Token Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#CodeFlowTokenValidation">3.1.3.8.</a>&nbsp;
+Access Token Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplicitFlowAuth">3.2.</a>&nbsp;
+Authentication using the Implicit Flow<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplicitFlowSteps">3.2.1.</a>&nbsp;
+Implicit Flow Steps<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplicitAuthorizationEndpoint">3.2.2.</a>&nbsp;
+Authorization Endpoint<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplicitAuthRequest">3.2.2.1.</a>&nbsp;
+Authentication Request<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplicitValidation">3.2.2.2.</a>&nbsp;
+Authentication Request Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplicitAuthenticates">3.2.2.3.</a>&nbsp;
+Authorization Server Authenticates End-User<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplicitConsent">3.2.2.4.</a>&nbsp;
+Authorization Server Obtains End-User Consent/Authorization<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplicitAuthResponse">3.2.2.5.</a>&nbsp;
+Successful Authentication Response<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplicitAuthError">3.2.2.6.</a>&nbsp;
+Authentication Error Response<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplicitCallback">3.2.2.7.</a>&nbsp;
+Redirect URI Fragment Handling<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplicitAuthResponseValidation">3.2.2.8.</a>&nbsp;
+Authentication Response Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplicitTokenValidation">3.2.2.9.</a>&nbsp;
+Access Token Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplicitIDToken">3.2.2.10.</a>&nbsp;
+ID Token<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplicitIDTValidation">3.2.2.11.</a>&nbsp;
+ID Token Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridFlowAuth">3.3.</a>&nbsp;
+Authentication using the Hybrid Flow<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridFlowSteps">3.3.1.</a>&nbsp;
+Hybrid Flow Steps<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridAuthorizationEndpoint">3.3.2.</a>&nbsp;
+Authorization Endpoint<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridAuthRequest">3.3.2.1.</a>&nbsp;
+Authentication Request<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridValidation">3.3.2.2.</a>&nbsp;
+Authentication Request Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridAuthenticates">3.3.2.3.</a>&nbsp;
+Authorization Server Authenticates End-User<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridConsent">3.3.2.4.</a>&nbsp;
+Authorization Server Obtains End-User Consent/Authorization<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridAuthResponse">3.3.2.5.</a>&nbsp;
+Successful Authentication Response<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridAuthError">3.3.2.6.</a>&nbsp;
+Authentication Error Response<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridCallback">3.3.2.7.</a>&nbsp;
+Redirect URI Fragment Handling<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridAuthResponseValidation">3.3.2.8.</a>&nbsp;
+Authentication Response Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridTokenValidation">3.3.2.9.</a>&nbsp;
+Access Token Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#CodeValidation">3.3.2.10.</a>&nbsp;
+Authorization Code Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridIDToken">3.3.2.11.</a>&nbsp;
+ID Token<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridIDTValidation">3.3.2.12.</a>&nbsp;
+ID Token Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridTokenEndpoint">3.3.3.</a>&nbsp;
+Token Endpoint<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridTokenRequest">3.3.3.1.</a>&nbsp;
+Token Request<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridTokenRequestValidation">3.3.3.2.</a>&nbsp;
+Token Request Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridTokenResponse">3.3.3.3.</a>&nbsp;
+Successful Token Response<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridTokenErrorResponse">3.3.3.4.</a>&nbsp;
+Token Error Response<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridTokenResponseValidation">3.3.3.5.</a>&nbsp;
+Token Response Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridIDToken2">3.3.3.6.</a>&nbsp;
+ID Token<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridIDTValidation2">3.3.3.7.</a>&nbsp;
+ID Token Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridAccessToken2">3.3.3.8.</a>&nbsp;
+Access Token<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HybridTokenValidation2">3.3.3.9.</a>&nbsp;
+Access Token Validation<br />
+<a href="#ThirdPartyInitiatedLogin">4.</a>&nbsp;
+Initiating Login from a Third Party<br />
+<a href="#Claims">5.</a>&nbsp;
+Claims<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#StandardClaims">5.1.</a>&nbsp;
+Standard Claims<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#AddressClaim">5.1.1.</a>&nbsp;
+Address Claim<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#AdditionalClaims">5.1.2.</a>&nbsp;
+Additional Claims<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ClaimsLanguagesAndScripts">5.2.</a>&nbsp;
+Claims Languages and Scripts<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#UserInfo">5.3.</a>&nbsp;
+UserInfo Endpoint<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#UserInfoRequest">5.3.1.</a>&nbsp;
+UserInfo Request<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#UserInfoResponse">5.3.2.</a>&nbsp;
+Successful UserInfo Response<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#UserInfoError">5.3.3.</a>&nbsp;
+UserInfo Error Response<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#UserInfoResponseValidation">5.3.4.</a>&nbsp;
+UserInfo Response Validation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ScopeClaims">5.4.</a>&nbsp;
+Requesting Claims using Scope Values<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ClaimsParameter">5.5.</a>&nbsp;
+Requesting Claims using the "claims" Request Parameter<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#IndividualClaimsRequests">5.5.1.</a>&nbsp;
+Individual Claims Requests<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#acrSemantics">5.5.1.1.</a>&nbsp;
+Requesting the "acr" Claim<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#IndividualClaimsLanguages">5.5.2.</a>&nbsp;
+Languages and Scripts for Individual Claims<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ClaimTypes">5.6.</a>&nbsp;
+Claim Types<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#NormalClaims">5.6.1.</a>&nbsp;
+Normal Claims<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#AggregatedDistributedClaims">5.6.2.</a>&nbsp;
+Aggregated and Distributed Claims<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#AggregatedExample">5.6.2.1.</a>&nbsp;
+Example of Aggregated Claims<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#DistributedExample">5.6.2.2.</a>&nbsp;
+Example of Distributed Claims<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ClaimStability">5.7.</a>&nbsp;
+Claim Stability and Uniqueness<br />
+<a href="#JWTRequests">6.</a>&nbsp;
+Passing Request Parameters as JWTs<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#RequestObject">6.1.</a>&nbsp;
+Passing a Request Object by Value<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#RequestParameter">6.1.1.</a>&nbsp;
+Request using the "request" Request Parameter<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#RequestUriParameter">6.2.</a>&nbsp;
+Passing a Request Object by Reference<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#CreateRequestUri">6.2.1.</a>&nbsp;
+URI Referencing the Request Object<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#UseRequestUri">6.2.2.</a>&nbsp;
+Request using the "request_uri" Request Parameter<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#GetRequestUri">6.2.3.</a>&nbsp;
+Authorization Server Fetches Request Object<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#RequestUriRationale">6.2.4.</a>&nbsp;
+&quot;request_uri&quot; Rationale<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#JWTRequestValidation">6.3.</a>&nbsp;
+Validating JWT-Based Requests<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#EncryptedRequestObject">6.3.1.</a>&nbsp;
+Encrypted Request Object<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#SignedRequestObject">6.3.2.</a>&nbsp;
+Signed Request Object<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#RequestParameterValidation">6.3.3.</a>&nbsp;
+Request Parameter Assembly and Validation<br />
+<a href="#SelfIssued">7.</a>&nbsp;
+Self-Issued OpenID Provider<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#SelfIssuedDiscovery">7.1.</a>&nbsp;
+Self-Issued OpenID Provider Discovery<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#SelfIssuedRegistration">7.2.</a>&nbsp;
+Self-Issued OpenID Provider Registration<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#RegistrationParameter">7.2.1.</a>&nbsp;
+Providing Information with the "registration" Request Parameter<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#SelfIssuedRequest">7.3.</a>&nbsp;
+Self-Issued OpenID Provider Request<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#SelfIssuedResponse">7.4.</a>&nbsp;
+Self-Issued OpenID Provider Response<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#SelfIssuedValidation">7.5.</a>&nbsp;
+Self-Issued ID Token Validation<br />
+<a href="#SubjectIDTypes">8.</a>&nbsp;
+Subject Identifier Types<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#PairwiseAlg">8.1.</a>&nbsp;
+Pairwise Identifier Algorithm<br />
+<a href="#ClientAuthentication">9.</a>&nbsp;
+Client Authentication<br />
+<a href="#SigEnc">10.</a>&nbsp;
+Signatures and Encryption<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#Signing">10.1.</a>&nbsp;
+Signing<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#RotateSigKeys">10.1.1.</a>&nbsp;
+Rotation of Asymmetric Signing Keys<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#Encryption">10.2.</a>&nbsp;
+Encryption<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#RotateEncKeys">10.2.1.</a>&nbsp;
+Rotation of Asymmetric Encryption Keys<br />
+<a href="#OfflineAccess">11.</a>&nbsp;
+Offline Access<br />
+<a href="#RefreshTokens">12.</a>&nbsp;
+Using Refresh Tokens<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#RefreshingAccessToken">12.1.</a>&nbsp;
+Refresh Request<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#RefreshTokenResponse">12.2.</a>&nbsp;
+Successful Refresh Response<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#RefreshErrorResponse">12.3.</a>&nbsp;
+Refresh Error Response<br />
+<a href="#Serializations">13.</a>&nbsp;
+Serializations<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#QuerySerialization">13.1.</a>&nbsp;
+Query String Serialization<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#FormSerialization">13.2.</a>&nbsp;
+Form Serialization<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#JSONSerialization">13.3.</a>&nbsp;
+JSON Serialization<br />
+<a href="#StringOps">14.</a>&nbsp;
+String Operations<br />
+<a href="#ImplementationConsiderations">15.</a>&nbsp;
+Implementation Considerations<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ServerMTI">15.1.</a>&nbsp;
+Mandatory to Implement Features for All OpenID Providers<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#DynamicMTI">15.2.</a>&nbsp;
+Mandatory to Implement Features for Dynamic OpenID Providers<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#DiscoReg">15.3.</a>&nbsp;
+Discovery and Registration<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#RPMTI">15.4.</a>&nbsp;
+Mandatory to Implement Features for Relying Parties<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplementationNotes">15.5.</a>&nbsp;
+Implementation Notes<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#CodeNotes">15.5.1.</a>&nbsp;
+Authorization Code Implementation Notes<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#NonceNotes">15.5.2.</a>&nbsp;
+Nonce Implementation Notes<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#FragmentNotes">15.5.3.</a>&nbsp;
+Redirect URI Fragment Handling Implementation Notes<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#CompatibilityNotes">15.6.</a>&nbsp;
+Compatibility Notes<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#RelatedSpecs">15.7.</a>&nbsp;
+Related Specifications and Implementer's Guides<br />
+<a href="#Security">16.</a>&nbsp;
+Security Considerations<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#RequestDisclosure">16.1.</a>&nbsp;
+Request Disclosure<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ServerMasquerading">16.2.</a>&nbsp;
+Server Masquerading<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#TokenManufacture">16.3.</a>&nbsp;
+Token Manufacture/Modification<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#AccessTokenDisclosure">16.4.</a>&nbsp;
+Access Token Disclosure<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ResponseDisclosure">16.5.</a>&nbsp;
+Server Response Disclosure<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ServerResponseRepudiation">16.6.</a>&nbsp;
+Server Response Repudiation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#RequestRepudation">16.7.</a>&nbsp;
+Request Repudiation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#AccessTokenRedirect">16.8.</a>&nbsp;
+Access Token Redirect<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#TokenReuse">16.9.</a>&nbsp;
+Token Reuse<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#AuthCodeCapture">16.10.</a>&nbsp;
+ Eavesdropping or Leaking Authorization Codes (Secondary Authenticator Capture)<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#TokenSubstitution">16.11.</a>&nbsp;
+Token Substitution<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#TimingAttack">16.12.</a>&nbsp;
+Timing Attack<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#OtherCryptoAttacks">16.13.</a>&nbsp;
+Other Crypto Related Attacks<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#SigningOrder">16.14.</a>&nbsp;
+Signing and Encryption Order<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#IssuerIdentifier">16.15.</a>&nbsp;
+Issuer Identifier<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ImplicitFlowThreats">16.16.</a>&nbsp;
+Implicit Flow Threats<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#TLSRequirements">16.17.</a>&nbsp;
+TLS Requirements<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#TokenLifetime">16.18.</a>&nbsp;
+Lifetimes of Access Tokens and Refresh Tokens<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#SymmetricKeyEntropy">16.19.</a>&nbsp;
+Symmetric Key Entropy<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#NeedForSignedRequests">16.20.</a>&nbsp;
+Need for Signed Requests<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#NeedForEncryptedRequests">16.21.</a>&nbsp;
+Need for Encrypted Requests<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HTTP307Redirects">16.22.</a>&nbsp;
+HTTP 307 Redirects<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#iOSCustomSchemes">16.23.</a>&nbsp;
+Custom URI Schemes on iOS<br />
+<a href="#Privacy">17.</a>&nbsp;
+Privacy Considerations<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#PII">17.1.</a>&nbsp;
+Personally Identifiable Information<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#AccessMonitoring">17.2.</a>&nbsp;
+Data Access Monitoring<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#Correlation">17.3.</a>&nbsp;
+Correlation<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#OfflineAccessPrivacy">17.4.</a>&nbsp;
+Offline Access<br />
+<a href="#IANA">18.</a>&nbsp;
+IANA Considerations<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ClaimsRegistry">18.1.</a>&nbsp;
+JSON Web Token Claims Registration<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ClaimsContents">18.1.1.</a>&nbsp;
+Registry Contents<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#OAuthParametersRegistry">18.2.</a>&nbsp;
+OAuth Parameters Registration<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ParametersContents">18.2.1.</a>&nbsp;
+Registry Contents<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#OAuthErrorRegistry">18.3.</a>&nbsp;
+OAuth Extensions Error Registration<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ErrorContents">18.3.1.</a>&nbsp;
+Registry Contents<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#URISchemeRegistry">18.4.</a>&nbsp;
+URI Scheme Registration<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#URISchemeContents">18.4.1.</a>&nbsp;
+Registry Contents<br />
+<a href="#rfc.references1">19.</a>&nbsp;
+References<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#rfc.references1">19.1.</a>&nbsp;
+Normative References<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#rfc.references2">19.2.</a>&nbsp;
+Informative References<br />
+<a href="#AuthorizationExamples">Appendix&nbsp;A.</a>&nbsp;
+Authorization Examples<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#codeExample">A.1.</a>&nbsp;
+Example using response_type=code<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#id_tokenExample">A.2.</a>&nbsp;
+Example using response_type=id_token<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#id_token-tokenExample">A.3.</a>&nbsp;
+Example using response_type=id_token&nbsp;token<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#code-id_tokenExample">A.4.</a>&nbsp;
+Example using response_type=code&nbsp;id_token<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#code-tokenExample">A.5.</a>&nbsp;
+Example using response_type=code&nbsp;token<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#code-id_token-tokenExample">A.6.</a>&nbsp;
+Example using response_type=code&nbsp;id_token&nbsp;token<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ExampleRSAKey">A.7.</a>&nbsp;
+RSA Key Used in Examples<br />
+<a href="#Acknowledgements">Appendix&nbsp;B.</a>&nbsp;
+Acknowledgements<br />
+<a href="#Notices">Appendix&nbsp;C.</a>&nbsp;
+Notices<br />
+<a href="#rfc.authors">&#167;</a>&nbsp;
+Authors' Addresses<br />
+</p>
+<br clear="all" />
+
+<a name="Introduction"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.1"></a><h3>1.&nbsp;
+Introduction</h3>
+
+<p>
+	OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0
+	<a class='info' href='#RFC6749'>[RFC6749]<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a>
+	protocol. It enables Clients to verify the identity of the End-User based
+	on the authentication performed by an Authorization Server, as well as to
+	obtain basic profile information about the End-User in an interoperable and
+	REST-like manner.
+      
+</p>
+<p>
+	The OpenID Connect Core 1.0 specification defines
+	the core OpenID Connect functionality:
+	authentication built on top of OAuth 2.0 and
+	the use of Claims to communicate information about the End-User.
+	It also describes the security and privacy considerations for using OpenID Connect.
+      
+</p>
+<p>
+	As background,
+	the <a class='info' href='#RFC6749'>OAuth 2.0 Authorization Framework<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749]
+	and <a class='info' href='#RFC6750'>OAuth 2.0 Bearer Token Usage<span> (</span><span class='info'>Jones, M. and D. Hardt, &ldquo;The OAuth 2.0 Authorization Framework: Bearer Token Usage,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6750]
+	specifications provide a general framework for third-party applications
+	to obtain and use limited access to HTTP resources.  They define
+	mechanisms to obtain and use Access Tokens to access resources but
+	do not define standard methods to provide identity information.
+	Notably, without profiling OAuth 2.0, it is incapable of
+	providing information about the authentication of an End-User.
+	Readers are expected to be familiar with these specifications.
+      
+</p>
+<p>
+	OpenID Connect implements authentication as an extension to the
+	OAuth 2.0 authorization process.
+	Use of this extension is requested by Clients by including
+	the <tt>openid</tt> scope value
+	in the Authorization Request.
+	Information about the authentication performed is returned
+	in a <a class='info' href='#JWT'>JSON Web Token (JWT)<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWT]
+	called an ID Token (see <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a>).
+	OAuth 2.0 Authentication Servers implementing OpenID Connect
+	are also referred to as OpenID Providers (OPs).
+	OAuth 2.0 Clients using OpenID Connect
+	are also referred to as Relying Parties (RPs).
+      
+</p>
+<p>
+	This specification assumes that the Relying Party has already obtained
+	configuration information about the OpenID Provider, including its
+	Authorization Endpoint and Token Endpoint locations.
+	This information is normally obtained via Discovery,
+	as described in <a class='info' href='#OpenID.Discovery'>OpenID Connect Discovery 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., and E. Jay, &ldquo;OpenID Connect Discovery 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Discovery],
+	or may be obtained via other mechanisms.
+      
+</p>
+<p>
+	Likewise, this specification assumes that the Relying Party has already obtained
+	sufficient credentials and provided information needed to use the OpenID Provider.
+	This is normally done via Dynamic Registration,
+	as described in
+	<a class='info' href='#OpenID.Registration'>OpenID Connect Dynamic Client Registration 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., and M. Jones, &ldquo;OpenID Connect Dynamic Client Registration 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Registration],
+	or may be obtained via other mechanisms.
+      
+</p>
+<p>
+	The previous versions of this specification are:
+	</p>
+<ul class="text">
+<li><a class='info' href='#OpenID.Core.Errata1'>OpenID Connect Core 1.0 incorporating errata set 1<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;OpenID Connect Core 1.0 incorporating errata set 1,&rdquo; November&nbsp;2014.</span><span>)</span></a> [OpenID.Core.Errata1]
+</li>
+<li><a class='info' href='#OpenID.Core.Final'>OpenID Connect Core 1.0 (final)<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;OpenID Connect Core 1.0 (final),&rdquo; February&nbsp;2014.</span><span>)</span></a> [OpenID.Core.Final]
+</li>
+</ul><p>
+      
+</p>
+<a name="rnc"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.1.1"></a><h3>1.1.&nbsp;
+Requirements Notation and Conventions</h3>
+
+<p>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+	"SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+	document are to be interpreted as described in <a class='info' href='#RFC2119'>RFC 2119<span> (</span><span class='info'>Bradner, S., &ldquo;Key words for use in RFCs to Indicate Requirement Levels,&rdquo; March&nbsp;1997.</span><span>)</span></a> [RFC2119].
+</p>
+<p>
+	  In the .txt version of this specification,
+	  values are quoted to indicate that they are to be taken literally.
+	  When using these values in protocol messages,
+	  the quotes MUST NOT be used as part of the value.
+	  In the HTML version of this specification,
+	  values to be taken literally are indicated by
+	  the use of <tt>this fixed-width font</tt>.
+	
+</p>
+<p>
+	  All uses of <a class='info' href='#JWS'>JSON Web Signature (JWS)<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Signature (JWS),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWS]
+	  and <a class='info' href='#JWE'>JSON Web Encryption (JWE)<span> (</span><span class='info'>Jones, M. and J. Hildebrand, &ldquo;JSON Web Encryption (JWE),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWE]
+	  data structures in this specification utilize
+	  the JWS Compact Serialization or the JWE Compact Serialization;
+	  the JWS JSON Serialization and the JWE JSON Serialization are not used.
+	
+</p>
+<a name="Terminology"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.1.2"></a><h3>1.2.&nbsp;
+Terminology</h3>
+
+<p>
+	  This specification uses the terms "Access Token", "Authorization Code",
+	  "Authorization Endpoint", "Authorization Grant", "Authorization Server",
+	  "Client", "Client Authentication", "Client Identifier", "Client Secret",
+	  "Grant Type", "Protected Resource", "Redirection URI", "Refresh Token",
+	  "Resource Server", "Response Type", and "Token Endpoint"
+	  defined by <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749],
+	  the terms "Claim Name", "Claim Value", "JSON Web Token (JWT)",
+	  "JWT Claims Set", and "Nested JWT"
+	  defined by <a class='info' href='#JWT'>JSON Web Token (JWT)<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWT],
+	  the terms "Base64url Encoding", "Header Parameter", and "JOSE Header"
+	  defined by <a class='info' href='#JWS'>JSON Web Signature (JWS)<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Signature (JWS),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWS],
+	  the term "User Agent" defined by <a class='info' href='#RFC7230'>RFC 7230<span> (</span><span class='info'>Fielding, R., Ed. and J. Reschke, Ed., &ldquo;Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing,&rdquo; June&nbsp;2014.</span><span>)</span></a> [RFC7230],
+	  and the term "Response Mode" defined by
+	  <a class='info' href='#OAuth.Responses'>OAuth 2.0 Multiple Response Type Encoding Practices<span> (</span><span class='info'>de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;OAuth 2.0 Multiple Response Type Encoding Practices,&rdquo; February&nbsp;2014.</span><span>)</span></a> [OAuth.Responses].
+        
+</p>
+<p>
+          This specification also defines the following terms:
+          </p>
+<blockquote class="text"><dl>
+<dt>Authentication</dt>
+<dd>
+	      
+	      Process used to achieve sufficient confidence in the binding
+	      between the Entity and the presented Identity.
+	    
+</dd>
+<dt>Authentication Request</dt>
+<dd>
+	      
+	      OAuth 2.0 Authorization Request using extension parameters and scopes
+	      defined by OpenID Connect to request that the End-User be authenticated
+	      by the Authorization Server, which is an OpenID Connect Provider,
+	      to the Client, which is an OpenID Connect Relying Party.
+	    
+</dd>
+<dt>Authentication Context</dt>
+<dd>
+	      
+              Information that the Relying Party can require before it makes an
+              entitlement decision with respect to an authentication response.
+              Such context can include, but is not limited to, the actual
+              authentication method used or level of assurance such as
+              <a class='info' href='#ISO29115'>ISO/IEC 29115<span> (</span><span class='info'>International Organization for Standardization, &ldquo;ISO/IEC 29115:2013. 	  Information technology - Security techniques - Entity authentication 	  assurance framework,&rdquo; April&nbsp;2013.</span><span>)</span></a> [ISO29115]
+              entity authentication assurance level.
+            
+</dd>
+<dt>Authentication Context Class</dt>
+<dd>
+	      
+              Set of authentication methods or procedures that are considered
+	      to be equivalent to each other in a particular context.
+            
+</dd>
+<dt>Authentication Context Class Reference</dt>
+<dd>
+	      
+              Identifier for an Authentication Context Class.
+            
+</dd>
+<dt>Authorization Code Flow</dt>
+<dd>
+	      
+              OAuth 2.0 flow in which
+	      an Authorization Code is returned from the Authorization Endpoint and
+	      all tokens are returned from the Token Endpoint.
+            
+</dd>
+<dt>Authorization Request</dt>
+<dd>
+	      
+              OAuth 2.0 Authorization Request as defined by <a class='info' href='#RFC6749'>[RFC6749]<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a>.
+            
+</dd>
+<dt>Claim</dt>
+<dd>
+	      
+	      Piece of information asserted about an Entity.
+	    
+</dd>
+<dt>Claim Type</dt>
+<dd>
+	      
+	      Syntax used for representing a Claim Value.
+	      This specification defines Normal, Aggregated, and Distributed Claim Types.
+	    
+</dd>
+<dt>Claims Provider</dt>
+<dd>
+	      
+	      Server that can return Claims about an Entity.
+	    
+</dd>
+<dt>Credential</dt>
+<dd>
+	      
+	      Data presented as evidence of the right to use an identity
+	      or other resources.
+	    
+</dd>
+<dt>End-User</dt>
+<dd>
+	      
+              Human participant.
+            
+</dd>
+<dt>Entity</dt>
+<dd>
+	      
+              Something that has a separate and distinct existence and that can be
+	      identified in a context. An End-User is one example of an Entity.
+            
+</dd>
+<dt>Essential Claim</dt>
+<dd>
+	      
+              Claim specified by the Client as being necessary to ensure a smooth
+	      authorization experience for the specific task requested by the End-User.
+            
+</dd>
+<dt>Hybrid Flow</dt>
+<dd>
+	      
+              OAuth 2.0 flow in which
+	      an Authorization Code is returned from the Authorization Endpoint,
+	      some tokens are returned from the Authorization Endpoint,
+	      and others are returned from the Token Endpoint.
+            
+</dd>
+<dt>ID Token</dt>
+<dd>
+	      
+              <a class='info' href='#JWT'>JSON Web Token (JWT)<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWT] that contains Claims about the Authentication event.
+	      It MAY contain other Claims.
+            
+</dd>
+<dt>Identifier</dt>
+<dd>
+	      
+	     Value that uniquely characterizes an Entity in a specific context.
+	    
+</dd>
+<dt>Identity</dt>
+<dd>
+	      
+	      Set of attributes related to an Entity.
+	    
+</dd>
+<dt>Implicit Flow</dt>
+<dd>
+	      
+              OAuth 2.0 flow in which all tokens are returned from the Authorization Endpoint
+	      and neither the Token Endpoint nor an Authorization Code are used.
+            
+</dd>
+<dt>Issuer</dt>
+<dd>
+	      
+	      Entity that issues a set of Claims.
+	    
+</dd>
+<dt>Issuer Identifier</dt>
+<dd>
+	      
+	      Verifiable Identifier for an Issuer.
+	      An Issuer Identifier is a case-sensitive URL
+	      using the <tt>https</tt> scheme that
+	      contains scheme, host, and optionally, port number and path
+	      components and no query or fragment components.
+	    
+</dd>
+<dt>Message</dt>
+<dd>
+	      
+	      Request or a response between an OpenID
+	      Relying Party and an OpenID Provider.
+	    
+</dd>
+<dt>OpenID Provider (OP)</dt>
+<dd>
+	      
+              OAuth 2.0 Authorization Server that is capable of
+	      Authenticating the End-User and
+              providing Claims to a Relying Party
+              about the Authentication event and the End-User.
+            
+</dd>
+<dt>Request Object</dt>
+<dd>
+	      
+	      JWT that contains a set of request parameters as its Claims.
+	    
+</dd>
+<dt>Request URI</dt>
+<dd>
+	      
+	      URL that references a resource containing a Request Object.
+	      The Request URI contents MUST be retrievable by the
+	      Authorization Server.
+	    
+</dd>
+<dt>Pairwise Pseudonymous Identifier (PPID)</dt>
+<dd>
+	      
+	      Identifier that identifies the Entity to a Relying Party that cannot be correlated
+	      with the Entity's PPID at another Relying Party.
+	    
+</dd>
+<dt>Personally Identifiable Information (PII)</dt>
+<dd>
+	      
+              Information that (a) can be used to identify the natural person
+              to whom such information relates, or
+              (b) is or might be directly or indirectly linked to a
+	      natural person to whom such information relates.
+	    
+</dd>
+<dt>Relying Party (RP)</dt>
+<dd>
+	      
+              OAuth 2.0 Client application requiring End-User Authentication
+	      and Claims from an OpenID Provider.
+            
+</dd>
+<dt>Sector Identifier</dt>
+<dd>
+	      
+	      Host component of a URL used by the Relying Party's organization
+	      that is an input to the computation of pairwise Subject Identifiers
+	      for that Relying Party.
+	    
+</dd>
+<dt>Self-Issued OpenID Provider</dt>
+<dd>
+	      
+	      Personal, self-hosted OpenID Provider that issues self-signed ID Tokens.
+	    
+</dd>
+<dt>Subject Identifier</dt>
+<dd>
+	      
+	      Locally unique and never
+	      reassigned identifier within the Issuer for the End-User,
+	      which is intended to be consumed by the Client.
+	    
+</dd>
+<dt>UserInfo Endpoint</dt>
+<dd>
+	      
+              Protected Resource that, when presented with an Access Token by the Client,
+	      returns authorized information about the End-User represented by the corresponding
+              Authorization Grant.
+	      The UserInfo Endpoint
+	      URL MUST use the <tt>https</tt> scheme and MAY contain
+	      port, path, and query parameter components.
+
+            
+</dd>
+<dt>Validation</dt>
+<dd>
+	      
+	      Process intended to establish the soundness or correctness of a construct.
+	    
+</dd>
+<dt>Verification</dt>
+<dd>
+	      
+	      Process intended to test or prove the truth or accuracy of a fact or value.
+	    
+</dd>
+<dt>Voluntary Claim</dt>
+<dd>
+	      
+              Claim specified by the Client as being useful but not Essential
+              for the specific task requested by the End-User.
+            
+</dd>
+</dl></blockquote><p>
+        
+</p>
+<p>
+	  IMPORTANT NOTE TO READERS: The terminology definitions in
+	  this section are a normative portion of this specification,
+	  imposing requirements upon implementations.  All the
+	  capitalized words in the text of this specification, such as
+	  "Issuer Identifier", reference these defined terms.
+	  Whenever the reader encounters them, their definitions
+	  found in this section must be followed.
+	
+</p>
+<p>
+	  For more background on some of the terminology used,
+	  see <a class='info' href='#RFC4949'>Internet Security Glossary, Version 2<span> (</span><span class='info'>Shirey, R., &ldquo;Internet Security Glossary, Version 2,&rdquo; August&nbsp;2007.</span><span>)</span></a> [RFC4949],
+	  <a class='info' href='#ISO29115'>ISO/IEC 29115 Entity Authentication Assurance<span> (</span><span class='info'>International Organization for Standardization, &ldquo;ISO/IEC 29115:2013. 	  Information technology - Security techniques - Entity authentication 	  assurance framework,&rdquo; April&nbsp;2013.</span><span>)</span></a> [ISO29115],
+	  and <a class='info' href='#X.1252'>ITU-T X.1252<span> (</span><span class='info'>International Telecommunication Union, &ldquo;ITU-T Recommendation X.1252 - Cyberspace security - Identity management 	  - Baseline identity management terms and definitions,&rdquo; April&nbsp;2010.</span><span>)</span></a> [X.1252].
+	
+</p>
+<a name="Overview"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.1.3"></a><h3>1.3.&nbsp;
+Overview</h3>
+
+<p>The OpenID Connect protocol, in abstract, follows the following
+	steps.
+</p>
+<p>
+	  </p>
+<ol class="text">
+<li>The RP (Client) sends a request to the OpenID Provider (OP).
+</li>
+<li>The OP authenticates the End-User and obtains authorization.
+</li>
+<li>The OP responds with an ID Token and usually an Access Token.
+</li>
+<li>The RP can send a request with the Access Token to the UserInfo Endpoint.
+</li>
+<li>The UserInfo Endpoint returns Claims about the End-User.
+</li>
+</ol><p>
+	
+</p>
+<p>
+	    These steps are illustrated in the following diagram:
+	  
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
++--------+                                   +--------+
+|        |                                   |        |
+|        |---------(1) AuthN Request--------&gt;|        |
+|        |                                   |        |
+|        |  +--------+                       |        |
+|        |  |        |                       |        |
+|        |  |  End-  |&lt;--(2) AuthN &amp; AuthZ--&gt;|        |
+|        |  |  User  |                       |        |
+|   RP   |  |        |                       |   OP   |
+|        |  +--------+                       |        |
+|        |                                   |        |
+|        |&lt;--------(3) AuthN Response--------|        |
+|        |                                   |        |
+|        |---------(4) UserInfo Request-----&gt;|        |
+|        |                                   |        |
+|        |&lt;--------(5) UserInfo Response-----|        |
+|        |                                   |        |
++--------+                                   +--------+
+</pre></div>
+<a name="IDToken"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.2"></a><h3>2.&nbsp;
+ID Token</h3>
+
+<p>
+	The primary extension that OpenID Connect makes to OAuth 2.0
+	to enable End-Users to be Authenticated
+	is the ID Token data structure.
+	The ID Token is a security token that contains Claims about the
+	Authentication of an End-User by an Authorization Server when using a Client,
+	and potentially other requested Claims.
+	The ID Token is represented as a
+	<a class='info' href='#JWT'>JSON Web Token (JWT)<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWT].
+      
+</p>
+<p>
+	The following Claims are used within the ID Token
+	for all OAuth 2.0 flows used by OpenID Connect:
+      
+</p>
+<p>
+	</p>
+<blockquote class="text"><dl>
+<dt>iss</dt>
+<dd>
+	    
+	    REQUIRED.
+	    Issuer Identifier for the Issuer of the response.
+	    The <tt>iss</tt> value is a case-sensitive URL
+	    using the <tt>https</tt> scheme that
+	    contains scheme, host, and optionally, port number and path
+	    components and no query or fragment components.
+	  
+</dd>
+<dt>sub</dt>
+<dd>
+	    
+	    REQUIRED.
+	    Subject Identifier.  A locally unique and never
+	    reassigned identifier within the Issuer for the End-User,
+	    which is intended to be consumed by the Client,
+	    e.g., <tt>24400320</tt>
+	    or <tt>AItOawmwtWwcT0k51BayewNvutrJUqsvl6qs7A4</tt>.
+	    It MUST NOT exceed 255 ASCII <a class='info' href='#RFC20'>[RFC20]<span> (</span><span class='info'>Cerf, V., &ldquo;ASCII format for Network Interchange,&rdquo; October&nbsp;1969.</span><span>)</span></a> characters in length.
+	    The <tt>sub</tt> value is a case-sensitive string.
+	  
+</dd>
+<dt>aud</dt>
+<dd>
+	    
+	    REQUIRED.
+	    Audience(s) that this ID Token is intended for.
+	    It MUST contain the OAuth 2.0 <tt>client_id</tt>
+	    of the Relying Party as an audience value.
+	    It MAY also contain identifiers for other audiences.
+	    In the general case,
+	    the <tt>aud</tt> value is an array of
+	    case-sensitive strings.
+	    In the common special case when there is one audience,
+	    the <tt>aud</tt> value MAY be a single
+	    case-sensitive string.
+	  
+</dd>
+<dt>exp</dt>
+<dd>
+	    
+	    REQUIRED.
+	    Expiration time on or after which the ID Token MUST NOT be
+	    accepted by the RP when performing authentication with the OP.
+	    The processing of this parameter
+	    requires that the current date/time MUST be before the
+	    expiration date/time listed in the value. Implementers MAY
+	    provide for some small leeway, usually no more than a few
+	    minutes, to account for clock skew.
+	    Its value is a JSON <a class='info' href='#RFC8259'>[RFC8259]<span> (</span><span class='info'>Bray, T., Ed., &ldquo;The JavaScript Object Notation (JSON) Data Interchange Format,&rdquo; December&nbsp;2017.</span><span>)</span></a> number representing the number of seconds from
+	    1970-01-01T00:00:00Z as measured in UTC until the date/time.
+	    See <a class='info' href='#RFC3339'>RFC 3339<span> (</span><span class='info'>Klyne, G. and C. Newman, &ldquo;Date and Time on the Internet: Timestamps,&rdquo; July&nbsp;2002.</span><span>)</span></a> [RFC3339]
+	    for details regarding date/times in general and UTC in
+	    particular.
+	    NOTE:  The ID Token expiration time is unrelated the lifetime of
+	    the authenticated session between the RP and the OP.
+	  
+</dd>
+<dt>iat</dt>
+<dd>
+	    
+	    REQUIRED.
+	    Time at which the JWT was issued.
+	    Its value is a JSON number representing the number of seconds from
+	    1970-01-01T00:00:00Z as measured in UTC until the date/time.
+	  
+</dd>
+<dt>auth_time</dt>
+<dd>
+	    
+	    Time when the End-User authentication occurred.
+	    Its value is a JSON number representing the number of seconds from
+	    1970-01-01T00:00:00Z as measured in UTC until the date/time.
+	    When a <tt>max_age</tt> request is made
+	    or when <tt>auth_time</tt> is requested
+	    as an Essential Claim,
+	    then this Claim is REQUIRED; otherwise, its inclusion is OPTIONAL.
+	    (The <tt>auth_time</tt> Claim semantically
+	    corresponds to the OpenID 2.0 <a class='info' href='#OpenID.PAPE'>PAPE<span> (</span><span class='info'>Recordon, D., Jones, M., Bufu, J., Ed., Daugherty, J., Ed., and N. Sakimura, &ldquo;OpenID Provider 	  Authentication Policy Extension 1.0,&rdquo; December&nbsp;2008.</span><span>)</span></a> [OpenID.PAPE]
+	    <tt>auth_time</tt> response parameter.)
+	  
+</dd>
+<dt>nonce</dt>
+<dd>
+	    
+	    String value used to associate a Client session
+	    with an ID Token, and to mitigate replay attacks.
+	    The value is passed through unmodified from the Authentication Request to the ID Token.
+	    If present in the ID Token,
+	    Clients MUST verify that
+	    the <tt>nonce</tt> Claim Value is equal to
+	    the value of the <tt>nonce</tt>
+	    parameter sent in the Authentication Request.
+	    If present in the Authentication Request, Authorization Servers
+	    MUST include a <tt>nonce</tt> Claim in the
+	    ID Token with the Claim Value
+	    being the nonce value sent in the Authentication Request.
+	    Authorization Servers SHOULD perform no other processing
+	    on <tt>nonce</tt> values used.
+	    The <tt>nonce</tt> value is a case-sensitive string.
+	  
+</dd>
+<dt>acr</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    Authentication Context Class Reference.
+	    String specifying an Authentication Context Class Reference value
+	    that identifies the Authentication Context Class that the
+	    authentication performed satisfied.
+	    The value "0" indicates the End-User authentication
+	    did not meet the requirements of
+	    <a class='info' href='#ISO29115'>ISO/IEC 29115<span> (</span><span class='info'>International Organization for Standardization, &ldquo;ISO/IEC 29115:2013. 	  Information technology - Security techniques - Entity authentication 	  assurance framework,&rdquo; April&nbsp;2013.</span><span>)</span></a> [ISO29115] level 1.
+	    For historic reasons, the value "0" is used to indicate that
+	    there is no confidence that the same person is actually there.
+	    Authentications with
+	    level 0 SHOULD NOT be used to authorize access to any resource of any
+	    monetary value.
+	    (This corresponds to the OpenID 2.0
+	    <a class='info' href='#OpenID.PAPE'>PAPE<span> (</span><span class='info'>Recordon, D., Jones, M., Bufu, J., Ed., Daugherty, J., Ed., and N. Sakimura, &ldquo;OpenID Provider 	  Authentication Policy Extension 1.0,&rdquo; December&nbsp;2008.</span><span>)</span></a> [OpenID.PAPE]
+	    <tt>nist_auth_level</tt> 0.)
+	    An absolute URI or an <a class='info' href='#RFC6711'>RFC 6711<span> (</span><span class='info'>Johansson, L., &ldquo;An IANA Registry for Level of Assurance (LoA) Profiles,&rdquo; August&nbsp;2012.</span><span>)</span></a> [RFC6711]
+	    registered name
+	    SHOULD be used as the <tt>acr</tt> value;
+	    registered names MUST NOT be used with a different meaning than
+	    that which is registered.
+	    Parties using this claim will need to agree upon the meanings of
+	    the values used, which may be context specific.
+	    The <tt>acr</tt> value is a case-sensitive string.
+	  
+</dd>
+<dt>amr</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    Authentication Methods References.
+	    JSON array of strings that are identifiers for authentication methods
+	    used in the authentication.
+	    For instance, values might indicate that both password and OTP
+	    authentication methods were used.
+	    The <tt>amr</tt> value is an array of
+	    case-sensitive strings.
+	    Values used in the
+	    <tt>amr</tt> Claim
+	    SHOULD be from those registered in the
+	    IANA Authentication Method Reference Values registry <a class='info' href='#IANA.AMR'>[IANA.AMR]<span> (</span><span class='info'>IANA, &ldquo;Authentication Method Reference Values,&rdquo; .</span><span>)</span></a>
+	    established by <a class='info' href='#RFC8176'>[RFC8176]<span> (</span><span class='info'>Jones, M., Hunt, P., and A. Nadalin, &ldquo;Authentication Method Reference Values,&rdquo; June&nbsp;2017.</span><span>)</span></a>;
+	    parties using this claim will need to agree upon the meanings of
+	    any unregistered values used, which may be context specific.
+	  
+</dd>
+<dt>azp</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    Authorized party - the party to which the ID Token was issued.
+	    If present, it MUST contain the OAuth 2.0
+	    Client ID of this party.
+	    The <tt>azp</tt> value is a case-sensitive string
+	    containing a StringOrURI value.
+	    Note that in practice, the <tt>azp</tt> Claim only occurs
+	    when extensions beyond the scope of this specification are used;
+	    therefore, implementations not using such extensions
+	    are encouraged to not use <tt>azp</tt>
+	    and to ignore it when it does occur.
+	  
+</dd>
+</dl></blockquote><p>
+      
+</p>
+<p>
+	ID Tokens MAY contain other Claims.
+	Any Claims used that are not understood MUST be ignored.
+	See Sections
+	<a class='info' href='#CodeIDToken'>3.1.3.6<span> (</span><span class='info'>ID Token</span><span>)</span></a>,
+	<a class='info' href='#HybridIDToken'>3.3.2.11<span> (</span><span class='info'>ID Token</span><span>)</span></a>,
+	<a class='info' href='#StandardClaims'>5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a>, and
+	<a class='info' href='#SelfIssuedResponse'>7.4<span> (</span><span class='info'>Self-Issued OpenID Provider Response</span><span>)</span></a>
+	for additional Claims defined by this specification.
+      
+</p>
+<p>
+	ID Tokens MUST be signed using <a class='info' href='#JWS'>JWS<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Signature (JWS),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWS] and optionally both signed and then
+	encrypted using <a class='info' href='#JWS'>JWS<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Signature (JWS),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWS] and <a class='info' href='#JWE'>JWE<span> (</span><span class='info'>Jones, M. and J. Hildebrand, &ldquo;JSON Web Encryption (JWE),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWE] respectively, thereby providing
+	authentication, integrity,
+	non-repudiation, and optionally, confidentiality,
+	per <a class='info' href='#SigningOrder'>Section&nbsp;16.14<span> (</span><span class='info'>Signing and Encryption Order</span><span>)</span></a>.
+	If the ID Token is encrypted, it MUST be signed then encrypted,
+	with the result being a Nested JWT, as defined in <a class='info' href='#JWT'>[JWT]<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a>.
+	ID Tokens MUST NOT use <tt>none</tt>
+	as the <tt>alg</tt> value
+	unless the Response Type used returns no ID Token from the
+	Authorization Endpoint
+	(such as when using the Authorization Code Flow)
+	and the Client explicitly requested the use of
+	<tt>none</tt> at Registration time.
+      
+</p>
+<p>
+	ID Tokens SHOULD NOT use the JWS or JWE
+	<tt>x5u</tt>,
+	<tt>x5c</tt>,
+	<tt>jku</tt>, or
+	<tt>jwk</tt>
+	Header Parameter fields.
+	Instead, references to keys used are
+	communicated in advance using Discovery and Registration parameters,
+	per <a class='info' href='#SigEnc'>Section&nbsp;10<span> (</span><span class='info'>Signatures and Encryption</span><span>)</span></a>.
+      
+</p>
+<p>
+	  The following is a non-normative example of
+	  the set of Claims (the JWT Claims Set) in an ID Token:
+	
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "iss": "https://server.example.com",
+   "sub": "24400320",
+   "aud": "s6BhdRkqt3",
+   "nonce": "n-0S6_WzA2Mj",
+   "exp": 1311281970,
+   "iat": 1311280970,
+   "auth_time": 1311280969,
+   "acr": "urn:mace:incommon:iap:silver"
+  }
+</pre></div>
+<a name="Authentication"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3"></a><h3>3.&nbsp;
+Authentication</h3>
+
+<p>
+	OpenID Connect performs authentication to log in the End-User
+	or to determine that the End-User is already logged in.
+	OpenID Connect returns the result of the Authentication
+	performed by the Server to the Client in a secure manner
+	so that the Client can rely on it.
+	For this reason, the Client is called Relying Party (RP) in this case.
+      
+</p>
+<p>
+	The Authentication result is returned in an
+	ID Token, as defined in <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a>.
+	It has Claims expressing such information as the Issuer,
+	the Subject Identifier, when the authentication was performed, etc.
+      
+</p>
+<p>
+	Authentication can follow one of three paths:
+	the Authorization Code Flow (<tt>response_type=code</tt>),
+	the Implicit Flow (<tt>response_type=id_token&nbsp;token</tt>
+	or <tt>response_type=id_token</tt>), or
+	the Hybrid Flow (using other Response Type values defined in
+	<a class='info' href='#OAuth.Responses'>OAuth 2.0 Multiple Response Type Encoding Practices<span> (</span><span class='info'>de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;OAuth 2.0 Multiple Response Type Encoding Practices,&rdquo; February&nbsp;2014.</span><span>)</span></a> [OAuth.Responses]).
+	The flows determine how the ID Token and Access Token
+	are returned to the Client.
+      
+</p>
+<p>
+	The characteristics of the three flows are summarized
+	in the following non-normative table.
+	The table is intended to provide some guidance on which flow to choose
+	in particular contexts.
+      
+</p><br /><hr class="insert" />
+<table class="full" align="center" border="0" cellpadding="2" cellspacing="2">
+<col align="left"><col align="left"><col align="left"><col align="left">
+<tr><th align="left">Property</th><th align="left">Authorization Code Flow</th><th align="left">Implicit Flow</th><th align="left">Hybrid Flow</th></tr>
+<tr>
+<td align="left">All tokens returned from Authorization Endpoint</td>
+<td align="left">no</td>
+<td align="left">yes</td>
+<td align="left">no</td>
+</tr>
+<tr>
+<td align="left">All tokens returned from Token Endpoint</td>
+<td align="left">yes</td>
+<td align="left">no</td>
+<td align="left">no</td>
+</tr>
+<tr>
+<td align="left">Tokens not revealed to User Agent</td>
+<td align="left">yes</td>
+<td align="left">no</td>
+<td align="left">no</td>
+</tr>
+<tr>
+<td align="left">Client can be authenticated</td>
+<td align="left">yes</td>
+<td align="left">no</td>
+<td align="left">yes</td>
+</tr>
+<tr>
+<td align="left">Refresh Token possible</td>
+<td align="left">yes</td>
+<td align="left">no</td>
+<td align="left">yes</td>
+</tr>
+<tr>
+<td align="left">Communication in one round trip</td>
+<td align="left">no</td>
+<td align="left">yes</td>
+<td align="left">no</td>
+</tr>
+<tr>
+<td align="left">Most communication server-to-server</td>
+<td align="left">yes</td>
+<td align="left">no</td>
+<td align="left">varies</td>
+</tr>
+</table>
+<br clear="all" />
+<table border="0" cellpadding="0" cellspacing="2" align="center"><tr><td align="center"><font face="monaco, MS Sans Serif" size="1"><b>&nbsp;OpenID Connect Authentication Flows&nbsp;</b></font><br /></td></tr></table><hr class="insert" />
+
+<p>
+	The flow used is determined by the <tt>response_type</tt>
+	value contained in the Authorization Request.
+	These <tt>response_type</tt> values select
+	these flows:
+      
+</p><br /><hr class="insert" />
+<table class="full" align="center" border="0" cellpadding="2" cellspacing="2">
+<col align="left"><col align="left">
+<tr><th align="left">"response_type" value</th><th align="left">Flow</th></tr>
+<tr>
+<td align="left"><tt>code</tt>&nbsp;</td>
+<td align="left">Authorization Code Flow</td>
+</tr>
+<tr>
+<td align="left"><tt>id_token</tt>&nbsp;</td>
+<td align="left">Implicit Flow</td>
+</tr>
+<tr>
+<td align="left"><tt>id_token&nbsp;token</tt>&nbsp;</td>
+<td align="left">Implicit Flow</td>
+</tr>
+<tr>
+<td align="left"><tt>code&nbsp;id_token</tt>&nbsp;</td>
+<td align="left">Hybrid Flow</td>
+</tr>
+<tr>
+<td align="left"><tt>code&nbsp;token</tt>&nbsp;</td>
+<td align="left">Hybrid Flow</td>
+</tr>
+<tr>
+<td align="left"><tt>code&nbsp;id_token&nbsp;token</tt>&nbsp;</td>
+<td align="left">Hybrid Flow</td>
+</tr>
+</table>
+<br clear="all" />
+<table border="0" cellpadding="0" cellspacing="2" align="center"><tr><td align="center"><font face="monaco, MS Sans Serif" size="1"><b>&nbsp;OpenID Connect "response_type" Values&nbsp;</b></font><br /></td></tr></table><hr class="insert" />
+
+<p>
+	All but the <tt>code</tt> Response Type value,
+	which is defined by <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749],
+	are defined in the
+	<a class='info' href='#OAuth.Responses'>OAuth 2.0 Multiple Response Type Encoding Practices<span> (</span><span class='info'>de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;OAuth 2.0 Multiple Response Type Encoding Practices,&rdquo; February&nbsp;2014.</span><span>)</span></a> [OAuth.Responses]
+	specification.
+	NOTE:  While OAuth 2.0 also defines the
+	<tt>token</tt> Response Type value
+	for the Implicit Flow, OpenID Connect does not use this Response Type,
+	since no ID Token would be returned.
+      
+</p>
+<a name="CodeFlowAuth"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1"></a><h3>3.1.&nbsp;
+Authentication using the Authorization Code Flow</h3>
+
+<p>
+	  This section describes how to perform authentication using the Authorization Code Flow.
+	  When using the Authorization Code Flow,
+	  all tokens are returned from the Token Endpoint.
+	
+</p>
+<p>The Authorization Code Flow returns an Authorization Code to the
+	Client, which can then exchange it for an ID Token and an Access Token directly.
+	This provides the benefit of not exposing any tokens to the
+	User Agent and possibly other malicious applications with access
+	to the User Agent.
+	The Authorization Server can also
+	authenticate the Client before exchanging the Authorization Code for an
+	Access Token. The Authorization Code flow is suitable for Clients that
+	can securely maintain a Client Secret between themselves and the
+	Authorization Server.
+</p>
+<a name="CodeFlowSteps"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.1"></a><h3>3.1.1.&nbsp;
+Authorization Code Flow Steps</h3>
+
+<p>The Authorization Code Flow goes through the following
+	  steps.
+</p>
+<p>
+	    </p>
+<ol class="text">
+<li>Client prepares an Authentication Request containing the desired
+	      request parameters.
+</li>
+<li>Client sends the request to the Authorization Server.
+</li>
+<li>Authorization Server Authenticates the End-User.
+</li>
+<li>Authorization Server obtains End-User Consent/Authorization.
+</li>
+<li>Authorization Server sends the End-User back to the Client with
+	      an Authorization Code.
+</li>
+<li>Client requests a response using the Authorization Code at the
+	      Token Endpoint.
+</li>
+<li>Client receives a response that contains an ID Token
+	      and Access Token in the response body.
+</li>
+<li>Client validates the ID token and retrieves the End-User's
+	      Subject Identifier.
+</li>
+</ol><p>
+	  
+</p>
+<a name="AuthorizationEndpoint"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.2"></a><h3>3.1.2.&nbsp;
+Authorization Endpoint</h3>
+
+<p>
+	    The Authorization Endpoint performs Authentication of the
+	    End-User.
+	    This is done by sending the User Agent to
+	    the Authorization Server's Authorization Endpoint for Authentication and
+	    Authorization, using request parameters defined by OAuth 2.0 and
+	    additional parameters and parameter values defined by OpenID Connect.
+	  
+</p>
+<p>
+	    Communication with the Authorization Endpoint MUST utilize TLS.
+	    See <a class='info' href='#TLSRequirements'>Section&nbsp;16.17<span> (</span><span class='info'>TLS Requirements</span><span>)</span></a> for more information on using TLS.
+	  
+</p>
+<a name="AuthRequest"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.2.1"></a><h3>3.1.2.1.&nbsp;
+Authentication Request</h3>
+
+<p>
+	      An Authentication Request is
+	      an OAuth 2.0 Authorization Request that requests that the End-User
+	      be authenticated by the Authorization Server.
+	    
+</p>
+<p>Authorization Servers MUST support the use of the HTTP <tt>GET</tt> and
+	    <tt>POST</tt> methods defined in <a class='info' href='#RFC7231'>RFC 7231<span> (</span><span class='info'>Fielding, R., Ed. and J. Reschke, Ed., &ldquo;Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content,&rdquo; June&nbsp;2014.</span><span>)</span></a> [RFC7231] at the
+	    Authorization Endpoint.
+	    Clients MAY use the HTTP <tt>GET</tt> or
+	    <tt>POST</tt> methods to send the
+	    Authorization Request to the Authorization Server. If using the HTTP
+	    <tt>GET</tt> method, the request parameters are serialized using
+	    URI Query String Serialization, per <a class='info' href='#QuerySerialization'>Section&nbsp;13.1<span> (</span><span class='info'>Query String Serialization</span><span>)</span></a>.
+	    If using the HTTP <tt>POST</tt>
+	    method, the request parameters are serialized using
+	    Form Serialization, per <a class='info' href='#FormSerialization'>Section&nbsp;13.2<span> (</span><span class='info'>Form Serialization</span><span>)</span></a>.
+</p>
+<p>
+	      OpenID Connect uses the following OAuth 2.0 request parameters with
+	      the Authorization Code Flow:
+	    
+</p>
+<p>
+	      </p>
+<blockquote class="text"><dl>
+<dt>scope</dt>
+<dd>
+		  
+		  REQUIRED.
+		  OpenID Connect requests MUST contain the <tt>openid</tt> scope value.
+		  If the <tt>openid</tt> scope value is not present,
+		  the behavior is entirely unspecified.
+		  Other scope values MAY be present.
+		  Scope values used that are not understood by an implementation SHOULD be ignored.
+		  See Sections <a class='info' href='#ScopeClaims'>5.4<span> (</span><span class='info'>Requesting Claims using Scope Values</span><span>)</span></a>
+		  and <a class='info' href='#OfflineAccess'>11<span> (</span><span class='info'>Offline Access</span><span>)</span></a>
+		  for additional scope values defined by this specification.
+		
+</dd>
+<dt>response_type</dt>
+<dd>
+		  
+		  REQUIRED.
+		  OAuth 2.0 Response Type value that determines
+		  the authorization processing flow to be used,
+		  including what parameters are returned from the endpoints used.
+		  When using the Authorization Code Flow, this value is
+		  <tt>code</tt>.
+		
+</dd>
+<dt>client_id</dt>
+<dd>
+		  
+		  REQUIRED.
+		  OAuth 2.0 Client Identifier
+		  valid at the Authorization Server.
+		
+</dd>
+<dt>redirect_uri</dt>
+<dd>
+		  
+		  REQUIRED.
+		  Redirection URI to which the response will be sent.
+		  This URI MUST exactly match one of the Redirection URI values
+		  for the Client pre-registered at the OpenID Provider,
+		  with the matching performed as described in
+		  Section 6.2.1 of <a class='info' href='#RFC3986'>[RFC3986]<span> (</span><span class='info'>Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;Uniform Resource Identifier (URI): Generic Syntax,&rdquo; January&nbsp;2005.</span><span>)</span></a> (Simple String Comparison).
+		  When using this flow, the Redirection URI
+		  SHOULD use the <tt>https</tt> scheme;
+		  however, it MAY use the <tt>http</tt> scheme,
+		  provided that the Client Type is
+		  <tt>confidential</tt>,
+		  as defined in Section 2.1 of OAuth 2.0, and
+		  provided the OP allows the use of
+		  <tt>http</tt> Redirection URIs in this case.
+		  Also, if the Client is a native application,
+		  it MAY use the <tt>http</tt> scheme with
+		  <tt>localhost</tt> or the IP loopback literals
+		  <tt>127.0.0.1</tt> or <tt>[::1]</tt>
+		  as the hostname.
+		  The Redirection URI MAY use an alternate scheme,
+		  such as one that is intended to identify a callback into a native application.
+		
+</dd>
+<dt>state</dt>
+<dd>
+		  
+		  RECOMMENDED.
+		  Opaque value used
+		  to maintain state between the request and the callback.
+		  Typically, Cross-Site Request Forgery (CSRF, XSRF)
+		  mitigation is done by cryptographically binding the value of
+		  this parameter with a browser cookie.
+		
+</dd>
+</dl></blockquote><p>
+	    
+</p>
+<p>
+	      OpenID Connect also uses the following OAuth 2.0 request parameter,
+	      which is defined in
+	      <a class='info' href='#OAuth.Responses'>OAuth 2.0 Multiple Response Type Encoding Practices<span> (</span><span class='info'>de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;OAuth 2.0 Multiple Response Type Encoding Practices,&rdquo; February&nbsp;2014.</span><span>)</span></a> [OAuth.Responses]:
+	    
+</p>
+<p>
+
+	      </p>
+<blockquote class="text"><dl>
+<dt>response_mode</dt>
+<dd>
+		  
+		  OPTIONAL.
+		  Informs the Authorization Server of the mechanism to be used
+		  for returning parameters from the Authorization Endpoint.
+		  This use of this parameter is NOT RECOMMENDED when the Response Mode
+		  that would be requested is the default mode specified for the Response Type.
+		
+</dd>
+</dl></blockquote><p>
+	    
+</p>
+<p>
+	      This specification also defines the following request parameters:
+	    
+</p>
+<p>
+	      </p>
+<blockquote class="text"><dl>
+<dt>nonce</dt>
+<dd>
+		  
+		  OPTIONAL.
+		  String value used to associate a Client session
+		  with an ID Token, and to mitigate replay attacks.
+		  The value is passed through unmodified from the Authentication Request to the ID Token.
+		  Sufficient entropy MUST be present in the
+		  <tt>nonce</tt> values used to prevent
+		  attackers from guessing values.
+		  For implementation notes, see <a class='info' href='#NonceNotes'>Section&nbsp;15.5.2<span> (</span><span class='info'>Nonce Implementation Notes</span><span>)</span></a>.
+		
+</dd>
+<dt>display</dt>
+<dd>
+		  
+		  OPTIONAL.
+		  ASCII string value that specifies
+		  how the Authorization Server displays the authentication and
+		  consent user interface pages to the End-User.
+		  The defined values are:
+
+		  
+<blockquote class="text"><dl>
+<dt>page</dt>
+<dd>
+		      
+		      The Authorization Server SHOULD display the
+		      authentication and consent UI consistent with a full User Agent page
+		      view. If the display parameter is not specified, this is the
+		      default display mode.
+		    
+</dd>
+<dt>popup</dt>
+<dd>
+		      
+		      The Authorization Server SHOULD display the
+		      authentication and consent UI consistent with a popup User Agent
+		      window.
+		      The popup User Agent window should be of an appropriate size
+		      for a login-focused dialog and should not obscure
+		      the entire window that it is popping up over.
+		    
+</dd>
+<dt>touch</dt>
+<dd>
+		      
+		      The Authorization Server SHOULD display the
+		      authentication and consent UI consistent with a device that
+		      leverages a touch interface.
+		    
+</dd>
+<dt>wap</dt>
+<dd>
+		      
+		      The Authorization Server SHOULD display the
+		      authentication and consent UI consistent with a "feature phone"
+		      type display.
+		    
+</dd>
+</dl></blockquote>
+		
+</dd>
+<dt></dt>
+<dd>
+		  The Authorization Server MAY also attempt to detect the capabilities
+		  of the User Agent and present an appropriate display.
+		
+</dd>
+<dt></dt>
+<dd>
+		  If an OP receives a <tt>display</tt> value
+		  outside the set defined above that it does not understand,
+		  it MAY return an error or it MAY ignore it;
+		  in practice, not returning errors for not-understood values
+		  will help facilitate phasing in extensions using new
+		  <tt>display</tt> values.
+		
+</dd>
+<dt>prompt</dt>
+<dd>
+		  
+		  OPTIONAL.
+		  Space-delimited, case-sensitive list of ASCII string values
+		  that specifies whether the Authorization Server prompts
+		  the End-User for reauthentication and consent.
+		  The defined values are:
+
+		  
+<blockquote class="text"><dl>
+<dt>none</dt>
+<dd>
+		      
+		      The Authorization Server
+		      MUST NOT display any authentication or consent
+		      user interface pages.
+		      An error is returned
+		      if an End-User
+		      is not already authenticated or the Client does not have
+		      pre-configured consent for the requested
+		      Claims or does not fulfill other conditions for processing the request.
+		      The error code will typically be
+		      <tt>login_required</tt>,
+		      <tt>interaction_required</tt>,
+		      or another code defined in <a class='info' href='#AuthError'>Section&nbsp;3.1.2.6<span> (</span><span class='info'>Authentication Error Response</span><span>)</span></a>.
+		      This can be used as a
+		      method to check for existing authentication and/or consent.
+		    
+</dd>
+<dt>login</dt>
+<dd>
+		      
+		      The Authorization Server SHOULD prompt the
+		      End-User for reauthentication.
+		      If it cannot reauthenticate the End-User, it MUST return an error,
+		      typically <tt>login_required</tt>.
+		    
+</dd>
+<dt>consent</dt>
+<dd>
+		      
+		      The Authorization Server SHOULD prompt the End-User for consent
+		      before returning information to the Client.
+		      If it cannot obtain consent, it MUST return an error,
+		      typically <tt>consent_required</tt>.
+		    
+</dd>
+<dt>select_account</dt>
+<dd>
+		      
+		      The Authorization Server SHOULD
+		      prompt the End-User to select a user account.  This enables
+		      an End-User who has multiple accounts at the Authorization Server
+		      to select amongst the multiple accounts that they might have
+		      current sessions for.
+		      If it cannot obtain an account selection choice made by the End-User,
+		      it MUST return an error,
+		      typically <tt>account_selection_required</tt>.
+		    
+</dd>
+</dl></blockquote>
+		
+</dd>
+<dt></dt>
+<dd>
+		  The <tt>prompt</tt> parameter
+		  can be used by the Client to make sure that the End-User is
+		  still present for the current session or to bring attention to the
+		  request. If this parameter contains <tt>none</tt>
+		  with any other value, an
+		  error is returned.
+		
+</dd>
+<dt></dt>
+<dd>
+		  If an OP receives a <tt>prompt</tt> value
+		  outside the set defined above that it does not understand,
+		  it MAY return an error or it MAY ignore it;
+		  in practice, not returning errors for not-understood values
+		  will help facilitate phasing in extensions using new
+		  <tt>prompt</tt> values.
+		
+</dd>
+<dt>max_age</dt>
+<dd>
+		  
+		  OPTIONAL.
+		  Maximum Authentication Age.
+		  Specifies the allowable elapsed time in seconds
+		  since the last time the End-User was actively
+		  authenticated by the OP. If the elapsed time is greater than
+		  this value, the OP MUST attempt to actively
+		  re-authenticate the End-User.
+		  (The <tt>max_age</tt> request parameter corresponds to
+		  the OpenID 2.0 <a class='info' href='#OpenID.PAPE'>PAPE<span> (</span><span class='info'>Recordon, D., Jones, M., Bufu, J., Ed., Daugherty, J., Ed., and N. Sakimura, &ldquo;OpenID Provider 	  Authentication Policy Extension 1.0,&rdquo; December&nbsp;2008.</span><span>)</span></a> [OpenID.PAPE]
+		  <tt>max_auth_age</tt> request parameter.)
+		  When <tt>max_age</tt> is used, the ID Token returned
+		  MUST include an <tt>auth_time</tt> Claim Value.
+		  Note that <tt>max_age=0</tt> is equivalent
+		  to <tt>prompt=login</tt>.
+		
+</dd>
+<dt>ui_locales</dt>
+<dd>
+		  
+		  OPTIONAL.
+		  End-User's preferred languages and scripts for the user interface,
+		  represented as a space-separated list of
+		  <a class='info' href='#RFC5646'>BCP47<span> (</span><span class='info'>Phillips, A., Ed. and M. Davis, Ed., &ldquo;Tags for Identifying Languages,&rdquo; September&nbsp;2009.</span><span>)</span></a> [RFC5646] language tag values,
+		  ordered by preference.
+		  For instance, the value "fr-CA fr en" represents a preference
+		  for French as spoken in Canada,
+		  then French (without a region designation),
+		  followed by English (without a region designation).
+		  An error SHOULD NOT result if some or all of the requested locales
+		  are not supported by the OpenID Provider.
+		
+</dd>
+<dt>id_token_hint</dt>
+<dd>
+		  
+		  OPTIONAL.
+		  ID Token previously issued by the Authorization Server
+		  being passed as a hint about the End-User's current or past
+		  authenticated session with the Client.
+		  If the End-User identified by the ID Token is already logged in
+		  or is logged in as a result of the request
+		  (with the OP possibly evaluating other information beyond the ID Token in this decision),
+		  then the Authorization Server returns a positive response;
+		  otherwise, it MUST return
+		  an error, such as <tt>login_required</tt>.
+		  When possible, an <tt>id_token_hint</tt>
+		  SHOULD be present when <tt>prompt=none</tt> is used
+		  and an <tt>invalid_request</tt> error
+		  MAY be returned if it is not;
+		  however, the server SHOULD respond successfully when possible,
+		  even if it is not present.
+		  The Authorization Server need not be listed as an
+		  audience of the ID Token when it is used as an
+		  <tt>id_token_hint</tt> value.
+		
+</dd>
+<dt></dt>
+<dd>
+		  If the ID Token received by the RP from the OP is encrypted,
+		  to use it as an <tt>id_token_hint</tt>, the Client MUST
+		  decrypt the signed ID Token contained within the encrypted ID Token.
+		  The Client MAY re-encrypt the signed ID token to the Authentication Server
+		  using a key that enables the server to decrypt the ID Token
+		  and use the re-encrypted ID token as the
+		  <tt>id_token_hint</tt> value.
+		
+</dd>
+<dt>login_hint</dt>
+<dd>
+		  
+		  OPTIONAL.
+		  Hint to the Authorization Server
+		  about the login identifier the End-User might use to log in (if necessary).
+		  This hint can be used by an RP if it first asks the End-User for their e-mail
+		  address (or other identifier) and then wants to pass that value as a hint
+		  to the discovered authorization service.
+		  It is RECOMMENDED that the hint value match the value used for discovery.
+		  This value MAY also be a phone number in the format specified for the
+		  <tt>phone_number</tt> Claim.
+		  The use of this parameter is left to the OP's discretion.
+		
+</dd>
+<dt>acr_values</dt>
+<dd>
+		  
+		  OPTIONAL.
+		  Requested Authentication Context Class Reference values.
+		  Space-separated string that specifies the <tt>acr</tt>
+		  values that the Authorization Server is being requested to use
+		  for processing this Authentication Request,
+		  with the values appearing in order of preference.
+		  The Authentication Context Class satisfied by the authentication
+		  performed is returned as the <tt>acr</tt> Claim Value,
+		  as specified in <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a>.
+		  The <tt>acr</tt> Claim is requested as
+		  a Voluntary Claim by this parameter.
+		
+</dd>
+</dl></blockquote><p>
+	    
+</p>
+<p>
+	      Other parameters MAY be sent.
+	      See Sections <a class='info' href='#ImplicitAuthorizationEndpoint'>3.2.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a>,
+	      <a class='info' href='#HybridAuthorizationEndpoint'>3.3.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a>,
+	      <a class='info' href='#ClaimsLanguagesAndScripts'>5.2<span> (</span><span class='info'>Claims Languages and Scripts</span><span>)</span></a>,
+	      <a class='info' href='#ClaimsParameter'>5.5<span> (</span><span class='info'>Requesting Claims using the &quot;claims&quot; Request Parameter</span><span>)</span></a>,
+	      <a class='info' href='#JWTRequests'>6<span> (</span><span class='info'>Passing Request Parameters as JWTs</span><span>)</span></a>, and
+	      <a class='info' href='#RegistrationParameter'>7.2.1<span> (</span><span class='info'>Providing Information with the &quot;registration&quot; Request Parameter</span><span>)</span></a>
+	      for additional Authorization Request parameters and parameter values
+	      defined by this specification.
+	    
+</p>
+<p>
+		The following is a non-normative example
+		HTTP 302 redirect response by the Client, which triggers
+		the User Agent to make an Authentication Request
+		to the Authorization Endpoint
+		(with line wraps within values for display purposes only):
+	      
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  HTTP/1.1 302 Found
+  Location: https://server.example.com/authorize?
+    response_type=code
+    &amp;scope=openid%20profile%20email
+    &amp;client_id=s6BhdRkqt3
+    &amp;state=af0ifjsldkj
+    &amp;redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+</pre></div>
+<p>
+		The following is the non-normative example request
+		that would be sent by the User Agent to the Authorization Server
+		in response to the HTTP 302 redirect response by the Client above
+		(with line wraps within values for display purposes only):
+	      
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /authorize?
+    response_type=code
+    &amp;scope=openid%20profile%20email
+    &amp;client_id=s6BhdRkqt3
+    &amp;state=af0ifjsldkj
+    &amp;redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb HTTP/1.1
+  Host: server.example.com
+</pre></div>
+<a name="AuthRequestValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.2.2"></a><h3>3.1.2.2.&nbsp;
+Authentication Request Validation</h3>
+
+<p>
+	      The Authorization Server MUST validate the request received as follows:
+	    
+</p>
+<p>
+	      </p>
+<ol class="text">
+<li>
+		  The Authorization Server MUST validate all the
+		  OAuth 2.0 parameters according to the OAuth 2.0 specification.
+		
+</li>
+<li>
+		  Verify that a <tt>scope</tt> parameter is present
+		  and contains the <tt>openid</tt> scope value.
+		  (If no <tt>openid</tt> scope value is present,
+		  the request may still be a valid OAuth 2.0 request
+		  but is not an OpenID Connect request.)
+		
+</li>
+<li>
+		  The Authorization Server MUST verify that all the REQUIRED parameters
+		  are present
+		  and their usage conforms to this specification.
+		
+</li>
+<li>
+		  If the <tt>sub</tt> (subject) Claim
+		  is requested with a specific value for the ID Token,
+		  the Authorization Server MUST only send a positive response
+		  if the End-User identified by that <tt>sub</tt> value
+		  has an active session with the Authorization Server
+		  or has been Authenticated as a result of the request.
+		  The Authorization Server MUST NOT reply with an ID Token or
+		  Access Token for a different user,
+		  even if they have an active session with the Authorization Server.
+		  Such a request can be made either using an
+		  <tt>id_token_hint</tt> parameter
+		  or by requesting a specific Claim Value
+		  as described in <a class='info' href='#IndividualClaimsRequests'>Section&nbsp;5.5.1<span> (</span><span class='info'>Individual Claims Requests</span><span>)</span></a>,
+		  if the <tt>claims</tt> parameter
+		  is supported by the implementation.
+		
+</li>
+<li>
+		  When an <tt>id_token_hint</tt> is present,
+		  the OP MUST validate that it was the issuer of the ID Token.
+		  The OP SHOULD accept ID Tokens when the RP identified by the ID Token
+		  has a current session or had a recent session at the OP,
+		  even when the <tt>exp</tt> time has passed.
+		
+</li>
+</ol><p>
+	    
+</p>
+<p>
+	      As specified in <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749],
+	      Authorization Servers SHOULD ignore unrecognized request parameters.
+	    
+</p>
+<p>
+	      If the Authorization Server encounters any error,
+	      it MUST return an error response, per <a class='info' href='#AuthError'>Section&nbsp;3.1.2.6<span> (</span><span class='info'>Authentication Error Response</span><span>)</span></a>.
+	    
+</p>
+<a name="Authenticates"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.2.3"></a><h3>3.1.2.3.&nbsp;
+Authorization Server Authenticates End-User</h3>
+
+<p>
+	      If the request is valid, the Authorization Server attempts
+	      to Authenticate the End-User or determines whether the End-User is Authenticated,
+	      depending upon the request parameter values used.
+	      The methods used by the Authorization Server to Authenticate the End-User
+	      (e.g., username and password, session cookies, etc.)
+	      are beyond the scope of this specification.
+	      An Authentication user interface MAY be displayed by
+	      the Authorization Server, depending upon the request parameter values used
+	      and the authentication methods used.
+	    
+</p>
+<p>The Authorization Server MUST attempt to Authenticate the
+	    End-User in the following cases:
+	    </p>
+<ul class="text">
+<li>The End-User is not already Authenticated.
+</li>
+<li>The Authentication Request contains the <tt>prompt</tt> parameter with the value
+	      <tt>login</tt>.  In this case, the
+	      Authorization Server MUST reauthenticate the End-User
+	      even if the End-User is already authenticated.
+</li>
+</ul><p>
+	    
+</p>
+<p>The Authorization Server MUST NOT interact with the End-User
+	    in the following case:
+            </p>
+<ul class="text">
+<li>The Authentication Request contains the <tt>prompt</tt> parameter with the value
+	      <tt>none</tt>.  In this case,
+	      the Authorization Server MUST return
+	      an error if an End-User
+	      is not already Authenticated or could not be silently Authenticated.
+</li>
+</ul><p>
+	    
+</p>
+<p>
+	      When interacting with the End-User,
+	      the Authorization Server MUST employ appropriate measures against
+	      Cross-Site Request Forgery and Clickjacking as, described in
+	      Sections 10.12 and 10.13 of <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749].
+	    
+</p>
+<a name="Consent"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.2.4"></a><h3>3.1.2.4.&nbsp;
+Authorization Server Obtains End-User Consent/Authorization</h3>
+
+<p>
+	      Once the End-User is authenticated, the Authorization Server MUST
+	      obtain an authorization decision before releasing information
+	      to the Relying Party.
+	      When permitted by the request parameters used,
+	      this MAY be done through an interactive dialogue with the End-User
+	      that makes it clear what is being consented to
+	      or by establishing consent via conditions for processing the request or
+	      other means (for example, via previous administrative consent).
+	      Sections <a class='info' href='#IDToken'>2<span> (</span><span class='info'>ID Token</span><span>)</span></a> and
+	      <a class='info' href='#UserInfo'>5.3<span> (</span><span class='info'>UserInfo Endpoint</span><span>)</span></a> describe
+	      information release mechanisms.
+	    
+</p>
+<a name="AuthResponse"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.2.5"></a><h3>3.1.2.5.&nbsp;
+Successful Authentication Response</h3>
+
+<p>
+	      An Authentication Response is an OAuth 2.0 Authorization Response
+	      message returned from the
+	      OP's Authorization Endpoint in response to the Authorization Request
+	      message sent by the RP.
+	    
+</p>
+<p>
+	      When using the Authorization Code Flow, the Authorization Response
+	      MUST return the parameters defined in Section 4.1.2 of
+	      <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749]
+	      by adding them as query parameters to the
+	      <tt>redirect_uri</tt> specified in the Authorization Request
+	      using the <tt>application/x-www-form-urlencoded</tt> format,
+	      unless a different Response Mode was specified.
+	    
+</p>
+<p>
+		The following is a non-normative example
+		successful response using this flow
+		(with line wraps within values for display purposes only):
+	      
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  HTTP/1.1 302 Found
+  Location: https://client.example.org/cb?
+    code=SplxlOBeZQQYbYS6WxSbIA
+    &amp;state=af0ifjsldkj
+</pre></div>
+<p>
+	      For implementation notes on the contents of
+	      the Authorization Code, see <a class='info' href='#CodeNotes'>Section&nbsp;15.5.1<span> (</span><span class='info'>Authorization Code Implementation Notes</span><span>)</span></a>.
+	    
+</p>
+<a name="AuthError"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.2.6"></a><h3>3.1.2.6.&nbsp;
+Authentication Error Response</h3>
+
+<p>
+	      An Authentication Error Response is an OAuth 2.0 Authorization Error Response
+	      message returned from the
+	      OP's Authorization Endpoint in response to the Authorization Request
+	      message sent by the RP.
+	    
+</p>
+<p>
+	      If the End-User denies the request or the End-User authentication
+	      fails, the OP (Authorization Server) informs the RP (Client)
+	      by using the Error Response parameters defined in
+	      Section 4.1.2.1 of <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749].
+	      (HTTP errors unrelated to RFC 6749 are returned to the User Agent using the
+	      appropriate HTTP status code.)
+	    
+</p>
+<p>
+	      Unless the Redirection URI is invalid,
+	      the Authorization Server returns the Client to
+	      the Redirection URI specified in the Authorization Request
+	      with the appropriate error and state parameters.
+	      Other parameters SHOULD NOT be returned.
+	      If the Redirection URI is invalid,
+	      the Authorization Server MUST NOT redirect
+	      the User Agent to the invalid Redirection URI.
+	    
+</p>
+<p>
+	      If the Response Mode value is not supported,
+	      the Authorization Server returns
+	      an HTTP response code of 400 (Bad Request)
+	      without Error Response parameters,
+	      since understanding the Response Mode is necessary
+	      to know how to return those parameters.
+	    
+</p>
+<p>
+	      In addition to the error codes defined in Section 4.1.2.1 of
+	      OAuth 2.0, this specification also defines the following error codes:
+	    
+</p>
+<p>
+	      </p>
+<blockquote class="text"><dl>
+<dt>interaction_required</dt>
+<dd>
+		  
+		  The Authorization Server
+		  requires End-User interaction of some form to proceed.
+		  This error MAY be returned when the
+		  <tt>prompt</tt> parameter value in the
+		  Authentication Request is <tt>none</tt>,
+		  but the Authentication Request cannot be completed
+		  without displaying a user interface for End-User interaction.
+		
+</dd>
+<dt>login_required</dt>
+<dd>
+		  
+		  The Authorization Server requires
+		  End-User authentication. This error MAY be returned when the
+		  <tt>prompt</tt> parameter value in the
+		  Authentication Request is <tt>none</tt>,
+		  but the Authentication Request cannot be completed
+		  without displaying a user interface for End-User authentication.
+		
+</dd>
+<dt>account_selection_required</dt>
+<dd>
+		  
+		  The End-User is REQUIRED
+		  to select a session at the Authorization Server. The End-User MAY
+		  be authenticated at the Authorization Server with different
+		  associated accounts, but the End-User did not select a session.
+		  This error MAY be returned
+		  when the <tt>prompt</tt> parameter value in the
+		  Authentication Request is <tt>none</tt>,
+		  but the Authentication Request cannot be completed
+		  without displaying a user interface to prompt for a session to use.
+		
+</dd>
+<dt>consent_required</dt>
+<dd>
+		  
+		  The Authorization Server
+		  requires End-User consent. This error MAY be returned when the
+		  <tt>prompt</tt> parameter value in the
+		  Authentication Request is <tt>none</tt>,
+		  but the Authentication Request cannot be completed
+		  without displaying a user interface for End-User consent.
+		
+</dd>
+<dt>invalid_request_uri</dt>
+<dd>
+		  
+		  The
+		  <tt>request_uri</tt> in
+		  the Authorization Request returns an error or contains invalid data.
+		
+</dd>
+<dt>invalid_request_object</dt>
+<dd>
+		  
+		  The
+		  <tt>request</tt> parameter contains an invalid
+		  Request Object.
+		
+</dd>
+<dt>request_not_supported</dt>
+<dd>
+		  
+		  The OP does not support use of the
+		  <tt>request</tt> parameter
+		  defined in <a class='info' href='#JWTRequests'>Section&nbsp;6<span> (</span><span class='info'>Passing Request Parameters as JWTs</span><span>)</span></a>.
+		
+</dd>
+<dt>request_uri_not_supported</dt>
+<dd>
+		  
+		  The OP does not support use of the
+		  <tt>request_uri</tt> parameter
+		  defined in <a class='info' href='#JWTRequests'>Section&nbsp;6<span> (</span><span class='info'>Passing Request Parameters as JWTs</span><span>)</span></a>.
+		
+</dd>
+<dt>registration_not_supported</dt>
+<dd>
+		  
+		  The OP does not support use of the
+		  <tt>registration</tt> parameter
+		  defined in <a class='info' href='#RegistrationParameter'>Section&nbsp;7.2.1<span> (</span><span class='info'>Providing Information with the &quot;registration&quot; Request Parameter</span><span>)</span></a>.
+		
+</dd>
+</dl></blockquote><p>
+	    
+</p>
+<p>
+	      The error response parameters are the following:
+
+	      </p>
+<blockquote class="text"><dl>
+<dt>error</dt>
+<dd>
+		  
+		  REQUIRED. Error code.
+		
+</dd>
+<dt>error_description</dt>
+<dd>
+		  
+		  OPTIONAL. Human-readable ASCII
+		  encoded text description of the error.
+		
+</dd>
+<dt>error_uri</dt>
+<dd>
+		  
+		  OPTIONAL. URI of a web page that
+		  includes additional information about the error.
+		
+</dd>
+<dt>state</dt>
+<dd>
+		  
+		  OAuth 2.0 state value.
+		  REQUIRED if the Authorization Request
+		  included the <tt>state</tt> parameter. Set
+		  to the value received from the Client.
+		
+</dd>
+</dl></blockquote><p>
+	    
+</p>
+<p>
+	      When using the Authorization Code Flow, the error response
+	      parameters are added to the query component of the Redirection URI,
+	      unless a different Response Mode was specified.
+	    
+</p>
+<p>
+	      
+<p>
+		  The following is a non-normative example
+		  error response using this flow
+		  (with line wraps within values for display purposes only):
+		
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  HTTP/1.1 302 Found
+  Location: https://client.example.org/cb?
+    error=invalid_request
+    &amp;error_description=
+      Unsupported%20response_type%20value
+    &amp;state=af0ifjsldkj
+</pre></div>
+	    
+
+<a name="AuthResponseValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.2.7"></a><h3>3.1.2.7.&nbsp;
+Authentication Response Validation</h3>
+
+<p>
+	      When using the Authorization Code Flow,
+	      the Client MUST validate the response according to RFC 6749,
+	      especially Sections 4.1.2 and 10.12.
+	    
+</p>
+<a name="TokenEndpoint"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.3"></a><h3>3.1.3.&nbsp;
+Token Endpoint</h3>
+
+<p>
+	    To obtain an Access Token, an ID Token, and optionally a Refresh Token,
+	    the RP (Client) sends a Token Request to the Token Endpoint
+	    to obtain a Token Response, as described in
+	    Section 3.2 of <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749],
+	    when using the Authorization Code Flow.
+	  
+</p>
+<p>
+	    Communication with the Token Endpoint MUST utilize TLS.
+	    See <a class='info' href='#TLSRequirements'>Section&nbsp;16.17<span> (</span><span class='info'>TLS Requirements</span><span>)</span></a> for more information on using TLS.
+	  
+</p>
+<a name="TokenRequest"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.3.1"></a><h3>3.1.3.1.&nbsp;
+Token Request</h3>
+
+<p>
+	      A Client makes a Token Request by
+	      presenting its Authorization Grant (in the form of
+	      an Authorization Code) to the Token Endpoint
+	      using the <tt>grant_type</tt> value
+	      <tt>authorization_code</tt>, as described in
+	      Section 4.1.3 of <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749].
+	      If the Client is a Confidential Client, then it MUST
+	      authenticate to the Token Endpoint using the authentication method
+	      registered for its <tt>client_id</tt>,
+	      as described in <a class='info' href='#ClientAuthentication'>Section&nbsp;9<span> (</span><span class='info'>Client Authentication</span><span>)</span></a>.
+	    
+</p>
+<p>
+	      The Client sends the parameters to the Token Endpoint
+	      using the HTTP <tt>POST</tt> method and the
+	      Form Serialization, per <a class='info' href='#FormSerialization'>Section&nbsp;13.2<span> (</span><span class='info'>Form Serialization</span><span>)</span></a>,
+	      as described in Section 4.1.3 of
+	      <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749].
+	    
+</p>
+<p>
+		The following is a non-normative example of a Token Request
+		(with line wraps within values for display purposes only):
+	      
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  POST /token HTTP/1.1
+  Host: server.example.com
+  Content-Type: application/x-www-form-urlencoded
+  Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW
+
+  grant_type=authorization_code&amp;code=SplxlOBeZQQYbYS6WxSbIA
+    &amp;redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+</pre></div>
+<a name="TokenRequestValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.3.2"></a><h3>3.1.3.2.&nbsp;
+Token Request Validation</h3>
+
+<p>
+	      The Authorization Server MUST validate the Token Request as follows:
+	    
+</p>
+<p>
+	      </p>
+<ul class="text">
+<li>
+		  Authenticate the Client if it was issued Client Credentials
+		  or if it uses another Client Authentication method,
+		  per <a class='info' href='#ClientAuthentication'>Section&nbsp;9<span> (</span><span class='info'>Client Authentication</span><span>)</span></a>.
+		
+</li>
+<li>
+		  Ensure the
+		  Authorization Code was issued to the authenticated Client.
+		
+</li>
+<li>
+		  Verify that the Authorization Code is valid.
+		
+</li>
+<li>
+		  If possible,
+		  verify that the Authorization Code has not been previously used.
+		
+</li>
+<li>
+		  Ensure that the
+		  <tt>redirect_uri</tt> parameter value
+		  is identical to the <tt>redirect_uri</tt>
+		  parameter value that was included in the initial Authorization Request.
+		  If the <tt>redirect_uri</tt> parameter value
+		  is not present when there is only one registered
+		  <tt>redirect_uri</tt> value,
+		  the Authorization Server MAY return an error
+		  (since the Client should have included the parameter)
+		  or MAY proceed without an error
+		  (since OAuth 2.0 permits the parameter to be omitted in this case).
+		
+</li>
+<li>
+		  Verify that the Authorization Code used was issued
+		  in response to an OpenID Connect Authentication Request
+		  (so that an ID Token will be returned from the Token Endpoint).
+		
+</li>
+</ul><p>
+	    
+</p>
+<a name="TokenResponse"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.3.3"></a><h3>3.1.3.3.&nbsp;
+Successful Token Response</h3>
+
+<p>
+	      After receiving and validating a valid and authorized Token Request
+	      from the Client, the Authorization Server returns a successful
+	      response that includes an ID Token and an Access Token.  The
+	      parameters in the successful response are defined in Section 4.1.4
+	      of <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749].
+	      The response uses the <tt>application/json</tt>
+	      media type.
+	    
+</p>
+<p>
+	      The OAuth 2.0 <tt>token_type</tt> response parameter
+	      value MUST be <tt>Bearer</tt>,
+	      as specified in <a class='info' href='#RFC6750'>OAuth 2.0 Bearer Token Usage<span> (</span><span class='info'>Jones, M. and D. Hardt, &ldquo;The OAuth 2.0 Authorization Framework: Bearer Token Usage,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6750],
+	      unless another Token Type has been negotiated with the Client.
+	      Servers SHOULD support the <tt>Bearer</tt> Token Type;
+	      use of other Token Types is outside the scope of this specification.
+	      Note that the <tt>token_type</tt> value is case insensitive.
+	    
+</p>
+<p>
+	      In addition to the response parameters specified by OAuth 2.0, the following
+	      parameters MUST be included in the response:
+	    
+</p>
+<p>
+	      </p>
+<blockquote class="text"><dl>
+<dt>id_token</dt>
+<dd>
+		  
+		  ID Token value associated with the
+		  authenticated session.
+		
+</dd>
+</dl></blockquote><p>
+	    
+</p>
+<p>
+	      All Token Responses that contain tokens, secrets, or other
+	      sensitive information MUST include the following HTTP response header
+	      fields and values:
+	    
+</p><br /><hr class="insert" />
+<table class="full" align="center" border="0" cellpadding="2" cellspacing="2">
+<col align="left"><col align="left">
+<tr><th align="left">Header Name</th><th align="left">Header Value</th></tr>
+<tr>
+<td align="left">Cache-Control</td>
+<td align="left">no-store</td>
+</tr>
+</table>
+<br clear="all" />
+<table border="0" cellpadding="0" cellspacing="2" align="center"><tr><td align="center"><font face="monaco, MS Sans Serif" size="1"><b>&nbsp;HTTP Response Headers and Values&nbsp;</b></font><br /></td></tr></table><hr class="insert" />
+
+<p>
+		The following is a non-normative example of a successful Token Response.
+		The ID Token signature in the example can be verified with the key at
+		<a class='info' href='#ExampleRSAKey'>Appendix&nbsp;A.7<span> (</span><span class='info'>RSA Key Used in Examples</span><span>)</span></a>.
+	      
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+  Cache-Control: no-store
+
+  {
+   "access_token": "SlAV32hkKG",
+   "token_type": "Bearer",
+   "refresh_token": "8xLOxBtZp8",
+   "expires_in": 3600,
+   "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjFlOWdkazcifQ.ewogImlzc
+     yI6ICJodHRwOi8vc2VydmVyLmV4YW1wbGUuY29tIiwKICJzdWIiOiAiMjQ4Mjg5
+     NzYxMDAxIiwKICJhdWQiOiAiczZCaGRSa3F0MyIsCiAibm9uY2UiOiAibi0wUzZ
+     fV3pBMk1qIiwKICJleHAiOiAxMzExMjgxOTcwLAogImlhdCI6IDEzMTEyODA5Nz
+     AKfQ.ggW8hZ1EuVLuxNuuIJKX_V8a_OMXzR0EHR9R6jgdqrOOF4daGU96Sr_P6q
+     Jp6IcmD3HP99Obi1PRs-cwh3LO-p146waJ8IhehcwL7F09JdijmBqkvPeB2T9CJ
+     NqeGpe-gccMg4vfKjkM8FcGvnzZUN4_KSP0aAp1tOJ1zZwgjxqGByKHiOtX7Tpd
+     QyHE5lcMiKPXfEIQILVq0pc_E2DzL7emopWoaoZTF_m0_N0YzFC6g6EJbOEoRoS
+     K5hoDalrcvRYLSrQAZZKflyuVCyixEoV9GfNQC3_osjzw2PAithfubEEBLuVVk4
+     XUVrWOLrLl0nx7RkKU8NXNHq-rvKMzqg"
+  }
+</pre></div>
+<p>As specified in <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749], Clients
+	    SHOULD ignore unrecognized response parameters.
+</p>
+<a name="TokenErrorResponse"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.3.4"></a><h3>3.1.3.4.&nbsp;
+Token Error Response</h3>
+
+<p>
+	      If the Token Request is invalid or unauthorized, the
+	      Authorization Server constructs the error response. The parameters
+	      of the Token Error Response are defined as in Section 5.2 of <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749].
+	      The HTTP response body uses the <tt>application/json</tt>
+	      media type with HTTP response code of 400.
+	    
+</p>
+<p>The following is a non-normative example Token Error Response:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  HTTP/1.1 400 Bad Request
+  Content-Type: application/json
+  Cache-Control: no-store
+
+  {
+   "error": "invalid_request"
+  }
+</pre></div>
+<a name="TokenResponseValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.3.5"></a><h3>3.1.3.5.&nbsp;
+Token Response Validation</h3>
+
+<p>
+	      The Client MUST validate the Token Response as follows:
+	      </p>
+<ol class="text">
+<li>
+		  Follow the validation rules in RFC 6749,
+		  especially those in Sections 5.1 and 10.12.
+		
+</li>
+<li>
+		  Follow the ID Token validation rules in <a class='info' href='#IDTokenValidation'>Section&nbsp;3.1.3.7<span> (</span><span class='info'>ID Token Validation</span><span>)</span></a>.
+		
+</li>
+<li>
+		  Follow the Access Token validation rules in <a class='info' href='#CodeFlowTokenValidation'>Section&nbsp;3.1.3.8<span> (</span><span class='info'>Access Token Validation</span><span>)</span></a>.
+		
+</li>
+</ol><p>
+	    
+</p>
+<a name="CodeIDToken"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.3.6"></a><h3>3.1.3.6.&nbsp;
+ID Token</h3>
+
+<p>
+	      The contents of the ID Token are as described in <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a>.
+	      When using the Authorization Code Flow,
+	      these additional requirements for the following ID Token Claims apply:
+	    
+</p>
+<p>
+	      </p>
+<blockquote class="text"><dl>
+<dt>at_hash</dt>
+<dd>
+		  
+		  OPTIONAL.
+		  Access Token hash value.
+		  Its value is the base64url encoding of the left-most half of the
+		  hash of the octets of the ASCII representation of the
+		  <tt>access_token</tt> value,
+		  where the hash algorithm used is the hash algorithm
+		  used in the <tt>alg</tt> Header Parameter
+		  of the ID Token's JOSE Header.
+		  For instance, if the <tt>alg</tt> is
+		  <tt>RS256</tt>, hash the
+		  <tt>access_token</tt> value
+		  with SHA-256, then take the left-most 128 bits and base64url-encode them.
+		  The <tt>at_hash</tt> value is a case-sensitive string.
+		
+</dd>
+</dl></blockquote><p>
+	    
+</p>
+<a name="IDTokenValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.3.7"></a><h3>3.1.3.7.&nbsp;
+ID Token Validation</h3>
+
+<p>
+              Clients MUST validate the ID Token in the Token Response
+	      in the following manner:
+	    
+</p>
+<p>
+	      </p>
+<ol class="text">
+<li>
+		  If the ID Token is encrypted, decrypt it using the
+		  keys and algorithms that the Client specified during Registration
+		  that the OP was to use to encrypt the ID Token.
+		  If encryption was negotiated with the OP at Registration time
+		  and the ID Token is not encrypted, the RP SHOULD reject it.
+		
+</li>
+<li>
+		  The Issuer Identifier for the OpenID Provider
+		  (which is typically obtained during Discovery)
+		  MUST exactly match the value of the
+		  <tt>iss</tt> (issuer) Claim.
+		
+</li>
+<li>
+		  The Client MUST validate that the
+		  <tt>aud</tt> (audience) Claim
+		  contains its <tt>client_id</tt> value
+		  registered at the Issuer identified by the
+		  <tt>iss</tt> (issuer) Claim
+		  as an audience.
+		  The <tt>aud</tt> (audience) Claim
+		  MAY contain an array with more than one element.
+		  The ID Token MUST be rejected if the ID Token does not list
+		  the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
+		
+</li>
+<li>
+		  If the implementation is using extensions
+		  (which are beyond the scope of this specification)
+		  that result in
+		  the <tt>azp</tt> (authorized party) Claim being present,
+		  it SHOULD validate the <tt>azp</tt> value
+		  as specified by those extensions.
+		
+</li>
+<li>
+		  This validation MAY include that
+		  when an <tt>azp</tt> (authorized party) Claim is present,
+		  the Client SHOULD verify that its <tt>client_id</tt>
+		  is the Claim Value.
+		
+</li>
+<li>
+		  If the ID Token is received via direct
+		  communication between the Client and the Token Endpoint
+		  (which it is in this flow), the TLS server
+		  validation MAY be used to validate the issuer in place of
+		  checking the token signature.
+		  The Client MUST validate the signature of all other ID Tokens according to
+		  <a class='info' href='#JWS'>JWS<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Signature (JWS),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWS] using the algorithm specified in the
+		  JWT <tt>alg</tt> Header Parameter.
+		  The Client MUST use the keys provided by the Issuer.
+		
+</li>
+<li>The <tt>alg</tt> value SHOULD be the default of
+		<tt>RS256</tt>
+		or the algorithm sent by the Client
+		in the <tt>id_token_signed_response_alg</tt> parameter
+		during Registration.
+</li>
+<li>If the JWT <tt>alg</tt> Header Parameter
+		uses a MAC based algorithm such as
+		<tt>HS256</tt>, <tt>HS384</tt>,
+		or <tt>HS512</tt>,
+		the octets of the UTF-8 <a class='info' href='#RFC3629'>[RFC3629]<span> (</span><span class='info'>Yergeau, F., &ldquo;UTF-8, a transformation format of ISO 10646,&rdquo; November&nbsp;2003.</span><span>)</span></a> representation of
+		the <tt>client_secret</tt> corresponding to the
+		<tt>client_id</tt> contained in the
+		<tt>aud</tt> (audience) Claim are used as the key
+		to validate the signature.
+		For MAC based algorithms, the behavior is unspecified
+		if the <tt>aud</tt> is multi-valued.
+		
+</li>
+<li>
+		  The current time MUST be before the time represented by the
+		  <tt>exp</tt> Claim.
+		
+</li>
+<li>The <tt>iat</tt> Claim can be used to reject tokens that
+		were issued too far away from the current time, limiting the amount of
+		time that nonces need to be stored to prevent attacks.
+		The acceptable range is Client specific.
+</li>
+<li>
+		  If a nonce value was sent in the Authentication Request,
+		  a <tt>nonce</tt> Claim MUST be present
+		  and its value checked to verify that
+		  it is the same value as the one that was sent in the Authentication Request.
+		  The Client SHOULD check the <tt>nonce</tt> value
+		  for replay attacks.
+		  The precise method for detecting replay attacks is Client specific.
+		
+</li>
+<li>If the <tt>acr</tt> Claim was requested, the
+		Client SHOULD check that the asserted Claim Value is appropriate.
+		The meaning and processing of
+		<tt>acr</tt> Claim Values is out of scope for this specification.
+</li>
+<li>
+		  If the <tt>auth_time</tt> Claim was requested,
+		  either through a specific request for this Claim
+		  or by using the <tt>max_age</tt> parameter,
+		  the Client SHOULD check the <tt>auth_time</tt> Claim
+		  value and request re-authentication if it determines too much time
+		  has elapsed since the last End-User authentication.
+		
+</li>
+</ol><p>
+	    
+</p>
+<a name="CodeFlowTokenValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.1.3.8"></a><h3>3.1.3.8.&nbsp;
+Access Token Validation</h3>
+
+<p>
+	      When using the Authorization Code Flow,
+	      if the ID Token contains an <tt>at_hash</tt> Claim,
+	      the Client MAY use it to validate the Access Token
+	      in the same manner as for the Implicit Flow,
+	      as defined in <a class='info' href='#ImplicitTokenValidation'>Section&nbsp;3.2.2.9<span> (</span><span class='info'>Access Token Validation</span><span>)</span></a>,
+	      but using the ID Token and Access Token returned from the Token Endpoint.
+	    
+</p>
+<a name="ImplicitFlowAuth"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2"></a><h3>3.2.&nbsp;
+Authentication using the Implicit Flow</h3>
+
+<p>
+	  This section describes how to perform authentication using the Implicit Flow.
+	  When using the Implicit Flow,
+	  all tokens are returned from the Authorization Endpoint;
+	  the Token Endpoint is not used.
+	
+</p>
+<p>The Implicit Flow is mainly used by Clients implemented in a browser
+	using a scripting language. The Access Token and ID Token are returned
+	directly to the Client, which may expose them to the End-User and
+	applications that have access to the End-User's User Agent.
+	The Authorization Server does not perform Client Authentication.
+	
+</p>
+<a name="ImplicitFlowSteps"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2.1"></a><h3>3.2.1.&nbsp;
+Implicit Flow Steps</h3>
+
+<p>The Implicit Flow follows the following steps:
+</p>
+<p>
+	    </p>
+<ol class="text">
+<li>Client prepares an Authentication Request containing the desired
+	      request parameters.
+</li>
+<li>Client sends the request to the Authorization Server.
+</li>
+<li>Authorization Server Authenticates the End-User.
+</li>
+<li>Authorization Server obtains End-User Consent/Authorization.
+</li>
+<li>Authorization Server sends the End-User back to the Client with
+	      an ID Token and, if requested, an Access Token.
+</li>
+<li>Client validates the ID token and retrieves the End-User's
+	      Subject Identifier.
+</li>
+</ol><p>
+	  
+</p>
+<a name="ImplicitAuthorizationEndpoint"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2.2"></a><h3>3.2.2.&nbsp;
+Authorization Endpoint</h3>
+
+<p>
+	    When using the Implicit Flow, the Authorization Endpoint is used
+	    in the same manner as for the Authorization Code Flow,
+	    as defined in <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a>,
+	    with the exception of the differences specified in this section.
+	  
+</p>
+<a name="ImplicitAuthRequest"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2.2.1"></a><h3>3.2.2.1.&nbsp;
+Authentication Request</h3>
+
+<p>
+	      Authentication Requests are made
+	      as defined in <a class='info' href='#AuthRequest'>Section&nbsp;3.1.2.1<span> (</span><span class='info'>Authentication Request</span><span>)</span></a>,
+	      except that these Authentication Request parameters
+	      are used as follows:
+	    
+</p>
+<p>
+	      </p>
+<blockquote class="text"><dl>
+<dt>response_type</dt>
+<dd>
+		  
+		  REQUIRED.
+		  OAuth 2.0 Response Type value that determines
+		  the authorization processing flow to be used,
+		  including what parameters are returned from the endpoints used.
+		  When using the Implicit Flow, this value is
+		  <tt>id_token&nbsp;token</tt> or
+		  <tt>id_token</tt>.
+		  The meanings of both of these values are defined in
+		  <a class='info' href='#OAuth.Responses'>OAuth 2.0 Multiple Response Type Encoding Practices<span> (</span><span class='info'>de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;OAuth 2.0 Multiple Response Type Encoding Practices,&rdquo; February&nbsp;2014.</span><span>)</span></a> [OAuth.Responses].
+		  No Access Token is returned when the value is
+		  <tt>id_token</tt>.
+		
+</dd>
+<dt></dt>
+<dd>
+		  NOTE:  While OAuth 2.0 also defines the
+		  <tt>token</tt> Response Type value
+		  for the Implicit Flow, OpenID Connect does not use this Response Type,
+		  since no ID Token would be returned.
+		
+</dd>
+<dt>redirect_uri</dt>
+<dd>
+		  
+		  REQUIRED.
+		  Redirection URI to which the response will be sent.
+		  This URI MUST exactly match one of the Redirection URI values
+		  for the Client pre-registered at the OpenID Provider,
+		  with the matching performed as described in
+		  Section 6.2.1 of <a class='info' href='#RFC3986'>[RFC3986]<span> (</span><span class='info'>Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;Uniform Resource Identifier (URI): Generic Syntax,&rdquo; January&nbsp;2005.</span><span>)</span></a> (Simple String Comparison).
+		  When using this flow, the Redirection URI
+		  MUST NOT use the <tt>http</tt> scheme
+		  unless the Client is a native application, in which case it MAY
+		  use the <tt>http</tt> scheme with
+		  <tt>localhost</tt> or the IP loopback literals
+		  <tt>127.0.0.1</tt> or <tt>[::1]</tt>
+		  as the hostname.
+		
+</dd>
+<dt>nonce</dt>
+<dd>
+		  
+		  REQUIRED.
+		  String value used to associate a Client session
+		  with an ID Token, and to mitigate replay attacks.
+		  The value is passed through unmodified from the Authentication Request to the ID Token.
+		  Sufficient entropy MUST be present in the
+		  <tt>nonce</tt> values used to prevent
+		  attackers from guessing values.
+		  For implementation notes, see <a class='info' href='#NonceNotes'>Section&nbsp;15.5.2<span> (</span><span class='info'>Nonce Implementation Notes</span><span>)</span></a>.
+		
+</dd>
+</dl></blockquote><p>
+	    
+</p>
+<p>
+		The following is a non-normative example request using the Implicit Flow
+		that would be sent by the User Agent to the Authorization Server
+		in response to a corresponding HTTP 302 redirect response by the Client
+		(with line wraps within values for display purposes only):
+	      
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /authorize?
+    response_type=id_token%20token
+    &amp;client_id=s6BhdRkqt3
+    &amp;redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+    &amp;scope=openid%20profile
+    &amp;state=af0ifjsldkj
+    &amp;nonce=n-0S6_WzA2Mj HTTP/1.1
+  Host: server.example.com
+</pre></div>
+<a name="ImplicitValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2.2.2"></a><h3>3.2.2.2.&nbsp;
+Authentication Request Validation</h3>
+
+<p>
+	      When using the Implicit Flow, the Authentication Request is validated
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#AuthRequestValidation'>Section&nbsp;3.1.2.2<span> (</span><span class='info'>Authentication Request Validation</span><span>)</span></a>.
+	    
+</p>
+<a name="ImplicitAuthenticates"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2.2.3"></a><h3>3.2.2.3.&nbsp;
+Authorization Server Authenticates End-User</h3>
+
+<p>
+	      When using the Implicit Flow, End-User Authentication is performed
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#Authenticates'>Section&nbsp;3.1.2.3<span> (</span><span class='info'>Authorization Server Authenticates End-User</span><span>)</span></a>.
+	    
+</p>
+<a name="ImplicitConsent"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2.2.4"></a><h3>3.2.2.4.&nbsp;
+Authorization Server Obtains End-User Consent/Authorization</h3>
+
+<p>
+	      When using the Implicit Flow, End-User Consent is obtained
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#Consent'>Section&nbsp;3.1.2.4<span> (</span><span class='info'>Authorization Server Obtains End-User Consent/Authorization</span><span>)</span></a>.
+	    
+</p>
+<a name="ImplicitAuthResponse"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2.2.5"></a><h3>3.2.2.5.&nbsp;
+Successful Authentication Response</h3>
+
+<p>
+	      When using the Implicit Flow, Authentication Responses are made
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#AuthResponse'>Section&nbsp;3.1.2.5<span> (</span><span class='info'>Successful Authentication Response</span><span>)</span></a>,
+	      with the exception of the differences specified in this section.
+	    
+</p>
+<p>
+	      When using the Implicit Flow,
+	      all response parameters are added to the fragment component
+	      of the Redirection URI, as specified in
+	      <a class='info' href='#OAuth.Responses'>OAuth 2.0 Multiple Response Type Encoding Practices<span> (</span><span class='info'>de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;OAuth 2.0 Multiple Response Type Encoding Practices,&rdquo; February&nbsp;2014.</span><span>)</span></a> [OAuth.Responses],
+	      unless a different Response Mode was specified.
+	    
+</p>
+<p>
+	      These parameters are returned from the Authorization Endpoint:
+	    
+</p>
+<p>
+	      </p>
+<blockquote class="text"><dl>
+<dt>access_token</dt>
+<dd>
+		  
+		  OAuth 2.0 Access Token.
+		  This is returned
+		  unless the <tt>response_type</tt> value used is
+		  <tt>id_token</tt>.
+		
+</dd>
+<dt>token_type</dt>
+<dd>
+		  
+		  OAuth 2.0 Token Type value.
+		  The value MUST be <tt>Bearer</tt> or
+		  another <tt>token_type</tt> value that the Client
+		  has negotiated with the Authorization Server.
+		  Clients implementing this profile MUST support the <a class='info' href='#RFC6750'>OAuth 2.0 Bearer Token Usage<span> (</span><span class='info'>Jones, M. and D. Hardt, &ldquo;The OAuth 2.0 Authorization Framework: Bearer Token Usage,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6750] specification.
+		  This profile only describes the use of bearer tokens.
+		  This is returned in the same cases as
+		  <tt>access_token</tt> is.
+		
+</dd>
+<dt>id_token</dt>
+<dd>
+		  
+		  REQUIRED.
+		  ID Token.
+		
+</dd>
+<dt>state</dt>
+<dd>
+		  
+		  OAuth 2.0 state value.
+		  REQUIRED if the
+		  <tt>state</tt> parameter is present in the
+		  Authorization Request. Clients MUST verify that the
+		  <tt>state</tt> value is equal to the
+		  value of <tt>state</tt> parameter in the
+		  Authorization Request.
+		
+</dd>
+<dt>expires_in</dt>
+<dd>
+		  
+		  OPTIONAL.
+		  Expiration time of the Access Token in seconds
+		  since the response was generated.
+		
+</dd>
+</dl></blockquote><p>
+	    
+</p>
+<p>
+	      Per Section 4.2.2 of <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749],
+	      no <tt>code</tt> result is returned
+	      when using the Implicit Flow.
+	    
+</p>
+<p>The following is a non-normative example
+	      of a successful response using the Implicit Flow
+	      (with line wraps for the display purposes only):
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  HTTP/1.1 302 Found
+  Location: https://client.example.org/cb#
+    access_token=SlAV32hkKG
+    &amp;token_type=bearer
+    &amp;id_token=eyJ0 ... NiJ9.eyJ1c ... I6IjIifX0.DeWt4Qu ... ZXso
+    &amp;expires_in=3600
+    &amp;state=af0ifjsldkj
+</pre></div>
+<a name="ImplicitAuthError"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2.2.6"></a><h3>3.2.2.6.&nbsp;
+Authentication Error Response</h3>
+
+<p>
+	      When using the Implicit Flow, Authorization Error Responses are made
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#AuthError'>Section&nbsp;3.1.2.6<span> (</span><span class='info'>Authentication Error Response</span><span>)</span></a>,
+	      with the exception of the differences specified in this section.
+	    
+</p>
+<p>
+	      Whenever Error Response parameters are returned,
+	      such as when End-User denies the authorization or the End-User authentication fails,
+	      the Authorization Server MUST return the error
+	      Authorization Response in the
+	      fragment component of the Redirection URI,
+	      as defined in Section 4.2.2.1 of
+	      <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749] and
+	      <a class='info' href='#OAuth.Responses'>OAuth 2.0 Multiple Response Type Encoding Practices<span> (</span><span class='info'>de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;OAuth 2.0 Multiple Response Type Encoding Practices,&rdquo; February&nbsp;2014.</span><span>)</span></a> [OAuth.Responses],
+	      unless a different Response Mode was specified.
+	    
+</p>
+<a name="ImplicitCallback"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2.2.7"></a><h3>3.2.2.7.&nbsp;
+Redirect URI Fragment Handling</h3>
+
+<p>
+	      Since response parameters are returned in the Redirection URI fragment value,
+	      the Client needs to have the User Agent parse the fragment encoded values
+	      and pass them to on to the Client's processing logic for consumption.
+	      See <a class='info' href='#FragmentNotes'>Section&nbsp;15.5.3<span> (</span><span class='info'>Redirect URI Fragment Handling Implementation Notes</span><span>)</span></a> for implementation notes
+	      on URI fragment handling.
+	    
+</p>
+<a name="ImplicitAuthResponseValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2.2.8"></a><h3>3.2.2.8.&nbsp;
+Authentication Response Validation</h3>
+
+<p>
+	      When using the Implicit Flow,
+	      the Client MUST validate the response as follows:
+	      </p>
+<ol class="text">
+<li>
+		  Verify that the response conforms to Section 5 of
+		  <a class='info' href='#OAuth.Responses'>[OAuth.Responses]<span> (</span><span class='info'>de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;OAuth 2.0 Multiple Response Type Encoding Practices,&rdquo; February&nbsp;2014.</span><span>)</span></a>.
+		
+</li>
+<li>
+		  Follow the validation rules in RFC 6749,
+		  especially those in Sections 4.2.2 and 10.12.
+		
+</li>
+<li>
+		  Follow the ID Token validation rules in <a class='info' href='#ImplicitIDTValidation'>Section&nbsp;3.2.2.11<span> (</span><span class='info'>ID Token Validation</span><span>)</span></a>.
+		
+</li>
+<li>
+		  Follow the Access Token validation rules in <a class='info' href='#ImplicitTokenValidation'>Section&nbsp;3.2.2.9<span> (</span><span class='info'>Access Token Validation</span><span>)</span></a>,
+		  unless the <tt>response_type</tt> value used is
+		  <tt>id_token</tt>.
+		
+</li>
+</ol><p>
+	    
+</p>
+<a name="ImplicitTokenValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2.2.9"></a><h3>3.2.2.9.&nbsp;
+Access Token Validation</h3>
+
+<p>To validate an Access Token issued from the Authorization Endpoint with an ID Token,
+	    the Client SHOULD do the following:
+</p>
+<p>
+	      </p>
+<ol class="text">
+<li>Hash the octets of the ASCII representation of
+		the <tt>access_token</tt>
+		with the hash algorithm specified in <a class='info' href='#JWA'>JWA<span> (</span><span class='info'>Jones, M., &ldquo;JSON Web Algorithms (JWA),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWA] for the
+		<tt>alg</tt> Header Parameter
+		of the ID Token's JOSE Header.
+		For instance, if the <tt>alg</tt> is
+		<tt>RS256</tt>,
+		the hash algorithm used is SHA-256.
+		
+</li>
+<li>Take the left-most half of the hash and base64url-encode it.
+</li>
+<li>
+		  The value of <tt>at_hash</tt> in the ID Token MUST
+		  match the value produced in the previous step.
+		
+</li>
+</ol><p>
+	    
+</p>
+<a name="ImplicitIDToken"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2.2.10"></a><h3>3.2.2.10.&nbsp;
+ID Token</h3>
+
+<p>
+	      The contents of the ID Token are as described in <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a>.
+	      When using the Implicit Flow,
+	      these additional requirements for the following ID Token Claims apply:
+	    
+</p>
+<p>
+	      </p>
+<blockquote class="text"><dl>
+<dt>nonce</dt>
+<dd>
+		  
+		  Use of the <tt>nonce</tt> Claim is REQUIRED
+		  for this flow.
+		
+</dd>
+<dt>at_hash</dt>
+<dd>
+		  
+		  Access Token hash value.
+		  Its value is the base64url encoding of the left-most half of the
+		  hash of the octets of the ASCII representation of the
+		  <tt>access_token</tt> value,
+		  where the hash algorithm used is the hash algorithm
+		  used in the <tt>alg</tt> Header Parameter
+		  of the ID Token's JOSE Header.
+		  For instance, if the <tt>alg</tt> is
+		  <tt>RS256</tt>, hash the
+		  <tt>access_token</tt> value
+		  with SHA-256, then take the left-most 128 bits and base64url-encode them.
+		  The <tt>at_hash</tt> value is a case-sensitive string.
+		
+</dd>
+<dt></dt>
+<dd>
+		  If the ID Token is issued from the Authorization Endpoint with an
+		  <tt>access_token</tt> value,
+		  which is the case for the <tt>response_type</tt> value
+		  <tt>id_token&nbsp;token</tt>,
+		  this is REQUIRED;
+		  it MAY NOT be used when no Access Token is issued,
+		  which is the case for the <tt>response_type</tt> value
+		  <tt>id_token</tt>.
+		
+</dd>
+</dl></blockquote><p>
+	    
+</p>
+<a name="ImplicitIDTValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.2.2.11"></a><h3>3.2.2.11.&nbsp;
+ID Token Validation</h3>
+
+<p>
+	      When using the Implicit Flow, the contents of the ID Token MUST be validated
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#IDTokenValidation'>Section&nbsp;3.1.3.7<span> (</span><span class='info'>ID Token Validation</span><span>)</span></a>,
+	      with the exception of the differences specified in this section.
+	    
+</p>
+<p>
+	      </p>
+<ol class="text">
+<li>
+		  The Client MUST validate the signature of the ID Token according to
+		  <a class='info' href='#JWS'>JWS<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Signature (JWS),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWS] using the algorithm specified in the
+		  <tt>alg</tt> Header Parameter of the JOSE Header.
+		
+</li>
+<li>
+		  The value of the <tt>nonce</tt>
+		  Claim MUST be checked to verify that
+		  it is the same value as the one that was sent in the Authentication Request.
+		  The Client SHOULD check the <tt>nonce</tt> value
+		  for replay attacks.
+		  The precise method for detecting replay attacks is Client specific.
+		
+</li>
+</ol><p>
+	    
+</p>
+<a name="HybridFlowAuth"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3"></a><h3>3.3.&nbsp;
+Authentication using the Hybrid Flow</h3>
+
+<p>
+	  This section describes how to perform authentication using the Hybrid Flow.
+	  When using the Hybrid Flow,
+	  some tokens are returned from the Authorization Endpoint
+	  and others are returned from the Token Endpoint.
+	  The mechanisms for returning tokens in the Hybrid Flow are specified in
+	  <a class='info' href='#OAuth.Responses'>OAuth 2.0 Multiple Response Type Encoding Practices<span> (</span><span class='info'>de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;OAuth 2.0 Multiple Response Type Encoding Practices,&rdquo; February&nbsp;2014.</span><span>)</span></a> [OAuth.Responses].
+	
+</p>
+<a name="HybridFlowSteps"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.1"></a><h3>3.3.1.&nbsp;
+Hybrid Flow Steps</h3>
+
+<p>The Hybrid Flow follows the following steps:
+</p>
+<p>
+	    </p>
+<ol class="text">
+<li>Client prepares an Authentication Request containing the desired
+	      request parameters.
+</li>
+<li>Client sends the request to the Authorization Server.
+</li>
+<li>Authorization Server Authenticates the End-User.
+</li>
+<li>Authorization Server obtains End-User Consent/Authorization.
+</li>
+<li>
+		Authorization Server sends the End-User back to the Client with
+		an Authorization Code and, depending on the Response Type,
+		one or more additional parameters.
+	      
+</li>
+<li>Client requests a response using the Authorization Code at the
+	      Token Endpoint.
+</li>
+<li>Client receives a response that contains an ID Token
+	      and Access Token in the response body.
+</li>
+<li>Client validates the ID Token and retrieves the End-User's
+	      Subject Identifier.
+</li>
+</ol><p>
+	  
+</p>
+<a name="HybridAuthorizationEndpoint"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.2"></a><h3>3.3.2.&nbsp;
+Authorization Endpoint</h3>
+
+<p>
+	    When using the Hybrid Flow, the Authorization Endpoint is used
+	    in the same manner as for the Authorization Code Flow,
+	    as defined in <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a>,
+	    with the exception of the differences specified in this section.
+	  
+</p>
+<a name="HybridAuthRequest"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.2.1"></a><h3>3.3.2.1.&nbsp;
+Authentication Request</h3>
+
+<p>
+	      Authentication Requests are made
+	      as defined in <a class='info' href='#AuthRequest'>Section&nbsp;3.1.2.1<span> (</span><span class='info'>Authentication Request</span><span>)</span></a>,
+	      except that these Authentication Request parameters
+	      are used as follows:
+	    
+</p>
+<p>
+	      </p>
+<blockquote class="text"><dl>
+<dt>response_type</dt>
+<dd>
+		  
+		  REQUIRED.
+		  OAuth 2.0 Response Type value that determines
+		  the authorization processing flow to be used,
+		  including what parameters are returned from the endpoints used.
+		  When using the Hybrid Flow, this value is
+		  <tt>code&nbsp;id_token</tt>,
+		  <tt>code&nbsp;token</tt>, or
+		  <tt>code&nbsp;id_token&nbsp;token</tt>.
+		  The meanings of these values are defined in
+		  <a class='info' href='#OAuth.Responses'>OAuth 2.0 Multiple Response Type Encoding Practices<span> (</span><span class='info'>de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;OAuth 2.0 Multiple Response Type Encoding Practices,&rdquo; February&nbsp;2014.</span><span>)</span></a> [OAuth.Responses].
+		
+</dd>
+<dt>nonce</dt>
+<dd>
+		  
+		  REQUIRED if the Response Type of the request is <tt>code&nbsp;id_token</tt>
+		  or <tt>code&nbsp;id_token&nbsp;token</tt> and OPTIONAL when the Response Type of
+		  the request is <tt>code&nbsp;token</tt>.
+		  It is a string value used to associate a Client session
+		  with an ID Token, and to mitigate replay attacks.
+		  The value is passed through unmodified from the Authentication Request to the ID Token.
+		  Sufficient entropy MUST be present in the
+		  <tt>nonce</tt> values used to prevent
+		  attackers from guessing values.
+		  For implementation notes, see <a class='info' href='#NonceNotes'>Section&nbsp;15.5.2<span> (</span><span class='info'>Nonce Implementation Notes</span><span>)</span></a>.
+		
+</dd>
+</dl></blockquote><p>
+	    
+</p>
+<p>
+		The following is a non-normative example request using the Hybrid Flow
+		that would be sent by the User Agent to the Authorization Server
+		in response to a corresponding HTTP 302 redirect response by the Client
+		(with line wraps within values for display purposes only):
+	      
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /authorize?
+    response_type=code%20id_token
+    &amp;client_id=s6BhdRkqt3
+    &amp;redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+    &amp;scope=openid%20profile%20email
+    &amp;nonce=n-0S6_WzA2Mj
+    &amp;state=af0ifjsldkj HTTP/1.1
+  Host: server.example.com
+</pre></div>
+<a name="HybridValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.2.2"></a><h3>3.3.2.2.&nbsp;
+Authentication Request Validation</h3>
+
+<p>
+	      When using the Hybrid Flow, the Authentication Request is validated
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#AuthRequestValidation'>Section&nbsp;3.1.2.2<span> (</span><span class='info'>Authentication Request Validation</span><span>)</span></a>.
+	    
+</p>
+<a name="HybridAuthenticates"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.2.3"></a><h3>3.3.2.3.&nbsp;
+Authorization Server Authenticates End-User</h3>
+
+<p>
+	      When using the Hybrid Flow, End-User Authentication is performed
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#Authenticates'>Section&nbsp;3.1.2.3<span> (</span><span class='info'>Authorization Server Authenticates End-User</span><span>)</span></a>.
+	    
+</p>
+<a name="HybridConsent"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.2.4"></a><h3>3.3.2.4.&nbsp;
+Authorization Server Obtains End-User Consent/Authorization</h3>
+
+<p>
+	      When using the Hybrid Flow, End-User Consent is obtained
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#Consent'>Section&nbsp;3.1.2.4<span> (</span><span class='info'>Authorization Server Obtains End-User Consent/Authorization</span><span>)</span></a>.
+	    
+</p>
+<a name="HybridAuthResponse"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.2.5"></a><h3>3.3.2.5.&nbsp;
+Successful Authentication Response</h3>
+
+<p>
+	      When using the Hybrid Flow, Authentication Responses are made
+	      in the same manner as for the Implicit Flow,
+	      as defined in <a class='info' href='#ImplicitAuthResponse'>Section&nbsp;3.2.2.5<span> (</span><span class='info'>Successful Authentication Response</span><span>)</span></a>,
+	      with the exception of the differences specified in this section.
+	    
+</p>
+<p>
+	      These Authorization Endpoint results are used in the following manner:
+	    
+</p>
+<p>
+	      </p>
+<blockquote class="text"><dl>
+<dt>access_token</dt>
+<dd>
+		  
+		  OAuth 2.0 Access Token.
+		  This is returned
+		  when the <tt>response_type</tt> value used is
+		  <tt>code&nbsp;token</tt>,
+		  or <tt>code&nbsp;id_token&nbsp;token</tt>.
+		  (A <tt>token_type</tt> value is also returned in the same cases.)
+		
+</dd>
+<dt>id_token</dt>
+<dd>
+		  
+		  ID Token.
+		  This is returned
+		  when the <tt>response_type</tt> value used is
+		  <tt>code&nbsp;id_token</tt> or
+		  <tt>code&nbsp;id_token&nbsp;token</tt>.
+		
+</dd>
+<dt>code</dt>
+<dd>
+		  
+		  Authorization Code.
+		  This is always returned when using the Hybrid Flow.
+		
+</dd>
+</dl></blockquote><p>
+	    
+</p>
+<p>The following is a non-normative example
+	      of a successful response using the Hybrid Flow
+	      (with line wraps for the display purposes only):
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  HTTP/1.1 302 Found
+  Location: https://client.example.org/cb#
+    code=SplxlOBeZQQYbYS6WxSbIA
+    &amp;id_token=eyJ0 ... NiJ9.eyJ1c ... I6IjIifX0.DeWt4Qu ... ZXso
+    &amp;state=af0ifjsldkj
+</pre></div>
+<a name="HybridAuthError"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.2.6"></a><h3>3.3.2.6.&nbsp;
+Authentication Error Response</h3>
+
+<p>
+	      When using the Hybrid Flow, Authorization Error Responses are made
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#AuthError'>Section&nbsp;3.1.2.6<span> (</span><span class='info'>Authentication Error Response</span><span>)</span></a>,
+	      with the exception of the differences specified in this section.
+	    
+</p>
+<p>
+	      Whenever Error Response parameters are returned,
+	      such as when End-User denies the authorization or the End-User authentication fails,
+	      the Authorization Server MUST return the error
+	      Authorization Response in the
+	      fragment component of the Redirection URI,
+	      as defined in Section 4.2.2.1 of
+	      <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749] and
+	      <a class='info' href='#OAuth.Responses'>OAuth 2.0 Multiple Response Type Encoding Practices<span> (</span><span class='info'>de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;OAuth 2.0 Multiple Response Type Encoding Practices,&rdquo; February&nbsp;2014.</span><span>)</span></a> [OAuth.Responses],
+	      unless a different Response Mode was specified.
+	    
+</p>
+<a name="HybridCallback"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.2.7"></a><h3>3.3.2.7.&nbsp;
+Redirect URI Fragment Handling</h3>
+
+<p>
+	      When using the Hybrid Flow, the same requirements for
+	      Redirection URI fragment parameter handling apply as do for
+	      the Implicit Flow, as defined in <a class='info' href='#ImplicitCallback'>Section&nbsp;3.2.2.7<span> (</span><span class='info'>Redirect URI Fragment Handling</span><span>)</span></a>.
+	      Also see <a class='info' href='#FragmentNotes'>Section&nbsp;15.5.3<span> (</span><span class='info'>Redirect URI Fragment Handling Implementation Notes</span><span>)</span></a> for implementation notes
+	      on URI fragment handling.
+	    
+</p>
+<a name="HybridAuthResponseValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.2.8"></a><h3>3.3.2.8.&nbsp;
+Authentication Response Validation</h3>
+
+<p>
+	      When using the Hybrid Flow,
+	      the Client MUST validate the response as follows:
+	      </p>
+<ol class="text">
+<li>
+		  Verify that the response conforms to Section 5 of
+		  <a class='info' href='#OAuth.Responses'>[OAuth.Responses]<span> (</span><span class='info'>de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;OAuth 2.0 Multiple Response Type Encoding Practices,&rdquo; February&nbsp;2014.</span><span>)</span></a>.
+		
+</li>
+<li>
+		  Follow the validation rules in RFC 6749,
+		  especially those in Sections 4.2.2 and 10.12.
+		
+</li>
+<li>
+		  Follow the ID Token validation rules in <a class='info' href='#HybridIDTValidation'>Section&nbsp;3.3.2.12<span> (</span><span class='info'>ID Token Validation</span><span>)</span></a>
+		  when the <tt>response_type</tt> value used is
+		  <tt>code&nbsp;id_token</tt> or
+		  <tt>code&nbsp;id_token&nbsp;token</tt>.
+		
+</li>
+<li>
+		  Follow the Access Token validation rules in <a class='info' href='#HybridTokenValidation'>Section&nbsp;3.3.2.9<span> (</span><span class='info'>Access Token Validation</span><span>)</span></a>
+		  when the <tt>response_type</tt> value used is
+		  <tt>code&nbsp;token</tt> or
+		  <tt>code&nbsp;id_token&nbsp;token</tt>.
+		
+</li>
+<li>
+		  Follow the Authorization Code validation rules in <a class='info' href='#CodeValidation'>Section&nbsp;3.3.2.10<span> (</span><span class='info'>Authorization Code Validation</span><span>)</span></a>
+		  when the <tt>response_type</tt> value used is
+		  <tt>code&nbsp;id_token</tt> or
+		  
+		  <tt>code&nbsp;id_token&nbsp;token</tt>.
+		
+</li>
+</ol><p>
+	    
+</p>
+<a name="HybridTokenValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.2.9"></a><h3>3.3.2.9.&nbsp;
+Access Token Validation</h3>
+
+<p>
+	      When using the Hybrid Flow, Access Tokens
+	      returned from the Authorization Endpoint are validated
+	      in the same manner as for the Implicit Flow,
+	      as defined in <a class='info' href='#ImplicitTokenValidation'>Section&nbsp;3.2.2.9<span> (</span><span class='info'>Access Token Validation</span><span>)</span></a>.
+	    
+</p>
+<a name="CodeValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.2.10"></a><h3>3.3.2.10.&nbsp;
+Authorization Code Validation</h3>
+
+<p>To validate an Authorization Code issued from the Authorization Endpoint with an ID Token,
+	    the Client SHOULD do the following:
+</p>
+<p>
+	      </p>
+<ol class="text">
+<li>Hash the octets of the ASCII representation of
+		the <tt>code</tt>
+		with the hash algorithm specified in <a class='info' href='#JWA'>JWA<span> (</span><span class='info'>Jones, M., &ldquo;JSON Web Algorithms (JWA),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWA] for the
+		<tt>alg</tt> Header Parameter
+		of the ID Token's JOSE Header.
+		For instance, if the <tt>alg</tt> is
+		<tt>RS256</tt>,
+		the hash algorithm used is SHA-256.
+		
+</li>
+<li>Take the left-most half of the hash and base64url-encode it.
+</li>
+<li>The value of <tt>c_hash</tt> in the ID Token MUST
+		match the value produced in the previous step if <tt>c_hash</tt>
+		is present in the ID Token.
+</li>
+</ol><p>
+	    
+</p>
+<a name="HybridIDToken"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.2.11"></a><h3>3.3.2.11.&nbsp;
+ID Token</h3>
+
+<p>
+	      The contents of the ID Token are as described in <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a>.
+	      When using the Hybrid Flow,
+	      these additional requirements for the following ID Token Claims apply
+	      to an ID Token returned from the Authorization Endpoint:
+	    
+</p>
+<p>
+	      </p>
+<blockquote class="text"><dl>
+<dt>nonce</dt>
+<dd>
+		  
+		  If a <tt>nonce</tt> parameter is present in the Authentication Request,
+		  Authorization Servers MUST include a <tt>nonce</tt> Claim in the ID Token.
+		
+</dd>
+<dt>at_hash</dt>
+<dd>
+		  
+		  Access Token hash value.
+		  Its value is the base64url encoding of the left-most half of the
+		  hash of the octets of the ASCII representation of the
+		  <tt>access_token</tt> value,
+		  where the hash algorithm used is the hash algorithm
+		  used in the <tt>alg</tt> Header Parameter
+		  of the ID Token's JOSE Header.
+		  For instance, if the <tt>alg</tt> is
+		  <tt>RS256</tt>, hash the
+		  <tt>access_token</tt> value
+		  with SHA-256, then take the left-most 128 bits and base64url-encode them.
+		  The <tt>at_hash</tt> value is a case-sensitive string.
+		
+</dd>
+<dt></dt>
+<dd>
+		  If the ID Token is issued from the Authorization Endpoint with an
+		  <tt>access_token</tt> value,
+		  which is the case for the <tt>response_type</tt> value
+		  <tt>code&nbsp;id_token&nbsp;token</tt>,
+		  this is REQUIRED; otherwise, its inclusion is OPTIONAL.
+		
+</dd>
+<dt>c_hash</dt>
+<dd>
+		  
+		  Code hash value.
+		  Its value is the base64url encoding of the left-most half of the
+		  hash of the octets of the ASCII representation of the
+		  <tt>code</tt> value,
+		  where the hash algorithm used is the hash algorithm
+		  used in the <tt>alg</tt> Header Parameter
+		  of the ID Token's JOSE Header.
+		  For instance, if the <tt>alg</tt> is
+		  <tt>HS512</tt>, hash the
+		  <tt>code</tt> value
+		  with SHA-512, then take the left-most 256 bits and base64url-encode them.
+		  The <tt>c_hash</tt> value is a case-sensitive string.
+		
+</dd>
+<dt></dt>
+<dd>
+		  If the ID Token is issued from the Authorization Endpoint with a
+		  <tt>code</tt>,
+		  which is the case for the <tt>response_type</tt> values
+		  <tt>code&nbsp;id_token</tt> and
+		  <tt>code&nbsp;id_token&nbsp;token</tt>,
+		  this is REQUIRED; otherwise, its inclusion is OPTIONAL.
+		
+</dd>
+</dl></blockquote><p>
+	    
+</p>
+<a name="HybridIDTValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.2.12"></a><h3>3.3.2.12.&nbsp;
+ID Token Validation</h3>
+
+<p>
+	      When using the Hybrid Flow, the contents of an ID Token
+	      returned from the Authorization Endpoint MUST be validated
+	      in the same manner as for the Implicit Flow,
+	      as defined in <a class='info' href='#ImplicitIDTValidation'>Section&nbsp;3.2.2.11<span> (</span><span class='info'>ID Token Validation</span><span>)</span></a>.
+	    
+</p>
+<a name="HybridTokenEndpoint"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.3"></a><h3>3.3.3.&nbsp;
+Token Endpoint</h3>
+
+<p>
+	    When using the Hybrid Flow, the Token Endpoint is used
+	    in the same manner as for the Authorization Code Flow,
+	    as defined in <a class='info' href='#TokenEndpoint'>Section&nbsp;3.1.3<span> (</span><span class='info'>Token Endpoint</span><span>)</span></a>,
+	    with the exception of the differences specified in this section.
+	  
+</p>
+<a name="HybridTokenRequest"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.3.1"></a><h3>3.3.3.1.&nbsp;
+Token Request</h3>
+
+<p>
+	      When using the Hybrid Flow, Token Requests are made
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#TokenRequest'>Section&nbsp;3.1.3.1<span> (</span><span class='info'>Token Request</span><span>)</span></a>.
+	    
+</p>
+<a name="HybridTokenRequestValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.3.2"></a><h3>3.3.3.2.&nbsp;
+Token Request Validation</h3>
+
+<p>
+	      When using the Hybrid Flow, Token Requests are validated
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#TokenRequestValidation'>Section&nbsp;3.1.3.2<span> (</span><span class='info'>Token Request Validation</span><span>)</span></a>.
+	    
+</p>
+<a name="HybridTokenResponse"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.3.3"></a><h3>3.3.3.3.&nbsp;
+Successful Token Response</h3>
+
+<p>
+	      When using the Hybrid Flow, Token Responses are made
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#TokenResponse'>Section&nbsp;3.1.3.3<span> (</span><span class='info'>Successful Token Response</span><span>)</span></a>.
+	    
+</p>
+<a name="HybridTokenErrorResponse"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.3.4"></a><h3>3.3.3.4.&nbsp;
+Token Error Response</h3>
+
+<p>
+	      When using the Hybrid Flow, Token Error Responses are made
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#TokenErrorResponse'>Section&nbsp;3.1.3.4<span> (</span><span class='info'>Token Error Response</span><span>)</span></a>.
+	    
+</p>
+<a name="HybridTokenResponseValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.3.5"></a><h3>3.3.3.5.&nbsp;
+Token Response Validation</h3>
+
+<p>
+	      When using the Hybrid Flow, Token Responses are validated
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#TokenResponseValidation'>Section&nbsp;3.1.3.5<span> (</span><span class='info'>Token Response Validation</span><span>)</span></a>.
+	    
+</p>
+<a name="HybridIDToken2"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.3.6"></a><h3>3.3.3.6.&nbsp;
+ID Token</h3>
+
+<p>
+	      When using the Hybrid Flow, the contents of an ID Token
+	      returned from the Token Endpoint are
+	      the same as for an ID Token returned from the Authorization Endpoint,
+	      as defined in <a class='info' href='#HybridIDToken'>Section&nbsp;3.3.2.11<span> (</span><span class='info'>ID Token</span><span>)</span></a>,
+	      with the exception of the differences specified in this section.
+	    
+</p>
+<p>
+	      If an ID Token is returned from both the Authorization Endpoint
+	      and from the Token Endpoint,
+	      which is the case for the <tt>response_type</tt> values
+	      <tt>code&nbsp;id_token</tt> and
+	      <tt>code&nbsp;id_token&nbsp;token</tt>,
+	      the <tt>iss</tt> and <tt>sub</tt>
+	      Claim Values MUST be identical in both ID Tokens.
+	      All Claims about the Authentication event present in either
+	      SHOULD be present in both.
+	      If either ID Token contains Claims about the End-User,
+	      any that are present in both SHOULD have the same values in both.
+	      Note that the OP MAY choose to return fewer Claims about the End-User
+	      from the Authorization Endpoint, for instance, for privacy reasons.
+	      The <tt>at_hash</tt>
+	      and <tt>c_hash</tt> Claims
+	      MAY be omitted from the ID Token returned from the Token Endpoint
+	      even when these Claims are
+	      present in the ID Token returned from the Authorization Endpoint,
+	      because the ID Token and Access Token values returned from
+	      the Token Endpoint are already cryptographically bound together
+	      by the TLS encryption performed by the Token Endpoint.
+	    
+</p>
+<a name="HybridIDTValidation2"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.3.7"></a><h3>3.3.3.7.&nbsp;
+ID Token Validation</h3>
+
+<p>
+	      When using the Hybrid Flow, the contents of an ID Token
+	      returned from the Token Endpoint MUST be validated
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#IDTokenValidation'>Section&nbsp;3.1.3.7<span> (</span><span class='info'>ID Token Validation</span><span>)</span></a>.
+	    
+</p>
+<a name="HybridAccessToken2"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.3.8"></a><h3>3.3.3.8.&nbsp;
+Access Token</h3>
+
+<p>
+	      If an Access Token is returned from both the Authorization Endpoint
+	      and from the Token Endpoint,
+	      which is the case for the <tt>response_type</tt> values
+	      <tt>code&nbsp;token</tt> and
+	      <tt>code&nbsp;id_token&nbsp;token</tt>,
+	      their values MAY be the same
+	      or they MAY be different.
+	      Note that different Access Tokens might be returned
+	      be due to the different security characteristics
+	      of the two endpoints and the lifetimes and
+	      the access to resources granted by them might also be different.
+	    
+</p>
+<a name="HybridTokenValidation2"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3.3.3.9"></a><h3>3.3.3.9.&nbsp;
+Access Token Validation</h3>
+
+<p>
+	      When using the Hybrid Flow, the Access Token
+	      returned from the Token Endpoint
+	      is validated
+	      in the same manner as for the Authorization Code Flow,
+	      as defined in <a class='info' href='#CodeFlowTokenValidation'>Section&nbsp;3.1.3.8<span> (</span><span class='info'>Access Token Validation</span><span>)</span></a>.
+	    
+</p>
+<a name="ThirdPartyInitiatedLogin"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4"></a><h3>4.&nbsp;
+Initiating Login from a Third Party</h3>
+
+<p>
+	In some cases, the login flow is initiated by an OpenID Provider
+	or another party, rather than the Relying Party.
+	In this case, the initiator redirects to the RP at its login initiation endpoint,
+	which requests that the RP send an Authentication Request to a specified OP.
+	Note that this login initiation endpoint can be a different page at the RP
+	than the RP's default landing page.
+	RPs supporting
+	<a class='info' href='#OpenID.Registration'>OpenID Connect Dynamic Client Registration 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., and M. Jones, &ldquo;OpenID Connect Dynamic Client Registration 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Registration]
+	register this endpoint value using the
+	<tt>initiate_login_uri</tt> Registration parameter.
+      
+</p>
+<p>
+	The party initiating the login request does so by redirecting
+	to the login initiation endpoint at the RP, passing the following parameters:
+      
+</p>
+<p>
+	</p>
+<blockquote class="text"><dl>
+<dt>iss</dt>
+<dd>
+	    
+	    REQUIRED.
+	    Issuer Identifier for the OP that the RP is to send
+	    the Authentication Request to.
+            Its value MUST be a URL using the <tt>https</tt> scheme.
+          
+</dd>
+<dt>login_hint</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    Hint to the Authorization Server about the End-User to be authenticated.
+	    The meaning of this string-valued parameter is left to the OP's discretion.
+	    In common use cases, the value will contain an e-mail address, phone number, or username
+	    collected by the RP before requesting authentication at the OP.
+	    For example, this hint can be used by an RP after it asks the End-User
+	    for their e-mail address (or other identifier),
+	    passing that identifier as a hint to the OpenID Provider.
+	    It is RECOMMENDED that the hint value match the value provided for discovery.
+	    Other uses MAY include
+	    using the <tt>sub</tt> claim from the ID Token as the hint value
+	    or potentially other kinds of information about the requested authentication.
+          
+</dd>
+<dt>target_link_uri</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    URL that the RP is requested to redirect to after authentication.
+	    RPs MUST verify the value of the
+            <tt>target_link_uri</tt> to prevent being used as
+	    an open redirector to external sites.
+          
+</dd>
+</dl></blockquote><p>
+      
+</p>
+<p>
+	The parameters can either be passed as query parameters using
+	the HTTP <tt>GET</tt> method
+	or be passed as HTML form values that are auto-submitted in the User Agent,
+	and thus are transmitted via the HTTP <tt>POST</tt> method.
+      
+</p>
+<p>
+	Other parameters MAY be sent, if defined by extensions.
+	Any parameters used that are not understood MUST be ignored by the Client.
+      
+</p>
+<p>
+	Clients SHOULD employ frame busting and other techniques to prevent
+	End-Users from being logged in by third party sites without their knowledge
+	through attacks such as Clickjacking.
+	Refer to Section 4.4.1.9 of <a class='info' href='#RFC6819'>[RFC6819]<span> (</span><span class='info'>Lodderstedt, T., Ed., McGloin, M., and P. Hunt, &ldquo;OAuth 2.0 Threat Model and Security Considerations,&rdquo; January&nbsp;2013.</span><span>)</span></a> for more details.
+      
+</p>
+<a name="Claims"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5"></a><h3>5.&nbsp;
+Claims</h3>
+
+<p>
+	This section specifies how the Client can obtain Claims about the End-User
+	and the Authentication event.
+	It also defines a standard set of basic profile Claims.
+	Pre-defined sets of Claims can be requested using specific scope values
+	or individual Claims can be requested using the
+	<tt>claims</tt> request parameter.
+	The Claims can come directly from the OpenID Provider
+	or from distributed sources as well.
+      
+</p>
+<a name="StandardClaims"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1"></a><h3>5.1.&nbsp;
+Standard Claims</h3>
+
+<p>This specification defines a set of standard Claims.
+	They can be requested to be returned either in the
+	UserInfo Response, per <a class='info' href='#UserInfoResponse'>Section&nbsp;5.3.2<span> (</span><span class='info'>Successful UserInfo Response</span><span>)</span></a>,
+	or in the ID Token, per <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a>.
+	
+</p><br /><hr class="insert" />
+<a name="ClaimTable"></a>
+<table class="full" align="center" border="0" cellpadding="2" cellspacing="2">
+<col align="left"><col align="left"><col align="left">
+<tr><th align="left">Member</th><th align="left">Type</th><th align="left">Description</th></tr>
+<tr>
+<td align="left">sub</td>
+<td align="left">string</td>
+<td align="left">Subject - Identifier for the End-User at the Issuer.</td>
+</tr>
+<tr>
+<td align="left">name</td>
+<td align="left">string</td>
+<td align="left">
+	    End-User's full name in displayable form including all name parts,
+	    possibly including titles and suffixes,
+	    ordered according to the End-User's locale and preferences.
+	  </td>
+</tr>
+<tr>
+<td align="left">given_name</td>
+<td align="left">string</td>
+<td align="left">
+	    Given name(s) or first name(s) of the End-User.
+	    Note that in some cultures, people can have multiple given names;
+	    all can be present, with the names being separated by space characters.
+	  </td>
+</tr>
+<tr>
+<td align="left">family_name</td>
+<td align="left">string</td>
+<td align="left">
+	    Surname(s) or last name(s) of the End-User.
+	    Note that in some cultures, people can have multiple family names
+	    or no family name;
+	    all can be present, with the names being separated by space characters.
+	  </td>
+</tr>
+<tr>
+<td align="left">middle_name</td>
+<td align="left">string</td>
+<td align="left">
+	    Middle name(s) of the End-User.
+	    Note that in some cultures, people can have multiple middle names;
+	    all can be present, with the names being separated by space characters.
+	    Also note that in some cultures, middle names are not used.
+	  </td>
+</tr>
+<tr>
+<td align="left">nickname</td>
+<td align="left">string</td>
+<td align="left">Casual name of the End-User that may or may not be the same as the
+	  <tt>given_name</tt>. For instance, a <tt>nickname</tt> value of <tt>Mike</tt>
+	  might be returned alongside a <tt>given_name</tt>
+	  value of <tt>Michael</tt>.</td>
+</tr>
+<tr>
+<td align="left">preferred_username</td>
+<td align="left">string</td>
+<td align="left">Shorthand name by which the End-User wishes to be referred to at the RP, such as
+	  <tt>janedoe</tt> or <tt>j.doe</tt>.
+	  This value MAY be any valid JSON string including
+	  special characters such as <tt>@</tt>,
+	  <tt>/</tt>, or whitespace.
+	  The RP MUST NOT rely upon this value being unique,
+	  as discussed in <a class='info' href='#ClaimStability'>Section&nbsp;5.7<span> (</span><span class='info'>Claim Stability and Uniqueness</span><span>)</span></a>.
+	  </td>
+</tr>
+<tr>
+<td align="left">profile</td>
+<td align="left">string</td>
+<td align="left">
+	    URL of the End-User's profile page.
+	    The contents of this Web page SHOULD be about the End-User.
+	  </td>
+</tr>
+<tr>
+<td align="left">picture</td>
+<td align="left">string</td>
+<td align="left">
+	    URL of the End-User's profile picture.
+	    This URL MUST refer to an image file
+	    (for example, a PNG, JPEG, or GIF image file),
+	    rather than to a Web page containing an image.
+	    Note that this URL SHOULD specifically reference
+	    a profile photo of the End-User
+	    suitable for displaying when describing the End-User,
+	    rather than an arbitrary photo taken by the End-User.
+	  </td>
+</tr>
+<tr>
+<td align="left">website</td>
+<td align="left">string</td>
+<td align="left">
+	    URL of the End-User's Web page or blog.
+	    This Web page SHOULD contain information published by the End-User
+	    or an organization that the End-User is affiliated with.
+	  </td>
+</tr>
+<tr>
+<td align="left">email</td>
+<td align="left">string</td>
+<td align="left">
+	    End-User's preferred e-mail address.
+	    Its value MUST conform to the <a class='info' href='#RFC5322'>RFC 5322<span> (</span><span class='info'>Resnick, P., Ed., &ldquo;Internet Message Format,&rdquo; October&nbsp;2008.</span><span>)</span></a> [RFC5322]
+	    addr-spec syntax.
+	    The RP MUST NOT rely upon this value being unique,
+	    as discussed in <a class='info' href='#ClaimStability'>Section&nbsp;5.7<span> (</span><span class='info'>Claim Stability and Uniqueness</span><span>)</span></a>.
+	  </td>
+</tr>
+<tr>
+<td align="left">email_verified</td>
+<td align="left">boolean</td>
+<td align="left">
+	    True if the End-User's e-mail address has been verified; otherwise false.
+	    When this Claim Value is <tt>true</tt>,
+	    this  means that the OP took affirmative steps
+	    to ensure that this e-mail address was controlled by the End-User
+	    at the time the verification was performed.
+	    The means by which an e-mail address is verified is context specific,
+	    and dependent upon the trust framework or contractual agreements
+	    within which the parties are operating.
+	  </td>
+</tr>
+<tr>
+<td align="left">gender</td>
+<td align="left">string</td>
+<td align="left"> End-User's gender.  Values defined by this
+	  specification are <tt>female</tt> and
+	  <tt>male</tt>.  Other values MAY be used
+	  when neither of the defined values are applicable.</td>
+</tr>
+<tr>
+<td align="left">birthdate</td>
+<td align="left">string</td>
+<td align="left">End-User's birthday, represented as an
+	  <a class='info' href='#ISO8601-1'>ISO 8601-1<span> (</span><span class='info'>International Organization for 	    Standardization, &ldquo;ISO 8601-1:2019/Amd 1:2022. Date and time - Representations for information interchange - Part 1: Basic rules,&rdquo; October&nbsp;2022.</span><span>)</span></a> [ISO8601&#8209;1] <tt>YYYY-MM-DD</tt>
+	  format. The year MAY be <tt>0000</tt>, indicating that it is omitted.
+	  To represent only the year, <tt>YYYY</tt> format is allowed. Note that
+	  depending on the underlying platform's date related function, providing just year can
+	  result in varying month and day, so the implementers need to take this factor into account
+	  to correctly process the dates. </td>
+</tr>
+<tr>
+<td align="left">zoneinfo</td>
+<td align="left">string</td>
+<td align="left">String from IANA Time Zone Database <a class='info' href='#IANA.time-zones'>[IANA.time&#8209;zones]<span> (</span><span class='info'>IANA, &ldquo;Time Zone Database,&rdquo; .</span><span>)</span></a>
+	  representing the End-User's time zone.
+	  For example, <tt>Europe/Paris</tt> or
+	  <tt>America/Los_Angeles</tt>.</td>
+</tr>
+<tr>
+<td align="left">locale</td>
+<td align="left">string</td>
+<td align="left">End-User's locale, represented as a
+	  <a class='info' href='#RFC5646'>BCP47<span> (</span><span class='info'>Phillips, A., Ed. and M. Davis, Ed., &ldquo;Tags for Identifying Languages,&rdquo; September&nbsp;2009.</span><span>)</span></a> [RFC5646] language tag.
+	  This is typically an <a class='info' href='#ISO639'>ISO 639 Alpha-2<span> (</span><span class='info'>International Organization for 	    Standardization, &ldquo;ISO 639:2023. Code for individual languages and language groups,&rdquo; November&nbsp;2023.</span><span>)</span></a> [ISO639]
+	  language code in
+	  lowercase and an <a class='info' href='#ISO3166-1'>ISO 3166-1 Alpha-2<span> (</span><span class='info'>International Organization for 	    Standardization, &ldquo;ISO 3166-1:2020. Codes for the representation of names of 	  countries and their subdivisions - Part 1: Country codes,&rdquo; August&nbsp;2020.</span><span>)</span></a> [ISO3166&#8209;1]
+	  country code in uppercase, separated by a dash. For example,
+	  <tt>en-US</tt> or <tt>fr-CA</tt>.
+	  As a compatibility note, some implementations have used an underscore
+	  as the separator rather than a dash, for example,
+	  <tt>en_US</tt>; Relying Parties MAY choose to
+	  accept this locale syntax as well.</td>
+</tr>
+<tr>
+<td align="left">phone_number</td>
+<td align="left">string</td>
+<td align="left">
+	    End-User's preferred telephone number. <a class='info' href='#E.164'>E.164<span> (</span><span class='info'>International Telecommunication Union, &ldquo;E.164: The international public telecommunication numbering plan,&rdquo; 2010.</span><span>)</span></a> [E.164]
+	    is RECOMMENDED as the format of this Claim,
+	    for example, <tt>+1 (425) 555-1212</tt>
+	    or <tt>+56 (2) 687 2400</tt>.
+	    If the phone number contains an extension, it is RECOMMENDED that
+	    the extension be represented using the
+	    <a class='info' href='#RFC3966'>RFC 3966<span> (</span><span class='info'>Schulzrinne, H., &ldquo;The tel URI for Telephone Numbers,&rdquo; December&nbsp;2004.</span><span>)</span></a> [RFC3966] extension syntax,
+	    for example, <tt>+1 (604) 555-1234;ext=5678</tt>.
+	  </td>
+</tr>
+<tr>
+<td align="left">phone_number_verified</td>
+<td align="left">boolean</td>
+<td align="left">
+	    True if the End-User's phone number has been verified; otherwise false.
+	    When this Claim Value is <tt>true</tt>,
+	    this  means that the OP took affirmative steps
+	    to ensure that this phone number was controlled by the End-User
+	    at the time the verification was performed.
+	    The means by which a phone number is verified is context specific,
+	    and dependent upon the trust framework or contractual agreements
+	    within which the parties are operating.
+	    When true, the <tt>phone_number</tt>
+	    Claim MUST be in E.164 format
+	    and any extensions MUST be represented in RFC 3966 format.
+	  </td>
+</tr>
+<tr>
+<td align="left">address</td>
+<td align="left">JSON object</td>
+<td align="left">
+	    End-User's preferred postal address.
+	    The value of the <tt>address</tt> member is
+	    a JSON <a class='info' href='#RFC8259'>[RFC8259]<span> (</span><span class='info'>Bray, T., Ed., &ldquo;The JavaScript Object Notation (JSON) Data Interchange Format,&rdquo; December&nbsp;2017.</span><span>)</span></a> structure containing some or all of
+	    the members defined in <a class='info' href='#AddressClaim'>Section&nbsp;5.1.1<span> (</span><span class='info'>Address Claim</span><span>)</span></a>.
+	  </td>
+</tr>
+<tr>
+<td align="left">updated_at</td>
+<td align="left">number</td>
+<td align="left">
+	    Time the End-User's information was last updated.
+	    Its value is a JSON number representing the number of seconds from
+	    1970-01-01T00:00:00Z as measured in UTC until the date/time.
+	  </td>
+</tr>
+</table>
+<br clear="all" />
+<table border="0" cellpadding="0" cellspacing="2" align="center"><tr><td align="center"><font face="monaco, MS Sans Serif" size="1"><b>&nbsp;Table 1: Registered Member Definitions&nbsp;</b></font><br /></td></tr></table><hr class="insert" />
+
+<a name="AddressClaim"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.1"></a><h3>5.1.1.&nbsp;
+Address Claim</h3>
+
+<p>
+	    The Address Claim represents a physical mailing address.
+	    Implementations MAY return only a subset of the
+	    fields of an <tt>address</tt>, depending upon
+	    the information available and the End-User's privacy
+	    preferences. For
+	    example, the <tt>country</tt> and <tt>region</tt> might be returned without returning
+	    more fine-grained address information.
+	  
+</p>
+<p>
+	    Implementations MAY return just the full address
+	    as a single string in the formatted sub-field,
+	    or they MAY return just the individual component
+	    fields using the other sub-fields,
+	    or they MAY return both.
+	    If both variants are returned,
+	    they SHOULD represent the same address,
+	    with the formatted address indicating how the
+	    component fields are combined.
+	  
+</p>
+<p>
+	    All the address values defined below are represented as JSON strings.
+	  
+</p>
+<p>
+	    </p>
+<blockquote class="text"><dl>
+<dt>formatted</dt>
+<dd>
+		
+		Full mailing address,
+		formatted for display or use on a mailing label.
+		This field MAY contain multiple lines, separated by newlines.
+		Newlines can be represented either as
+		a carriage return/line feed pair ("\r\n") or as
+		a single line feed character ("\n").
+	      
+</dd>
+<dt>street_address</dt>
+<dd>
+		
+		Full street address component,
+		which MAY include house number, street name,
+		Post Office Box, and multi-line extended street
+		address information.
+		This field MAY contain multiple lines, separated by newlines.
+		Newlines can be represented either as
+		a carriage return/line feed pair ("\r\n") or as
+		a single line feed character ("\n").
+	      
+</dd>
+<dt>locality</dt>
+<dd>
+		
+		City or locality component.
+	      
+</dd>
+<dt>region</dt>
+<dd>
+		
+		State, province,
+		prefecture, or region component.
+	      
+</dd>
+<dt>postal_code</dt>
+<dd>
+		
+		Zip code or
+		postal code component.
+	      
+</dd>
+<dt>country</dt>
+<dd>
+		
+		Country name component.
+	      
+</dd>
+</dl></blockquote><p>
+	  
+</p>
+<a name="AdditionalClaims"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.1.2"></a><h3>5.1.2.&nbsp;
+Additional Claims</h3>
+
+<p>
+	    While this specification defines only a small set of Claims as
+	    standard Claims, other Claims MAY be used in conjunction
+	    with the standard Claims.
+	    When using such Claims, it is RECOMMENDED that
+	    collision-resistant names be used for the Claim Names,
+	    as described in  the
+	    <a class='info' href='#JWT'>JSON Web Token (JWT)<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWT] specification.
+	    Alternatively, Private Claim Names can be safely used
+	    when naming conflicts are unlikely to arise,
+	    as described in  the JWT specification.
+	    Or, if specific additional Claims will have broad and general applicability,
+	    they can be registered with Registered Claim Names,
+	    per  the JWT specification.
+	  
+</p>
+<a name="ClaimsLanguagesAndScripts"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.2"></a><h3>5.2.&nbsp;
+Claims Languages and Scripts</h3>
+
+<p>
+	  Human-readable Claim Values and Claim Values that reference human-readable values
+	  MAY be represented in multiple languages and scripts.
+	  To specify the languages and scripts, <a class='info' href='#RFC5646'>BCP47<span> (</span><span class='info'>Phillips, A., Ed. and M. Davis, Ed., &ldquo;Tags for Identifying Languages,&rdquo; September&nbsp;2009.</span><span>)</span></a> [RFC5646] language tags are added to member names,
+	  delimited by a <tt>#</tt> character.  For example,
+	  <tt>family_name#ja-Kana-JP</tt> expresses the
+	  Family Name in Katakana in Japanese, which is commonly used to index
+	  and represent the phonetics of the Kanji representation of the same name
+	  represented as <tt>family_name#ja-Hani-JP</tt>.
+	  As another example, both <tt>website</tt> and
+	  <tt>website#de</tt> Claim Values might be returned,
+	  referencing a Web site in an unspecified language and a Web site
+	  in German.
+	
+</p>
+<p>
+	  Since Claim Names are case sensitive, it is strongly RECOMMENDED
+	  that language tag values used in Claim Names be spelled using the
+	  character case with which they are registered in the
+	  IANA "Language Subtag Registry" <a class='info' href='#IANA.Language'>[IANA.Language]<span> (</span><span class='info'>IANA, &ldquo;Language Subtag Registry,&rdquo; .</span><span>)</span></a>.
+	  In particular, normally language names are spelled with lowercase characters,
+	  region names are spelled with uppercase characters, and
+	  scripts are spelled with mixed case characters.
+	  However, since BCP47 language tag values are case insensitive,
+	  implementations SHOULD interpret the language tag values supplied
+	  in a case-insensitive manner.
+	
+</p>
+<p>
+	  Per the recommendations in BCP47, language tag values for Claims
+	  SHOULD only be as specific as necessary.
+	  For instance, using <tt>fr</tt> might be sufficient
+	  in many contexts, rather than <tt>fr-CA</tt> or
+	  <tt>fr-FR</tt>.
+	  Where possible, OPs SHOULD try to match requested Claim locales with
+	  Claims it has.  For instance, if the Client asks for a Claim with
+	  a <tt>de</tt> (German) language tag and the OP
+	  has a value tagged with <tt>de-CH</tt> (Swiss German)
+	  and no generic German value, it would be appropriate for the OP
+	  to return the Swiss German value to the Client.
+	  (This intentionally moves as much of the complexity of language tag
+	  matching to the OP as possible, to simplify Clients.)
+	
+</p>
+<p>
+	  OpenID Connect defines the following Authorization Request parameter
+	  to enable specify the preferred languages and scripts to be used
+	  for the returned Claims:
+
+	  </p>
+<blockquote class="text"><dl>
+<dt>claims_locales</dt>
+<dd>
+	      
+	      OPTIONAL.
+	      End-User's preferred languages and scripts for Claims being returned,
+	      represented as a space-separated list of
+	      <a class='info' href='#RFC5646'>BCP47<span> (</span><span class='info'>Phillips, A., Ed. and M. Davis, Ed., &ldquo;Tags for Identifying Languages,&rdquo; September&nbsp;2009.</span><span>)</span></a> [RFC5646] language tag values,
+	      ordered by preference.
+	      An error SHOULD NOT result if some or all of the requested locales
+	      are not supported by the OpenID Provider.
+	    
+</dd>
+</dl></blockquote><p>
+	
+</p>
+<p>
+	  When the OP determines, either through the
+	  <tt>claims_locales</tt> parameter,
+	  or by other means, that the End-User and Client are
+	  requesting Claims in only one set of languages and scripts,
+	  it is RECOMMENDED that OPs return Claims without language tags
+	  when they employ this language and script.
+	  It is also RECOMMENDED that Clients be written in a manner
+	  that they can handle and utilize Claims using language tags.
+	
+</p>
+<a name="UserInfo"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3"></a><h3>5.3.&nbsp;
+UserInfo Endpoint</h3>
+
+<p>
+	  The UserInfo Endpoint is an OAuth 2.0 Protected Resource that
+	  returns Claims about the authenticated End-User.
+	  To obtain the requested Claims about the End-User, the Client
+	  makes a request to the UserInfo Endpoint
+	  using an Access Token obtained through OpenID Connect Authentication.
+	  These Claims are normally represented by a JSON object that contains
+	  a collection of name and value pairs for the Claims.
+	
+</p>
+<p>
+	  Communication with the UserInfo Endpoint MUST utilize TLS.
+	  See <a class='info' href='#TLSRequirements'>Section&nbsp;16.17<span> (</span><span class='info'>TLS Requirements</span><span>)</span></a> for more information on using TLS.
+	
+</p>
+<p>
+	  The UserInfo Endpoint MUST support the use of the
+	  HTTP <tt>GET</tt> and
+	  HTTP <tt>POST</tt> methods
+	  defined in <a class='info' href='#RFC7231'>RFC 7231<span> (</span><span class='info'>Fielding, R., Ed. and J. Reschke, Ed., &ldquo;Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content,&rdquo; June&nbsp;2014.</span><span>)</span></a> [RFC7231].
+	
+</p>
+<p>The UserInfo Endpoint MUST accept Access Tokens as
+	<a class='info' href='#RFC6750'>OAuth 2.0 Bearer Token Usage<span> (</span><span class='info'>Jones, M. and D. Hardt, &ldquo;The OAuth 2.0 Authorization Framework: Bearer Token Usage,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6750].
+</p>
+<p>The UserInfo Endpoint SHOULD support the use of
+	<a class='info' href='#CORS'>Cross-Origin Resource Sharing (CORS)<span> (</span><span class='info'>Opera Software ASA, &ldquo;Cross-Origin Resource Sharing,&rdquo; July&nbsp;2010.</span><span>)</span></a> [CORS]
+	and/or other methods as appropriate
+	to enable JavaScript Clients and other Browser-Based Clients to access it.
+</p>
+<a name="UserInfoRequest"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.1"></a><h3>5.3.1.&nbsp;
+UserInfo Request</h3>
+
+<p>
+	    The Client sends the UserInfo Request using either
+	    HTTP <tt>GET</tt> or HTTP <tt>POST</tt>.
+	    The Access Token obtained
+	    from an OpenID Connect Authentication Request MUST be sent as a Bearer Token,
+	    per Section 2 of <a class='info' href='#RFC6750'>OAuth 2.0 Bearer Token Usage<span> (</span><span class='info'>Jones, M. and D. Hardt, &ldquo;The OAuth 2.0 Authorization Framework: Bearer Token Usage,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6750].
+	  
+</p>
+<p>
+	    It is RECOMMENDED that the request use the
+	    HTTP <tt>GET</tt> method and
+	    the Access Token be sent using the
+	    <tt>Authorization</tt> header field.
+	  
+</p>
+<p>
+	      The following is a non-normative example of a UserInfo Request:
+	    
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /userinfo HTTP/1.1
+  Host: server.example.com
+  Authorization: Bearer SlAV32hkKG
+</pre></div>
+<a name="UserInfoResponse"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.2"></a><h3>5.3.2.&nbsp;
+Successful UserInfo Response</h3>
+
+<p>
+	    The UserInfo Claims MUST be returned as the members of a JSON object
+	    unless a signed or encrypted response was requested during Client Registration.
+	    The Claims defined in <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> can be returned,
+	    as can additional Claims not specified there.
+	  
+</p>
+<p>
+	    For privacy reasons, OpenID Providers MAY elect to not return
+	    values for some requested Claims.
+	    It is not an error condition to not return a requested Claim.
+	  
+</p>
+<p>
+	    If a Claim is not returned, that Claim Name SHOULD be
+	    omitted from the JSON object representing the Claims; it
+	    SHOULD NOT be present with a null or empty string value.
+	  
+</p>
+<p>
+	    The <tt>sub</tt> (subject) Claim
+	    MUST always be returned in the UserInfo Response.
+	  
+</p>
+<p>
+	    NOTE:  Due to the possibility of token substitution attacks
+	    (see <a class='info' href='#TokenSubstitution'>Section&nbsp;16.11<span> (</span><span class='info'>Token Substitution</span><span>)</span></a>),
+	    the UserInfo Response is not guaranteed to be about the
+	    End-User identified by the <tt>sub</tt> (subject)
+	    element of the ID Token.
+	    The <tt>sub</tt> Claim in the UserInfo Response
+	    MUST be verified to exactly match the
+	    <tt>sub</tt> Claim in the ID Token;
+	    if they do not match, the UserInfo Response values MUST NOT be used.
+	  
+</p>
+<p>
+	    Upon receipt of the UserInfo Request, the UserInfo Endpoint MUST
+	    return the JSON Serialization of the UserInfo Response as in
+	    <a class='info' href='#JSONSerialization'>Section&nbsp;13.3<span> (</span><span class='info'>JSON Serialization</span><span>)</span></a> in the HTTP response
+	    body unless a
+	    different format was specified during Registration
+	    <a class='info' href='#OpenID.Registration'>[OpenID.Registration]<span> (</span><span class='info'>Sakimura, N., Bradley, J., and M. Jones, &ldquo;OpenID Connect Dynamic Client Registration 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a>.
+	    The UserInfo Endpoint MUST return a content-type header to indicate
+	    which format is being returned.
+	    The content-type of the HTTP response MUST be <tt>application/json</tt> if the response body is a text
+	    JSON object;
+	    the response body SHOULD be encoded using UTF-8.
+	  
+</p>
+<p>
+	    If the UserInfo Response is
+	    signed and/or encrypted, then the Claims are returned in a JWT and the
+	    content-type MUST be <tt>application/jwt</tt>.
+	    The response MAY be encrypted without also being signed.
+	    If both signing and encryption are requested,
+	    the response MUST be signed then encrypted,
+	    with the result being a Nested JWT, as defined in <a class='info' href='#JWT'>[JWT]<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a>.
+	  
+</p>
+<p>
+	    If signed, the UserInfo Response
+	    MUST contain the Claims
+	    <tt>iss</tt> (issuer)
+	    and <tt>aud</tt> (audience) as members.
+	    The <tt>iss</tt> value MUST be the OP's Issuer Identifier URL.
+	    The <tt>aud</tt> value MUST be or include the RP's Client ID value.
+	  
+</p>
+<p>The following is a non-normative example
+	    of a UserInfo Response:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+
+  {
+   "sub": "248289761001",
+   "name": "Jane Doe",
+   "given_name": "Jane",
+   "family_name": "Doe",
+   "preferred_username": "j.doe",
+   "email": "janedoe@example.com",
+   "picture": "http://example.com/janedoe/me.jpg"
+  }
+</pre></div>
+<a name="UserInfoError"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.3"></a><h3>5.3.3.&nbsp;
+UserInfo Error Response</h3>
+
+<p>
+	    When an error condition occurs, the UserInfo Endpoint returns
+	    an Error Response as defined in Section 3 of
+	    <a class='info' href='#RFC6750'>OAuth 2.0 Bearer Token Usage<span> (</span><span class='info'>Jones, M. and D. Hardt, &ldquo;The OAuth 2.0 Authorization Framework: Bearer Token Usage,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6750].
+	    (HTTP errors unrelated to RFC 6750 are returned to the User Agent using the
+	    appropriate HTTP status code.)
+	  
+</p>
+<p>The following is a non-normative example
+	    of a UserInfo Error Response:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  HTTP/1.1 401 Unauthorized
+  WWW-Authenticate: Bearer error="invalid_token",
+    error_description="The Access Token expired"
+</pre></div>
+<a name="UserInfoResponseValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.3.4"></a><h3>5.3.4.&nbsp;
+UserInfo Response Validation</h3>
+
+<p>
+	    The Client MUST validate the UserInfo Response as follows:
+	  
+</p>
+<p>
+	    </p>
+<ol class="text">
+<li>Verify that the OP that responded was the intended OP
+	      through a TLS server certificate check, per
+	      <a class='info' href='#RFC6125'>RFC 6125<span> (</span><span class='info'>Saint-Andre, P. and J. Hodges, &ldquo;Representation and Verification of Domain-Based Application Service Identity within Internet Public Key Infrastructure Using X.509 (PKIX) Certificates in the Context of Transport Layer Security (TLS),&rdquo; March&nbsp;2011.</span><span>)</span></a> [RFC6125].
+</li>
+<li>If the Client has provided a
+	      <tt>userinfo_encrypted_response_alg</tt>
+	      parameter during Registration, decrypt the UserInfo Response
+	      using the keys specified during Registration.
+</li>
+<li>If the response was signed, the Client SHOULD validate the
+	      signature according to <a class='info' href='#JWS'>JWS<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Signature (JWS),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWS].
+</li>
+</ol><p>
+	  
+</p>
+<a name="ScopeClaims"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.4"></a><h3>5.4.&nbsp;
+Requesting Claims using Scope Values</h3>
+
+<p>
+	  OpenID Connect Clients use <tt>scope</tt> values,
+	  as defined in Section 3.3 of <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749],
+	  to specify what
+	  access privileges are being requested for Access Tokens. The scopes associated
+	  with Access Tokens determine what resources will be available when they are
+	  used to access OAuth 2.0 protected endpoints.
+	  Protected Resource endpoints MAY perform different actions and
+	  return different information based on the scope values and other parameters
+	  used when requesting the presented Access Token.
+	
+</p>
+<p>
+	  For OpenID Connect, scopes
+	  can be used to request that specific sets of information
+	  be made available as Claim Values.
+	
+</p>
+<p>
+	  Claims requested by the following scopes are treated by Authorization Servers
+	  as Voluntary Claims.
+	
+</p>
+<p>
+	  OpenID Connect defines the following <tt>scope</tt> values
+	  that are used to request Claims:
+	
+</p>
+<p>
+	  </p>
+<blockquote class="text"><dl>
+<dt>profile</dt>
+<dd>
+	      
+	      OPTIONAL. This scope value
+	      requests access to the End-User's default profile Claims,
+	      which are:
+
+	      <tt>name</tt>,
+	      <tt>family_name</tt>,
+	      <tt>given_name</tt>,
+	      <tt>middle_name</tt>,
+	      <tt>nickname</tt>,
+	      <tt>preferred_username</tt>,
+	      <tt>profile</tt>,
+	      <tt>picture</tt>,
+	      <tt>website</tt>,
+	      <tt>gender</tt>,
+	      <tt>birthdate</tt>,
+	      <tt>zoneinfo</tt>,
+	      <tt>locale</tt>, and
+	      <tt>updated_at</tt>.
+	    
+</dd>
+<dt>email</dt>
+<dd>
+	      
+	      OPTIONAL. This scope value requests access to
+	      the <tt>email</tt> and
+	      <tt>email_verified</tt> Claims.
+	    
+</dd>
+<dt>address</dt>
+<dd>
+	      
+	      OPTIONAL. This scope value requests access to
+	      the <tt>address</tt> Claim.
+	    
+</dd>
+<dt>phone</dt>
+<dd>
+	      
+	      OPTIONAL. This scope value requests access to
+	      the <tt>phone_number</tt> and
+	      <tt>phone_number_verified</tt> Claims.
+	    
+</dd>
+</dl></blockquote><p>
+	
+</p>
+<p>
+	  Multiple scope values MAY be used by creating a space-delimited,
+	  case-sensitive list of ASCII scope values.
+	
+</p>
+<p>
+	  The Claims requested by the
+	  <tt>profile</tt>,
+	  <tt>email</tt>,
+	  <tt>address</tt>, and
+	  <tt>phone</tt> scope values
+	  are returned from the UserInfo Endpoint,
+	  as described in <a class='info' href='#UserInfoResponse'>Section&nbsp;5.3.2<span> (</span><span class='info'>Successful UserInfo Response</span><span>)</span></a>,
+	  when a <tt>response_type</tt> value is used
+	  that results in an Access Token being issued.
+	  However, when no Access Token is issued
+	  (which is the case for the <tt>response_type</tt>
+	  value <tt>id_token</tt>),
+	  the resulting Claims are returned in the ID Token.
+	
+</p>
+<p>In some cases, the End-User will be given the option to
+	have the OpenID Provider decline to provide some or all
+	information requested by RPs.
+	To minimize the amount of information that the End-User is being asked
+	to disclose, an RP can elect to
+	only request a subset of the information available from the
+	UserInfo Endpoint.
+</p>
+<p>
+	  
+<p>
+	      The following is a non-normative example of an unencoded
+	      <tt>scope</tt> request:
+	    
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  scope=openid profile email phone
+</pre></div>
+	
+
+<a name="ClaimsParameter"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5"></a><h3>5.5.&nbsp;
+Requesting Claims using the "claims" Request Parameter</h3>
+
+<p>
+	  OpenID Connect defines the following Authorization Request parameter
+	  to enable requesting individual Claims
+	  and specifying parameters that apply to the requested Claims:
+
+	  </p>
+<blockquote class="text"><dl>
+<dt>claims</dt>
+<dd>
+	      
+	      OPTIONAL.
+	      This parameter is used to request that specific Claims be returned.
+	      The value is a JSON object listing the requested Claims.
+	    
+</dd>
+</dl></blockquote><p>
+	
+</p>
+<p>
+	  The <tt>claims</tt> Authentication Request
+	  parameter requests that specific Claims
+	  be returned from the UserInfo Endpoint and/or in the ID Token.
+	  It is represented as a JSON object containing lists of Claims being requested
+	  from these locations.
+	  Properties of the Claims being requested MAY also be specified.
+	
+</p>
+<p>
+	  Support for the <tt>claims</tt> parameter is OPTIONAL.
+	  Should an OP not support this parameter and an RP uses it,
+	  the OP SHOULD return a set of Claims to the RP that it believes would
+	  be useful to the RP and the End-User using whatever heuristics it
+	  believes are appropriate.
+	  The <tt>claims_parameter_supported</tt>
+	  Discovery result indicates whether the OP supports this parameter.
+	
+</p>
+<p>
+	  The <tt>claims</tt> parameter value is represented
+	  in an OAuth 2.0 request as UTF-8 encoded JSON
+	  (which ends up being form-urlencoded when passed as an OAuth parameter).
+	  When used in a Request Object value, per <a class='info' href='#RequestObject'>Section&nbsp;6.1<span> (</span><span class='info'>Passing a Request Object by Value</span><span>)</span></a>,
+	  the JSON is used as the value of the
+	  <tt>claims</tt> member.
+	
+</p>
+<p>
+	  The top-level members of the Claims request JSON object are:
+
+	  </p>
+<blockquote class="text"><dl>
+<dt>userinfo</dt>
+<dd>
+	      
+	      OPTIONAL.
+	      Requests that the listed individual Claims be returned
+	      from the UserInfo Endpoint.
+	      If present, the listed Claims are being requested to be added to
+	      any Claims that are being requested using
+	      <tt>scope</tt> values.
+	      If not present, the Claims being requested from the UserInfo Endpoint
+	      are only those requested using  <tt>scope</tt> values.
+	    
+</dd>
+<dt></dt>
+<dd>
+	      When the <tt>userinfo</tt> member is used,
+	      the request MUST also use a <tt>response_type</tt>
+	      value that results in an Access Token being issued to the Client
+	      for use at the UserInfo Endpoint.
+	    
+</dd>
+<dt>id_token</dt>
+<dd>
+	      
+	      OPTIONAL.
+	      Requests that the listed individual Claims be returned
+	      in the ID Token.
+	      If present, the listed Claims are being requested to be added to
+	      the default Claims in the ID Token.
+	      If not present, the default ID Token Claims are requested,
+	      as per the ID Token definition in <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a>
+	      and per the additional per-flow ID Token requirements in Sections
+	      <a class='info' href='#CodeIDToken'>3.1.3.6<span> (</span><span class='info'>ID Token</span><span>)</span></a>,
+	      <a class='info' href='#ImplicitIDToken'>3.2.2.10<span> (</span><span class='info'>ID Token</span><span>)</span></a>,
+	      <a class='info' href='#HybridIDToken'>3.3.2.11<span> (</span><span class='info'>ID Token</span><span>)</span></a>,
+	      and <a class='info' href='#HybridIDToken2'>3.3.3.6<span> (</span><span class='info'>ID Token</span><span>)</span></a>.
+	    
+</dd>
+</dl></blockquote><p>
+	
+</p>
+<p>
+	  Other members MAY be present.
+	  Any members used that are not understood MUST be ignored.
+	
+</p>
+<p>
+	  
+<p>An example Claims request is as follows:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "userinfo":
+    {
+     "given_name": {"essential": true},
+     "nickname": null,
+     "email": {"essential": true},
+     "email_verified": {"essential": true},
+     "picture": null,
+     "http://example.info/claims/groups": null
+    },
+   "id_token":
+    {
+     "auth_time": {"essential": true},
+     "acr": {"values": ["urn:mace:incommon:iap:silver"] }
+    }
+  }
+</pre></div>
+	  Note that a Claim that is not in the standard set defined in
+	  <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a>, the (example)
+	  <tt>http://example.info/claims/groups</tt> Claim,
+	  is being requested.
+	  Using the <tt>claims</tt> parameter
+	  is the only way to request specific combinations of
+	  Claims that cannot be specified using scope values.
+	
+
+<a name="IndividualClaimsRequests"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.1"></a><h3>5.5.1.&nbsp;
+Individual Claims Requests</h3>
+
+<p>
+	    The <tt>userinfo</tt> and
+	    <tt>id_token</tt> members of the
+	    <tt>claims</tt> request both are JSON objects
+	    with the names of the individual Claims being requested as the member names.
+	    The member values MUST be one of the following:
+
+	    </p>
+<blockquote class="text"><dl>
+<dt>null</dt>
+<dd>
+		
+		Indicates that this Claim is being requested in the default manner.
+		In particular, this is a Voluntary Claim.
+		For instance, the Claim request:
+
+		<div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  "given_name": null
+</pre></div>
+
+		requests the <tt>given_name</tt> Claim
+		in the default manner.
+	      
+</dd>
+<dt>JSON Object</dt>
+<dd>
+		
+		Used to provide additional information about the Claim being
+		requested. This specification defines the following members:
+
+		
+<blockquote class="text"><dl>
+<dt>essential</dt>
+<dd>
+		    
+		    OPTIONAL.
+		    Indicates whether the Claim being requested is an Essential Claim.
+		    If the value is <tt>true</tt>,
+		    this indicates that the Claim is an Essential Claim.
+		    For instance, the Claim request:
+
+		    <div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  "auth_time": {"essential": true}
+</pre></div>
+
+		    can be used to specify that it is Essential to return an
+		    <tt>auth_time</tt> Claim Value.
+		  
+</dd>
+<dt></dt>
+<dd>
+		    If the value is <tt>false</tt>,
+		    it indicates that it is a Voluntary Claim.
+		    The default is <tt>false</tt>.
+		  
+</dd>
+<dt></dt>
+<dd>
+		    By requesting Claims as Essential Claims,
+		    the RP indicates to the End-User
+		    that releasing these Claims will ensure a smooth authorization
+		    for the specific task requested by the End-User.
+		    Note that even if the Claims are not available because
+		    the End-User did not authorize their release or they are not present,
+		    the Authorization Server MUST NOT generate an error when
+		    Claims are not returned, whether they are Essential or Voluntary,
+		    unless otherwise specified in the description of the specific claim.
+		  
+</dd>
+<dt>value</dt>
+<dd>
+		    
+		    OPTIONAL.
+		    Requests that the Claim be returned with a particular value.
+		    For instance, the Claim request:
+
+		    <div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  "sub": {"value": "248289761001"}
+</pre></div>
+
+		    can be used to specify that the request apply to the End-User
+		    with Subject Identifier <tt>248289761001</tt>.
+		  
+</dd>
+<dt></dt>
+<dd>
+		    The value of the <tt>value</tt> member
+		    MUST be a valid value for the Claim being requested.
+		    Definitions of individual Claims can include requirements on
+		    how and whether the <tt>value</tt>
+		    qualifier is to be used when requesting that Claim.
+		    An equality comparison is used to determine whether the requested Claim value matches.
+		  
+</dd>
+<dt></dt>
+<dd>
+		    When the Claim value does not match the requested value,
+		    the Claim is not included in the response.
+		    If the Claim was <tt>sub</tt>,
+		    a mismatch MUST cause the authentication to fail,
+		    as described in <a class='info' href='#AuthRequestValidation'>Section&nbsp;3.1.2.2<span> (</span><span class='info'>Authentication Request Validation</span><span>)</span></a>.
+		  
+</dd>
+<dt>values</dt>
+<dd>
+		    
+		    OPTIONAL.
+		    Requests that the Claim be returned with one of a set of values,
+		    with the values appearing in order of preference.
+		    This is processed equivalently to a <tt>value</tt> request,
+		    except that a choice of acceptable Claim values is provided.
+		  
+</dd>
+<dt></dt>
+<dd>
+		    For instance, the Claim request:
+
+		    <div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  "acr": {"essential": true,
+          "values": ["urn:mace:incommon:iap:silver",
+                     "urn:mace:incommon:iap:bronze"]}
+</pre></div>
+
+		    specifies that it is Essential that the <tt>acr</tt>
+		    Claim be returned with either the value
+		    <tt>urn:mace:incommon:iap:silver</tt> or
+		    <tt>urn:mace:incommon:iap:bronze</tt>.
+		  
+</dd>
+<dt></dt>
+<dd>
+		    The values in the <tt>values</tt> member array
+		    MUST be valid values for the Claim being requested.
+		    Definitions of individual Claims can include requirements on
+		    how and whether the <tt>values</tt>
+		    qualifier is to be used when requesting that Claim.
+		    An equality comparison is used to determine whether the requested Claim values match.
+		  
+</dd>
+<dt></dt>
+<dd>
+		    When the Claim value does not match any of the requested values,
+		    the Claim is not included in the response.
+		  
+</dd>
+</dl></blockquote>
+	      
+</dd>
+<dt></dt>
+<dd>
+		Other members MAY be defined to provide additional
+		information about the requested Claims.
+		Any members used that are not understood MUST be ignored.
+	      
+</dd>
+</dl></blockquote><p>
+	  
+</p>
+<p>
+	    Note that when the <tt>claims</tt> request parameter
+	    is supported, the scope values that request Claims, as defined in
+	    <a class='info' href='#ScopeClaims'>Section&nbsp;5.4<span> (</span><span class='info'>Requesting Claims using Scope Values</span><span>)</span></a>, are effectively shorthand methods for
+	    requesting sets of individual Claims.
+	    For example, using the scope value <tt>openid email</tt>
+	    and a <tt>response_type</tt> that returns an Access Token
+	    is equivalent to using the scope value <tt>openid</tt>
+	    and the following request for individual Claims.
+
+	    
+<p>
+		Equivalent of using the <tt>email</tt> scope value:
+	      
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "userinfo":
+    {
+     "email": null,
+     "email_verified": null
+    }
+  }
+</pre></div>
+	  
+
+<a name="acrSemantics"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.1.1"></a><h3>5.5.1.1.&nbsp;
+Requesting the "acr" Claim</h3>
+
+<p>
+	      If the <tt>acr</tt> Claim is requested
+	      as an Essential Claim for the ID Token
+	      with a <tt>value</tt> or <tt>values</tt> parameter requesting
+	      specific Authentication Context Class Reference values and
+	      the implementation supports the <tt>claims</tt> parameter,
+	      the Authorization Server MUST return an <tt>acr</tt>
+	      Claim Value that matches one of the requested values.
+	      The Authorization Server MAY ask the End-User to re-authenticate
+	      with additional factors
+	      to meet this requirement. If this is an Essential Claim and the
+	      requirement cannot be met, then the Authorization Server MUST
+	      treat that outcome as a failed authentication attempt.
+	    
+</p>
+<p>
+	      Note that the RP MAY request the <tt>acr</tt>
+	      Claim as a Voluntary Claim
+	      by using the <tt>acr_values</tt> request parameter
+	      or by not including "essential": true in an individual
+	      <tt>acr</tt> Claim request.
+	      If the Claim is not Essential and a requested value
+	      cannot be provided, the Authorization Server SHOULD return
+	      the session's current <tt>acr</tt> as
+	      the value of the <tt>acr</tt> Claim.
+	      If the Claim is not Essential, the Authorization Server is not required to
+	      provide this Claim in its response.
+	    
+</p>
+<p>
+	      If the client requests the <tt>acr</tt> Claim using
+	      both the <tt>acr_values</tt> request parameter and
+	      an individual <tt>acr</tt> Claim request for the ID Token
+	      listing specific requested values,
+	      the resulting behavior is unspecified.
+	    
+</p>
+<a name="IndividualClaimsLanguages"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.5.2"></a><h3>5.5.2.&nbsp;
+Languages and Scripts for Individual Claims</h3>
+
+<p>
+	    As described in <a class='info' href='#ClaimsLanguagesAndScripts'>Section&nbsp;5.2<span> (</span><span class='info'>Claims Languages and Scripts</span><span>)</span></a>,
+	    human-readable Claim Values and Claim Values that reference human-readable values
+	    MAY be represented in multiple languages and scripts.
+	    Within a request for individual Claims, requested languages and scripts
+	    for particular Claims MAY be requested by including Claim Names
+	    that contain <tt>#</tt>-separated
+	    <a class='info' href='#RFC5646'>BCP47<span> (</span><span class='info'>Phillips, A., Ed. and M. Davis, Ed., &ldquo;Tags for Identifying Languages,&rdquo; September&nbsp;2009.</span><span>)</span></a> [RFC5646] language tags
+	    in the Claims request, using the Claim Name syntax specified in
+	    <a class='info' href='#ClaimsLanguagesAndScripts'>Section&nbsp;5.2<span> (</span><span class='info'>Claims Languages and Scripts</span><span>)</span></a>.
+	    For example, a Family Name in Katakana in Japanese
+	    can be requested using the Claim Name
+	    <tt>family_name#ja-Kana-JP</tt>
+	    and a Kanji representation of the Family Name in Japanese
+	    can be requested using the Claim Name
+	    <tt>family_name#ja-Hani-JP</tt>.
+	    A German-language Web site can be requested with the Claim Name
+	    <tt>website#de</tt>.
+	  
+</p>
+<p>
+	    If an OP receives a request for human-readable Claims in a language and script
+	    that it does not have, any versions of those Claims returned that do not use
+	    the requested language and script SHOULD use a language tag in the Claim Name.
+	  
+</p>
+<a name="ClaimTypes"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.6"></a><h3>5.6.&nbsp;
+Claim Types</h3>
+
+<p>
+	  Three representations of Claim Values are defined by this specification:
+	
+</p>
+<p>
+	  </p>
+<blockquote class="text"><dl>
+<dt>Normal Claims</dt>
+<dd>
+	      
+	      Claims that are directly asserted by
+	      the OpenID Provider.
+	    
+</dd>
+<dt>Aggregated Claims</dt>
+<dd>
+	      
+	      Claims that are asserted by a
+	      Claims Provider other than the OpenID Provider but are returned
+	      by OpenID Provider.
+	    
+</dd>
+<dt>Distributed Claims</dt>
+<dd>
+	      
+	      Claims that are asserted by a
+	      Claims Provider other than the OpenID Provider but are returned
+	      as references by the OpenID Provider.
+	    
+</dd>
+</dl></blockquote><p>
+	
+</p>
+<p>
+	  Normal Claims MUST be supported.
+	  Support for Aggregated Claims and Distributed Claims is OPTIONAL.
+	
+</p>
+<a name="NormalClaims"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.6.1"></a><h3>5.6.1.&nbsp;
+Normal Claims</h3>
+
+<p>Normal Claims are represented as members in a JSON object. The
+	  Claim Name is the member name and the Claim Value is the member
+	  value.
+</p>
+<p>The following is a non-normative response containing Normal Claims:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "sub": "248289761001",
+   "name": "Jane Doe",
+   "given_name": "Jane",
+   "family_name": "Doe",
+   "email": "janedoe@example.com",
+   "picture": "http://example.com/janedoe/me.jpg"
+  }
+</pre></div>
+<a name="AggregatedDistributedClaims"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.6.2"></a><h3>5.6.2.&nbsp;
+Aggregated and Distributed Claims</h3>
+
+<p>Aggregated and distributed Claims are represented by
+	  using special <tt>_claim_names</tt> and
+	  <tt>_claim_sources</tt> members
+	  of the JSON object containing the Claims.
+</p>
+<p>
+	    </p>
+<blockquote class="text"><dl>
+<dt>_claim_names</dt>
+<dd>
+		
+		JSON object whose member
+		names are the Claim Names for the Aggregated and Distributed
+		Claims. The member values are references to the member names
+		in the <tt>_claim_sources</tt> member from which
+		the actual Claim Values can be retrieved.
+		The OP MAY omit some Claims available from referenced Claims Providers
+		from the set of Claim Names.
+	      
+</dd>
+<dt>_claim_sources</dt>
+<dd>
+		
+		JSON object whose
+		member names are referenced by the member values of the
+		<tt>_claim_names</tt> member. The member values
+		contain sets of Aggregated Claims or reference locations for
+		Distributed Claims. The member values can have one of the
+		following formats depending on whether it is providing
+		Aggregated or Distributed Claims:
+
+		
+<blockquote class="text"><dl>
+<dt>Aggregated Claims</dt>
+<dd>
+		    
+		    JSON object that MUST
+		    contain the <tt>JWT</tt> member whose value is a <a class='info' href='#JWT'>JWT<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWT] that MUST contain all the Claims
+		    in the <tt>_claim_names</tt> object that references the
+		    corresponding <tt>_claim_sources</tt> member.
+		    Other members MAY be present.
+		    Any members used that are not understood MUST be ignored.
+
+		    
+<blockquote class="text"><dl>
+<dt>JWT</dt>
+<dd>
+			
+			REQUIRED.
+			JWT containing Claim Values.
+		      
+</dd>
+</dl></blockquote>
+		  
+</dd>
+<dt></dt>
+<dd>
+		    The JWT SHOULD NOT contain a <tt>sub</tt> (subject)
+		    Claim unless its value is an identifier for the End-User at
+		    the Claims Provider (and not for the OpenID Provider or another party);
+		    this typically means that a <tt>sub</tt> Claim
+		    SHOULD NOT be provided.
+		  
+</dd>
+<dt>Distributed Claims</dt>
+<dd>
+		    
+		    JSON object that
+		    contains the following members and values:
+
+		    
+<blockquote class="text"><dl>
+<dt>endpoint</dt>
+<dd>
+			
+			REQUIRED.
+			OAuth 2.0 resource endpoint from which the associated
+			Claim can be retrieved. The endpoint URL MUST return
+			the Claim as a JWT.
+		      
+</dd>
+<dt>access_token</dt>
+<dd>
+			
+			OPTIONAL.
+			Access Token
+			enabling retrieval of the Claims from the endpoint URL
+			by using the <a class='info' href='#RFC6750'>OAuth 2.0 Bearer Token Usage<span> (</span><span class='info'>Jones, M. and D. Hardt, &ldquo;The OAuth 2.0 Authorization Framework: Bearer Token Usage,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6750]
+			protocol. Claims SHOULD be requested using
+			the Authorization Request header field and Claims Providers
+			MUST support this method. If the Access Token
+			is not available, RPs MAY need to retrieve the
+			Access Token out of band or use an Access Token
+			that was pre-negotiated between the Claims Provider and
+			RP, or the Claims Provider MAY reauthenticate the
+			End-User and/or reauthorize the RP.
+		      
+</dd>
+</dl></blockquote>
+		  
+</dd>
+<dt></dt>
+<dd>
+		    Since it is not an error condition to not return a requested Claim,
+		    RPs MUST be prepared to handle the condition that some Claims listed in
+		    <tt>_claim_sources</tt> are not returned from the Claims Provider.
+		    They SHOULD treat this the same as when any other requested Claim is not returned.
+		  
+</dd>
+<dt></dt>
+<dd>
+		    A <tt>sub</tt> (subject) Claim SHOULD NOT
+		    be returned from the Claims Provider
+		    unless its value is an identifier for the End-User at
+		    the Claims Provider (and not for the OpenID Provider or another party);
+		    this typically means that a <tt>sub</tt> Claim
+		    SHOULD NOT be provided.
+		  
+</dd>
+</dl></blockquote>
+	      
+</dd>
+</dl></blockquote><p>
+	  
+</p>
+<p>
+	    An <tt>iss</tt> (issuer) Claim SHOULD be included
+	    in any JWT issued by a Claims Provider so that the Claims Provider's
+	    keys can be retrieved for signature validation of the JWT.
+	    The value of the Claim is the Claims Provider's Issuer Identifier URL.
+	  
+</p>
+<p>
+	    In general, it is up to the OP when it is appropriate to use
+	    Aggregated Claims and Distributed Claims.
+	    In some cases, information about when to use what Claim Types
+	    might be negotiated out of band between RPs and OPs.
+	  
+</p>
+<a name="AggregatedExample"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.6.2.1"></a><h3>5.6.2.1.&nbsp;
+Example of Aggregated Claims</h3>
+
+<p>
+	      In this non-normative example, Claims from Claims Provider A
+	      are combined with other Claims held by the OpenID provider, with the
+	      Claims from Claims Provider A being returned as Aggregated Claims.
+	    
+</p>
+<p>
+	      
+<p>
+		  In this example, these Claims about Jane Doe have been issued by
+		  Claims Provider A.
+		  (The example also includes the Claims Provider's Issuer Identifier URL.)
+		
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "iss": "https://a.example.com",
+   "address": {
+     "street_address": "1234 Hollywood Blvd.",
+     "locality": "Los Angeles",
+     "region": "CA",
+     "postal_code": "90210",
+     "country": "United States of America"},
+   "phone_number": "+1 (310) 123-4567"
+  }
+</pre></div>
+	    
+
+<p>
+	      Claims Provider A signs the JSON Claims, representing them in a signed JWT:
+	      jwt_header.jwt_part2.jwt_part3.
+	      It is this JWT that is used by the OpenID Provider.
+	    
+</p>
+<p>
+	      
+<p>
+		  In this example, this JWT containing Jane Doe's Aggregated Claims
+		  from Claims Provider A is combined with other Normal Claims,
+		  and returned as the following set of Claims:
+		
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "sub": "248289761001",
+   "name": "Jane Doe",
+   "given_name": "Jane",
+   "family_name": "Doe",
+   "birthdate": "0000-03-22",
+   "eye_color": "blue",
+   "email": "janedoe@example.com",
+   "_claim_names": {
+     "address": "src1",
+     "phone_number": "src1"
+   },
+   "_claim_sources": {
+     "src1": {"JWT": "jwt_header.jwt_part2.jwt_part3"}
+   }
+  }
+</pre></div>
+	    
+
+<a name="DistributedExample"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.6.2.2"></a><h3>5.6.2.2.&nbsp;
+Example of Distributed Claims</h3>
+
+<p>
+	      In this non-normative example, the OpenID Provider combines
+	      Normal Claims that it holds with references to Claims held by
+	      two different Claims Providers, B and C, incorporating references
+	      to some of the Claims held by B and C as Distributed Claims.
+	    
+</p>
+<p>
+	      
+<p>
+		  In this example, these Claims about Jane Doe are held by
+		  Claims Provider B (Jane Doe's bank).
+		  (The example also includes the Claims Provider's Issuer Identifier URL.)
+		
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "iss": "https://bank.example.com",
+   "shipping_address": {
+     "street_address": "1234 Hollywood Blvd.",
+     "locality": "Los Angeles",
+     "region": "CA",
+     "postal_code": "90210",
+     "country": "United States of America"},
+   "payment_info": "Some_Card 1234 5678 9012 3456",
+   "phone_number": "+1 (310) 123-4567"
+  }
+</pre></div>
+	    
+
+<p>
+	      
+<p>
+		  Also in this example, this Claim about Jane Doe is held by
+		  Claims Provider C (a credit agency).
+		  (The example also includes the Claims Provider's Issuer Identifier URL.)
+		
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "iss": "https://creditagency.example.com",
+   "credit_score": 650
+  }
+</pre></div>
+	    
+
+<p>
+	      
+<p>
+		  The OpenID Provider returns Jane Doe's Claims along with references
+		  to the Distributed Claims from Claims Provider B and Claims Provider C
+		  by sending the Access Tokens and URLs of locations from which the
+		  Distributed Claims can be retrieved:
+		
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "sub": "248289761001",
+   "name": "Jane Doe",
+   "given_name": "Jane",
+   "family_name": "Doe",
+   "email": "janedoe@example.com",
+   "birthdate": "0000-03-22",
+   "eye_color": "blue",
+   "_claim_names": {
+     "payment_info": "src1",
+     "shipping_address": "src1",
+     "credit_score": "src2"
+    },
+   "_claim_sources": {
+     "src1": {"endpoint":
+                "https://bank.example.com/claim_source"},
+     "src2": {"endpoint":
+                "https://creditagency.example.com/claims_here",
+              "access_token": "ksj3n283dke"}
+   }
+  }
+</pre></div>
+	    
+
+<p>
+	      Note that not returning <tt>phone_number</tt>, which is held by Claims Provider B,
+	      demonstrates that not all Claims held by a utilized Claims Provider need be included.
+	    
+</p>
+<a name="ClaimStability"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5.7"></a><h3>5.7.&nbsp;
+Claim Stability and Uniqueness</h3>
+
+<p>
+	  The <tt>sub</tt> (subject) and
+	  <tt>iss</tt> (issuer) Claims from the ID Token, used together,
+	  are the only Claims that an RP
+	  can rely upon as a stable identifier for the End-User,
+	  since the <tt>sub</tt>
+	  Claim MUST be locally unique and never reassigned within the Issuer
+	  for a particular End-User, as described in <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a>.
+	  Therefore, the only guaranteed unique identifier for a given End-User is the
+	  combination of the <tt>iss</tt> Claim
+	  and the <tt>sub</tt> Claim.
+	
+</p>
+<p>
+	  All other Claims carry no such guarantees across different issuers in terms of
+	  stability over time or uniqueness across users, and Issuers are permitted to
+	  apply local restrictions and policies. For instance, an Issuer MAY re-use an
+	  <tt>email</tt> Claim Value across different
+	  End-Users at different points in time, and the claimed
+	  <tt>email</tt> address for a given End-User MAY change
+	  over time.
+	  Therefore, other Claims such as <tt>email</tt>,
+	  <tt>phone_number</tt>,
+	  <tt>preferred_username</tt>,
+	  and <tt>name</tt>
+	  MUST NOT be used as unique identifiers for the End-User,
+	  whether obtained from the ID Token or the UserInfo Endpoint.
+	
+</p>
+<a name="JWTRequests"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6"></a><h3>6.&nbsp;
+Passing Request Parameters as JWTs</h3>
+
+<p>
+	OpenID Connect defines the following Authorization Request parameters
+	to enable Authentication Requests to be signed and optionally encrypted:
+
+	</p>
+<blockquote class="text"><dl>
+<dt>request</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    This parameter enables
+	    OpenID Connect requests to be passed in a single,
+	    self-contained parameter and to be optionally signed and/or encrypted.
+	    The parameter value is a Request Object value,
+	    as specified in <a class='info' href='#RequestObject'>Section&nbsp;6.1<span> (</span><span class='info'>Passing a Request Object by Value</span><span>)</span></a>.
+	    It represents the request as a JWT whose Claims
+	    are the request parameters.
+	  
+</dd>
+<dt>request_uri</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    This parameter enables
+	    OpenID Connect requests to be passed by reference, rather than by value.
+	    The <tt>request_uri</tt> value is a URL
+	    referencing a resource containing a Request Object value,
+	    which is a JWT containing the request parameters.
+	    This URL MUST use the <tt>https</tt> scheme
+	    unless the target Request Object is signed in a way that is verifiable by the OP.
+	  
+</dd>
+</dl></blockquote><p>
+      
+</p>
+<p>
+	Requests using these parameters are represented as JWTs, which are respectively
+	passed by value or by reference.
+	The ability to pass requests by reference is particularly useful for large requests.
+	If one of these parameters is used,
+	the other MUST NOT be used in the same request.
+      
+</p>
+<p>
+	Note that the Request Objects defined here are compatible with those specified by
+	<a class='info' href='#RFC9101'>The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR)<span> (</span><span class='info'>Sakimura, N., Bradley, J., and M. Jones, &ldquo;The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR),&rdquo; August&nbsp;2021.</span><span>)</span></a> [RFC9101].
+      
+</p>
+<a name="RequestObject"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.1"></a><h3>6.1.&nbsp;
+Passing a Request Object by Value</h3>
+
+<p>
+	  The <tt>request</tt> Authorization Request parameter
+	  enables OpenID Connect requests to be passed in a single,
+	  self-contained parameter and to be optionally signed and/or encrypted.
+	  It represents the request as a JWT whose Claims are the request parameters
+	  specified in <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a>.
+	  This JWT is called a Request Object.
+	
+</p>
+<p>
+	  Support for the <tt>request</tt> parameter is OPTIONAL.
+	  The <tt>request_parameter_supported</tt>
+	  Discovery result indicates whether the OP supports this parameter.
+	  Should an OP not support this parameter and an RP uses it,
+	  the OP MUST return the <tt>request_not_supported</tt>
+	  error.
+	
+</p>
+<p>
+	  When the <tt>request</tt> parameter is used,
+	  the OpenID Connect request parameter values contained in the JWT
+	  supersede those passed using the OAuth 2.0 request syntax.
+	  However, parameters MAY also be passed using the OAuth 2.0 request syntax
+	  even when a Request Object is used;
+	  this would typically be done to enable a cached,
+	  pre-signed (and possibly pre-encrypted) Request Object value
+	  to be used containing the fixed request parameters, while parameters that
+	  can vary with each request, such as <tt>state</tt> and
+	  <tt>nonce</tt>, are passed as OAuth 2.0 parameters.
+	
+</p>
+<p>
+	  So that the request is a valid OAuth 2.0 Authorization Request,
+	  values for the <tt>response_type</tt> and
+	  <tt>client_id</tt> parameters MUST be included
+	  using the OAuth 2.0 request syntax, since they are REQUIRED by OAuth 2.0.
+	  The values for these parameters MUST match those in the Request Object,
+	  if present.
+	
+</p>
+<p>
+	  Even if a <tt>scope</tt> parameter
+	  is present in the Request Object value,
+	  a <tt>scope</tt> parameter MUST always be passed using
+	  the OAuth 2.0 request syntax containing the
+	  <tt>openid</tt> scope value to indicate to the
+	  underlying OAuth 2.0 logic that this is an OpenID Connect request.
+	
+</p>
+<p>
+	  The Request Object MAY be signed or unsigned (unsecured).
+	  When it is unsecured, this is indicated by use of the
+	  <tt>none</tt> algorithm <a class='info' href='#JWA'>[JWA]<span> (</span><span class='info'>Jones, M., &ldquo;JSON Web Algorithms (JWA),&rdquo; May&nbsp;2015.</span><span>)</span></a>
+	  in the JOSE Header.  If signed, the Request Object
+	  SHOULD contain the Claims
+	  <tt>iss</tt> (issuer)
+	  and <tt>aud</tt> (audience) as members.
+	  The <tt>iss</tt> value SHOULD be the Client ID of the RP,
+	  unless it was signed by a different party than the RP.
+	  The <tt>aud</tt> value SHOULD be or include
+	  the OP's Issuer Identifier URL.
+	
+</p>
+<p>
+	  The Request Object MAY also be encrypted using <a class='info' href='#JWE'>JWE<span> (</span><span class='info'>Jones, M. and J. Hildebrand, &ldquo;JSON Web Encryption (JWE),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWE]
+	  and MAY be encrypted without also being signed.
+	  If both signing and encryption are performed, it MUST be signed then encrypted,
+	  with the result being a Nested JWT, as defined in <a class='info' href='#JWT'>[JWT]<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a>.
+	
+</p>
+<p>
+	  <tt>request</tt> and
+	  <tt>request_uri</tt> parameters
+	  MUST NOT be included in Request Objects.
+	
+</p>
+<p>
+	  
+<p>
+	      The following is a non-normative example of the Claims in
+	      a Request Object before base64url-encoding and signing:
+	    
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "iss": "s6BhdRkqt3",
+   "aud": "https://server.example.com",
+   "response_type": "code id_token",
+   "client_id": "s6BhdRkqt3",
+   "redirect_uri": "https://client.example.org/cb",
+   "scope": "openid",
+   "state": "af0ifjsldkj",
+   "nonce": "n-0S6_WzA2Mj",
+   "max_age": 86400,
+   "claims":
+    {
+     "userinfo":
+      {
+       "given_name": {"essential": true},
+       "nickname": null,
+       "email": {"essential": true},
+       "email_verified": {"essential": true},
+       "picture": null
+      },
+     "id_token":
+      {
+       "gender": null,
+       "birthdate": {"essential": true},
+       "acr": {"values": ["urn:mace:incommon:iap:silver"]}
+      }
+    }
+  }
+</pre></div>
+	  
+<p>
+	      Signing it with the <tt>RS256</tt> algorithm
+	      results in this Request Object value
+	      (with line wraps within values for display purposes only):
+	    
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  eyJhbGciOiJSUzI1NiIsImtpZCI6ImsyYmRjIn0.ew0KICJpc3MiOiAiczZCaGRSa3
+  F0MyIsDQogImF1ZCI6ICJodHRwczovL3NlcnZlci5leGFtcGxlLmNvbSIsDQogInJl
+  c3BvbnNlX3R5cGUiOiAiY29kZSBpZF90b2tlbiIsDQogImNsaWVudF9pZCI6ICJzNk
+  JoZFJrcXQzIiwNCiAicmVkaXJlY3RfdXJpIjogImh0dHBzOi8vY2xpZW50LmV4YW1w
+  bGUub3JnL2NiIiwNCiAic2NvcGUiOiAib3BlbmlkIiwNCiAic3RhdGUiOiAiYWYwaW
+  Zqc2xka2oiLA0KICJub25jZSI6ICJuLTBTNl9XekEyTWoiLA0KICJtYXhfYWdlIjog
+  ODY0MDAsDQogImNsYWltcyI6IA0KICB7DQogICAidXNlcmluZm8iOiANCiAgICB7DQ
+  ogICAgICJnaXZlbl9uYW1lIjogeyJlc3NlbnRpYWwiOiB0cnVlfSwNCiAgICAgIm5p
+  Y2tuYW1lIjogbnVsbCwNCiAgICAgImVtYWlsIjogeyJlc3NlbnRpYWwiOiB0cnVlfS
+  wNCiAgICAgImVtYWlsX3ZlcmlmaWVkIjogeyJlc3NlbnRpYWwiOiB0cnVlfSwNCiAg
+  ICAgInBpY3R1cmUiOiBudWxsDQogICAgfSwNCiAgICJpZF90b2tlbiI6IA0KICAgIH
+  sNCiAgICAgImdlbmRlciI6IG51bGwsDQogICAgICJiaXJ0aGRhdGUiOiB7ImVzc2Vu
+  dGlhbCI6IHRydWV9LA0KICAgICAiYWNyIjogeyJ2YWx1ZXMiOiBbInVybjptYWNlOm
+  luY29tbW9uOmlhcDpzaWx2ZXIiXX0NCiAgICB9DQogIH0NCn0.nwwnNsk1-Zkbmnvs
+  F6zTHm8CHERFMGQPhos-EJcaH4Hh-sMgk8ePrGhw_trPYs8KQxsn6R9Emo_wHwajyF
+  KzuMXZFSZ3p6Mb8dkxtVyjoy2GIzvuJT_u7PkY2t8QU9hjBcHs68PkgjDVTrG1uRTx
+  0GxFbuPbj96tVuj11pTnmFCUR6IEOXKYr7iGOCRB3btfJhM0_AKQUfqKnRlrRscc8K
+  ol-cSLWoYE9l5QqholImzjT_cMnNIznW9E7CDyWXTsO70xnB4SkG6pXfLSjLLlxmPG
+  iyon_-Te111V8uE83IlzCYIb_NMXvtTIVc1jpspnTSD7xMbpL-2QgwUsAlMGzw
+</pre></div>
+	  
+<p>
+	      The following RSA public key, represented in JWK format, can be used to
+	      validate the Request Object signature in this
+	      and subsequent Request Object examples
+	      (with line wraps within values for display purposes only):
+	    
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "kty":"RSA",
+   "kid":"k2bdc",
+   "n":"y9Lqv4fCp6Ei-u2-ZCKq83YvbFEk6JMs_pSj76eMkddWRuWX2aBKGHAtKlE5P
+        7_vn__PCKZWePt3vGkB6ePgzAFu08NmKemwE5bQI0e6kIChtt_6KzT5OaaXDF
+        I6qCLJmk51Cc4VYFaxgqevMncYrzaW_50mZ1yGSFIQzLYP8bijAHGVjdEFgZa
+        ZEN9lsn_GdWLaJpHrB3ROlS50E45wxrlg9xMncVb8qDPuXZarvghLL0HzOuYR
+        adBJVoWZowDNTpKpk2RklZ7QaBO7XDv3uR7s_sf2g-bAjSYxYUGsqkNA9b3xV
+        W53am_UZZ3tZbFTIh557JICWKHlWj5uzeJXaw",
+   "e":"AQAB"
+  }
+</pre></div>
+
+	
+
+<a name="RequestParameter"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.1.1"></a><h3>6.1.1.&nbsp;
+Request using the "request" Request Parameter</h3>
+
+<p>The Client sends the Authorization Request to the
+	  Authorization Endpoint.
+</p>
+<p>
+	    
+<p>The following is a non-normative example of an
+	      Authorization Request using the <tt>request</tt>
+	      parameter
+	      (with line wraps within values for display purposes only):
+	      
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  https://server.example.com/authorize?
+    response_type=code%20id_token
+    &amp;client_id=s6BhdRkqt3
+    &amp;redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+    &amp;scope=openid
+    &amp;state=af0ifjsldkj
+    &amp;nonce=n-0S6_WzA2Mj
+    &amp;request=eyJhbGciOiJSUzI1NiIsImtpZCI6ImsyYmRjIn0.ew0KICJpc3MiOiA
+    iczZCaGRSa3F0MyIsDQogImF1ZCI6ICJodHRwczovL3NlcnZlci5leGFtcGxlLmN
+    vbSIsDQogInJlc3BvbnNlX3R5cGUiOiAiY29kZSBpZF90b2tlbiIsDQogImNsaWV
+    udF9pZCI6ICJzNkJoZFJrcXQzIiwNCiAicmVkaXJlY3RfdXJpIjogImh0dHBzOi8
+    vY2xpZW50LmV4YW1wbGUub3JnL2NiIiwNCiAic2NvcGUiOiAib3BlbmlkIiwNCiA
+    ic3RhdGUiOiAiYWYwaWZqc2xka2oiLA0KICJub25jZSI6ICJuLTBTNl9XekEyTWo
+    iLA0KICJtYXhfYWdlIjogODY0MDAsDQogImNsYWltcyI6IA0KICB7DQogICAidXN
+    lcmluZm8iOiANCiAgICB7DQogICAgICJnaXZlbl9uYW1lIjogeyJlc3NlbnRpYWw
+    iOiB0cnVlfSwNCiAgICAgIm5pY2tuYW1lIjogbnVsbCwNCiAgICAgImVtYWlsIjo
+    geyJlc3NlbnRpYWwiOiB0cnVlfSwNCiAgICAgImVtYWlsX3ZlcmlmaWVkIjogeyJ
+    lc3NlbnRpYWwiOiB0cnVlfSwNCiAgICAgInBpY3R1cmUiOiBudWxsDQogICAgfSw
+    NCiAgICJpZF90b2tlbiI6IA0KICAgIHsNCiAgICAgImdlbmRlciI6IG51bGwsDQo
+    gICAgICJiaXJ0aGRhdGUiOiB7ImVzc2VudGlhbCI6IHRydWV9LA0KICAgICAiYWN
+    yIjogeyJ2YWx1ZXMiOiBbInVybjptYWNlOmluY29tbW9uOmlhcDpzaWx2ZXIiXX0
+    NCiAgICB9DQogIH0NCn0.nwwnNsk1-ZkbmnvsF6zTHm8CHERFMGQPhos-EJcaH4H
+    h-sMgk8ePrGhw_trPYs8KQxsn6R9Emo_wHwajyFKzuMXZFSZ3p6Mb8dkxtVyjoy2
+    GIzvuJT_u7PkY2t8QU9hjBcHs68PkgjDVTrG1uRTx0GxFbuPbj96tVuj11pTnmFC
+    UR6IEOXKYr7iGOCRB3btfJhM0_AKQUfqKnRlrRscc8Kol-cSLWoYE9l5QqholImz
+    jT_cMnNIznW9E7CDyWXTsO70xnB4SkG6pXfLSjLLlxmPGiyon_-Te111V8uE83Il
+    zCYIb_NMXvtTIVc1jpspnTSD7xMbpL-2QgwUsAlMGzw
+</pre></div>
+	  
+
+<a name="RequestUriParameter"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.2"></a><h3>6.2.&nbsp;
+Passing a Request Object by Reference</h3>
+
+<p>
+	  The <tt>request_uri</tt> Authorization Request parameter enables
+	  OpenID Connect requests to be passed by reference, rather than by value.
+	  This parameter is used identically to the
+	  <tt>request</tt> parameter, other than that
+	  the Request Object value is retrieved from the resource at the specified URL,
+	  rather than passed by value.
+	
+</p>
+<p>
+	  The <tt>request_uri_parameter_supported</tt>
+	  Discovery result indicates whether the OP supports this parameter.
+	  Should an OP not support this parameter and an RP uses it,
+	  the OP MUST return the <tt>request_uri_not_supported</tt>
+	  error.
+	
+</p>
+<p>
+	  When the <tt>request_uri</tt> parameter is used,
+	  the OpenID Connect request parameter values contained in the referenced JWT
+	  supersede those passed using the OAuth 2.0 request syntax.
+	  However, parameters MAY also be passed using the OAuth 2.0 request syntax
+	  even when a <tt>request_uri</tt> is used;
+	  this would typically be done to enable a cached,
+	  pre-signed (and possibly pre-encrypted) Request Object value
+	  to be used containing the fixed request parameters, while parameters that
+	  can vary with each request, such as <tt>state</tt> and
+	  <tt>nonce</tt>, are passed as OAuth 2.0 parameters.
+	
+</p>
+<p>
+	  So that the request is a valid OAuth 2.0 Authorization Request,
+	  values for the <tt>response_type</tt> and
+	  <tt>client_id</tt> parameters MUST be included
+	  using the OAuth 2.0 request syntax, since they are REQUIRED by OAuth 2.0.
+	  The values for these parameters MUST match those in the Request Object,
+	  if present.
+	
+</p>
+<p>
+	  Even if a <tt>scope</tt> parameter
+	  is present in the referenced Request Object,
+	  a <tt>scope</tt> parameter MUST always be passed using
+	  the OAuth 2.0 request syntax containing the
+	  <tt>openid</tt> scope value to indicate to the
+	  underlying OAuth 2.0 logic that this is an OpenID Connect request.
+	
+</p>
+<p>
+	  Servers MAY cache the contents of the resources referenced by Request URIs.
+	  If the contents of the referenced resource could ever change,
+	  the URI SHOULD include the base64url-encoded SHA-256 hash of the
+	  referenced resource contents as the fragment component of the URI.
+	  If the fragment value used for a URI changes, that signals the server
+	  that any cached value for that URI with the old fragment value
+	  is no longer valid.
+	
+</p>
+<p>
+	  Note that Clients MAY pre-register
+	  <tt>request_uri</tt> values using the
+	  <tt>request_uris</tt> parameter defined in
+	  Section 2.1 of the
+	  <a class='info' href='#OpenID.Registration'>OpenID Connect Dynamic Client Registration 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., and M. Jones, &ldquo;OpenID Connect Dynamic Client Registration 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Registration]
+	  specification.
+	  OPs can require that <tt>request_uri</tt> values used
+	  be pre-registered with the <tt>require_request_uri_registration</tt>
+	  discovery parameter.
+	
+</p>
+<p>
+	  The entire Request URI SHOULD NOT exceed 512 ASCII characters.
+	
+</p>
+<p>
+	  The contents of the resource referenced by the URL MUST be a Request Object.
+	  The scheme used in the
+	  <tt>request_uri</tt> value MUST be <tt>https</tt>,
+	  unless the target Request Object is signed in a way that is verifiable by the
+	  Authorization Server.
+	  The <tt>request_uri</tt> value MUST be reachable by the
+	  Authorization Server and SHOULD be reachable by the Client.
+	
+</p>
+<p>
+	  
+<p>The following is a non-normative example of
+	    the contents of a Request Object resource that can be
+	    referenced by a <tt>request_uri</tt>
+	    (with line wraps within values for display purposes only):
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  eyJhbGciOiJSUzI1NiIsImtpZCI6ImsyYmRjIn0.ew0KICJpc3MiOiAiczZCaGRSa3
+  F0MyIsDQogImF1ZCI6ICJodHRwczovL3NlcnZlci5leGFtcGxlLmNvbSIsDQogInJl
+  c3BvbnNlX3R5cGUiOiAiY29kZSBpZF90b2tlbiIsDQogImNsaWVudF9pZCI6ICJzNk
+  JoZFJrcXQzIiwNCiAicmVkaXJlY3RfdXJpIjogImh0dHBzOi8vY2xpZW50LmV4YW1w
+  bGUub3JnL2NiIiwNCiAic2NvcGUiOiAib3BlbmlkIiwNCiAic3RhdGUiOiAiYWYwaW
+  Zqc2xka2oiLA0KICJub25jZSI6ICJuLTBTNl9XekEyTWoiLA0KICJtYXhfYWdlIjog
+  ODY0MDAsDQogImNsYWltcyI6IA0KICB7DQogICAidXNlcmluZm8iOiANCiAgICB7DQ
+  ogICAgICJnaXZlbl9uYW1lIjogeyJlc3NlbnRpYWwiOiB0cnVlfSwNCiAgICAgIm5p
+  Y2tuYW1lIjogbnVsbCwNCiAgICAgImVtYWlsIjogeyJlc3NlbnRpYWwiOiB0cnVlfS
+  wNCiAgICAgImVtYWlsX3ZlcmlmaWVkIjogeyJlc3NlbnRpYWwiOiB0cnVlfSwNCiAg
+  ICAgInBpY3R1cmUiOiBudWxsDQogICAgfSwNCiAgICJpZF90b2tlbiI6IA0KICAgIH
+  sNCiAgICAgImdlbmRlciI6IG51bGwsDQogICAgICJiaXJ0aGRhdGUiOiB7ImVzc2Vu
+  dGlhbCI6IHRydWV9LA0KICAgICAiYWNyIjogeyJ2YWx1ZXMiOiBbInVybjptYWNlOm
+  luY29tbW9uOmlhcDpzaWx2ZXIiXX0NCiAgICB9DQogIH0NCn0.nwwnNsk1-Zkbmnvs
+  F6zTHm8CHERFMGQPhos-EJcaH4Hh-sMgk8ePrGhw_trPYs8KQxsn6R9Emo_wHwajyF
+  KzuMXZFSZ3p6Mb8dkxtVyjoy2GIzvuJT_u7PkY2t8QU9hjBcHs68PkgjDVTrG1uRTx
+  0GxFbuPbj96tVuj11pTnmFCUR6IEOXKYr7iGOCRB3btfJhM0_AKQUfqKnRlrRscc8K
+  ol-cSLWoYE9l5QqholImzjT_cMnNIznW9E7CDyWXTsO70xnB4SkG6pXfLSjLLlxmPG
+  iyon_-Te111V8uE83IlzCYIb_NMXvtTIVc1jpspnTSD7xMbpL-2QgwUsAlMGzw
+</pre></div>
+	
+
+<a name="CreateRequestUri"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.2.1"></a><h3>6.2.1.&nbsp;
+URI Referencing the Request Object</h3>
+
+<p>
+	    The Client stores the Request Object resource either
+	    locally or remotely at a URL the Server can access.
+	    This URL is the Request URI, <tt>request_uri</tt>.
+	  
+</p>
+<p>
+	    If the Request Object includes requested values for Claims,
+	    it MUST NOT be revealed to anybody but the Authorization Server.
+	    As such, the <tt>request_uri</tt> MUST have
+	    appropriate entropy for its lifetime.
+	    It is RECOMMENDED that it be removed
+	    if it is known that it will not be used again
+	    or after a reasonable timeout
+	    unless access control measures are taken.
+	  
+</p>
+<p>The following is a non-normative example
+	    of a Request URI value
+	    (with line wraps within values for display purposes only):
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  https://client.example.org/request.jwt#
+    GkurKxf5T0Y-mnPFCHqWOMiZi4VS138cQO_V7PZHAdM
+</pre></div>
+<a name="UseRequestUri"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.2.2"></a><h3>6.2.2.&nbsp;
+Request using the "request_uri" Request Parameter</h3>
+
+<p>The Client sends the Authorization Request to the
+	  Authorization Endpoint.
+</p>
+<p>The following is a non-normative example
+	    of an Authorization Request using the <tt>request_uri</tt> parameter
+	    (with line wraps within values for display purposes only):
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  https://server.example.com/authorize?
+    response_type=code%20id_token
+    &amp;client_id=s6BhdRkqt3
+    &amp;request_uri=https%3A%2F%2Fclient.example.org%2Frequest.jwt
+    %23GkurKxf5T0Y-mnPFCHqWOMiZi4VS138cQO_V7PZHAdM
+    &amp;state=af0ifjsldkj&amp;nonce=n-0S6_WzA2Mj
+    &amp;scope=openid
+</pre></div>
+<a name="GetRequestUri"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.2.3"></a><h3>6.2.3.&nbsp;
+Authorization Server Fetches Request Object</h3>
+
+<p>Upon receipt of the Request, the Authorization Server MUST
+	  send an HTTP <tt>GET</tt> request to the <tt>request_uri</tt>
+	  to retrieve the referenced Request Object, unless it is already cached, and parse it
+	  to recreate the Authorization Request parameters.
+</p>
+<p>Note that the RP SHOULD use a unique URI for each
+	  request utilizing distinct parameters, or otherwise
+	  prevent the Authorization Server from caching the <tt>request_uri</tt>.
+	  
+</p>
+<p>The following is a non-normative example of this fetch
+	    process:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /request.jwt HTTP/1.1
+  Host: client.example.org
+</pre></div>
+<a name="RequestUriRationale"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.2.4"></a><h3>6.2.4.&nbsp;
+&quot;request_uri&quot; Rationale</h3>
+
+<p>
+	    There are several reasons that one might choose to use the
+	    <tt>request_uri</tt> parameter:
+	  
+</p>
+<p>
+	    </p>
+<ol class="text">
+<li>
+		The set of request parameters can become large and can exceed browser
+		URI size limitations.  Passing the request parameters by reference
+		can solve this problem.
+	      
+</li>
+<li>
+		Passing a <tt>request_uri</tt> value, rather than
+		a complete request by value, can reduce request latency.
+	      
+</li>
+<li>
+		Most requests for Claims from an RP are constant.
+		The <tt>request_uri</tt> is a way of creating
+		and sometimes also signing and encrypting a constant set of
+		request parameters in advance.
+		(The <tt>request_uri</tt> value becomes an "artifact"
+		representing a particular fixed set of request parameters.)
+	      
+</li>
+<li>
+		Pre-registering a fixed set of request parameters at Registration time
+		enables OPs to cache and pre-validate the request parameters at
+		Registration time, meaning they need not be retrieved at request time.
+	      
+</li>
+<li>
+		Pre-registering a fixed set of request parameters at
+		Registration time enables OPs to vet the contents of
+		the request from consumer protection and other points
+		of views, either itself or by utilizing a third party.
+	      
+</li>
+</ol><p>
+	  
+</p>
+<a name="JWTRequestValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.3"></a><h3>6.3.&nbsp;
+Validating JWT-Based Requests</h3>
+
+<p>
+	  When the <tt>request</tt> or
+	  <tt>request_uri</tt> Authorization Request parameters
+	  are used, additional steps must be performed to validate the
+	  Authentication Request beyond those specified in
+	  Sections <a class='info' href='#AuthRequestValidation'>3.1.2.2<span> (</span><span class='info'>Authentication Request Validation</span><span>)</span></a>,
+	  <a class='info' href='#ImplicitValidation'>3.2.2.2<span> (</span><span class='info'>Authentication Request Validation</span><span>)</span></a>, or
+	  <a class='info' href='#HybridValidation'>3.3.2.2<span> (</span><span class='info'>Authentication Request Validation</span><span>)</span></a>.
+	  These steps are to validate the JWT containing the Request Object
+	  and to validate the Request Object itself.
+
+	
+</p>
+<a name="EncryptedRequestObject"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.3.1"></a><h3>6.3.1.&nbsp;
+Encrypted Request Object</h3>
+
+<p>
+	    If the Authorization Server has advertised JWE encryption algorithms
+	    in the <tt>request_object_encryption_alg_values_supported</tt> and
+	    <tt>request_object_encryption_enc_values_supported</tt> elements of its
+	    Discovery document <a class='info' href='#OpenID.Discovery'>[OpenID.Discovery]<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., and E. Jay, &ldquo;OpenID Connect Discovery 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a>,
+	    or has supplied encryption algorithms by other means,
+	    these are used by the Client to encrypt the JWT.
+	  
+</p>
+<p>
+	    The Authorization Server MUST decrypt the JWT in accordance with
+	    the <a class='info' href='#JWE'>JSON Web Encryption<span> (</span><span class='info'>Jones, M. and J. Hildebrand, &ldquo;JSON Web Encryption (JWE),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWE] specification.
+	    The result MAY be either a signed or unsigned (unsecured) Request Object.
+	    In the former case, signature validation MUST be performed
+	    as defined in <a class='info' href='#SignedRequestObject'>Section&nbsp;6.3.2<span> (</span><span class='info'>Signed Request Object</span><span>)</span></a>.
+	  
+</p>
+<p>
+	    The Authorization Server MUST return an error if decryption fails.
+	  
+</p>
+<a name="SignedRequestObject"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.3.2"></a><h3>6.3.2.&nbsp;
+Signed Request Object</h3>
+
+<p>
+	    To perform Signature Validation,
+	    the <tt>alg</tt> Header Parameter in the JOSE Header MUST match the value
+	    of the <tt>request_object_signing_alg</tt> set during
+	    Client Registration <a class='info' href='#OpenID.Registration'>[OpenID.Registration]<span> (</span><span class='info'>Sakimura, N., Bradley, J., and M. Jones, &ldquo;OpenID Connect Dynamic Client Registration 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> or a value that was
+	    pre-registered by other means.
+	    The signature MUST be validated against the appropriate key
+	    for that <tt>client_id</tt>
+	    and algorithm.
+	  
+</p>
+<p>
+	    The Authorization Server MUST return an error if signature validation fails.
+	  
+</p>
+<a name="RequestParameterValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.3.3"></a><h3>6.3.3.&nbsp;
+Request Parameter Assembly and Validation</h3>
+
+<p>
+	    The Authorization Server MUST assemble
+	    the set of Authorization Request parameters to be used
+	    from the Request Object value
+	    and the OAuth 2.0 Authorization Request parameters
+	    (minus the <tt>request</tt> or
+	    <tt>request_uri</tt> parameters).
+	    If the same parameter exists both in
+	    the Request Object and the OAuth Authorization Request parameters,
+	    the parameter in the Request Object is used.
+	    Using the assembled set of Authorization Request parameters,
+	    the Authorization Server then validates the request
+	    the normal manner for the flow being used, as specified in
+	    Sections <a class='info' href='#AuthRequestValidation'>3.1.2.2<span> (</span><span class='info'>Authentication Request Validation</span><span>)</span></a>,
+	    <a class='info' href='#ImplicitValidation'>3.2.2.2<span> (</span><span class='info'>Authentication Request Validation</span><span>)</span></a>, or
+	    <a class='info' href='#HybridValidation'>3.3.2.2<span> (</span><span class='info'>Authentication Request Validation</span><span>)</span></a>.
+	  
+</p>
+<a name="SelfIssued"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7"></a><h3>7.&nbsp;
+Self-Issued OpenID Provider</h3>
+
+<p>
+	OpenID Connect supports Self-Issued OpenID Providers -
+	personal, self-hosted OPs that issue self-signed ID Tokens.
+	Self-Issued OPs use the special Issuer Identifier
+	<tt>https://self-issued.me</tt>.
+      
+</p>
+<p>
+	The messages used to communicate with Self-Issued OPs are
+	mostly the same as those used to communicate with other OPs.
+	Specifications for the few additional parameters used and
+	for the values of some parameters in the Self-Issued case
+	are defined in this section.
+      
+</p>
+<a name="SelfIssuedDiscovery"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.1"></a><h3>7.1.&nbsp;
+Self-Issued OpenID Provider Discovery</h3>
+
+<p>
+	  If the input identifier for the discovery process
+	  contains the domain self-issued.me, dynamic discovery is not performed.
+	  Instead, then the following static configuration values are used:
+	
+</p>
+<p>
+	  </p>
+<div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "authorization_endpoint":
+     "openid:",
+   "issuer":
+     "https://self-issued.me",
+   "scopes_supported":
+     ["openid", "profile", "email", "address", "phone"],
+   "response_types_supported":
+     ["id_token"],
+   "subject_types_supported":
+     ["pairwise"],
+   "id_token_signing_alg_values_supported":
+     ["RS256"],
+   "request_object_signing_alg_values_supported":
+     ["none", "RS256"]
+  }
+</pre></div><p>
+
+	
+</p>
+<p>
+	  NOTE:  The OpenID Foundation plans to host the OpenID Provider site
+	  <tt>https://self-issued.me/</tt>,
+	  including its WebFinger service, so that performing discovery on it
+	  returns the above static discovery information, enabling RPs
+	  to not need any special processing for discovery of the Self-Issued OP.
+	  This site will be hosted on an experimental basis.
+	  Production implementations should not take a dependency upon it
+	  without a subsequent commitment by the OpenID Foundation
+	  to host the site in a manner intended for production use.
+	
+</p>
+<a name="SelfIssuedRegistration"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.2"></a><h3>7.2.&nbsp;
+Self-Issued OpenID Provider Registration</h3>
+
+<p>
+	  When using a Self-Issued OP, registration is not required.
+	  The Client can proceed without registration as if it had
+	  registered with the OP and obtained the following
+	  Client Registration Response:
+	
+</p>
+<p>
+	  </p>
+<blockquote class="text"><dl>
+<dt>client_id</dt>
+<dd>
+	      
+	      <tt>redirect_uri</tt> value of the Client.
+	    
+</dd>
+<dt>client_secret_expires_at</dt>
+<dd>
+	      
+	      0
+	    
+</dd>
+</dl></blockquote><p>
+	
+</p>
+<p>
+	  NOTE:  The OpenID Foundation plans to host the (stateless) endpoint
+	  <tt>https://self-issued.me/registration/1.0/</tt>
+	  that returns the response above, enabling RPs to not need
+	  any special processing for registration with the Self-Issued OP.
+	  This site will be hosted on an experimental basis.
+	  Production implementations should not take a dependency upon it
+	  without a subsequent commitment by the OpenID Foundation
+	  to host the site in a manner intended for production use.
+	
+</p>
+<a name="RegistrationParameter"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.2.1"></a><h3>7.2.1.&nbsp;
+Providing Information with the "registration" Request Parameter</h3>
+
+<p>
+	    OpenID Connect defines the following Authorization Request parameter
+	    to enable Clients to provide additional registration information to
+	    Self-Issued OpenID Providers:
+
+	    </p>
+<blockquote class="text"><dl>
+<dt>registration</dt>
+<dd>
+		
+		OPTIONAL.
+		This parameter is used by the Client to provide information about itself
+		to a Self-Issued OP that would normally be provided to an OP during
+		Dynamic Client Registration.
+		The value is a JSON object containing Client metadata values,
+		as defined in Section 2.1 of the
+		<a class='info' href='#OpenID.Registration'>OpenID Connect Dynamic Client Registration 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., and M. Jones, &ldquo;OpenID Connect Dynamic Client Registration 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Registration]
+		specification.
+		The <tt>registration</tt> parameter SHOULD NOT be used
+		when the OP is not a Self-Issued OP.
+	      
+</dd>
+</dl></blockquote><p>
+	  
+</p>
+<p>
+	    None of this information is REQUIRED by Self-Issued OPs,
+	    so the use of this parameter is OPTIONAL.
+	  
+</p>
+<p>
+	    The <tt>registration</tt> parameter value is represented
+	    in an OAuth 2.0 request as a UTF-8 encoded JSON object
+	    (which ends up being form-urlencoded when passed as an OAuth parameter).
+	    When used in a Request Object value, per <a class='info' href='#RequestObject'>Section&nbsp;6.1<span> (</span><span class='info'>Passing a Request Object by Value</span><span>)</span></a>,
+	    the JSON object is used as the value of the
+	    <tt>registration</tt> member.
+	  
+</p>
+<p>
+	    The Registration parameters that would typically be used in requests
+	    to Self-Issued OPs are
+	    <tt>policy_uri</tt>,
+	    <tt>tos_uri</tt>, and
+	    <tt>logo_uri</tt>.
+	    If the Client uses more than one Redirection URI, the
+	    <tt>redirect_uris</tt>
+	    parameter would be used to register them.
+	    Finally, if the Client is requesting encrypted responses, it would typically use the
+	    <tt>jwks_uri</tt>,
+	    <tt>id_token_encrypted_response_alg</tt> and
+	    <tt>id_token_encrypted_response_enc</tt> parameters.
+	  
+</p>
+<a name="SelfIssuedRequest"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.3"></a><h3>7.3.&nbsp;
+Self-Issued OpenID Provider Request</h3>
+
+<p>
+	  The self-issued OP's Authorization Endpoint is the URI <tt>openid:</tt>.
+	
+</p>
+<p>The Client sends the Authentication Request to the Authorization Endpoint
+	with the following parameters:
+</p>
+<p>
+	  </p>
+<blockquote class="text"><dl>
+<dt>scope</dt>
+<dd>
+	      
+	      REQUIRED.
+	      <tt>scope</tt> parameter value,
+	      as specified in <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a>.
+	    
+</dd>
+<dt>response_type</dt>
+<dd>
+	      
+	      REQUIRED. Constant string value <tt>id_token</tt>.
+	    
+</dd>
+<dt>client_id</dt>
+<dd>
+	      
+	      REQUIRED.
+	      Client ID value for the Client, which in this case contains the
+	      <tt>redirect_uri</tt> value of the Client.
+	      Since the Client's
+	      <tt>redirect_uri</tt> URI value is communicated
+	      as the Client ID,
+	      a <tt>redirect_uri</tt> parameter
+	      is NOT REQUIRED to also be included in the request.
+	    
+</dd>
+<dt>id_token_hint</dt>
+<dd>
+	      
+	      OPTIONAL.
+	      <tt>id_token_hint</tt> parameter value,
+	      as specified in <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a>.
+	      Encrypting content to Self-Issued OPs is not supported.
+	    
+</dd>
+<dt>claims</dt>
+<dd>
+	      
+	      OPTIONAL.
+	      <tt>claims</tt> parameter value,
+	      as specified in <a class='info' href='#ClaimsParameter'>Section&nbsp;5.5<span> (</span><span class='info'>Requesting Claims using the &quot;claims&quot; Request Parameter</span><span>)</span></a>.
+	    
+</dd>
+<dt>registration</dt>
+<dd>
+	      
+	      OPTIONAL.
+	      This parameter is used by the Client to provide information about itself
+	      to a Self-Issued OP that would normally be provided to an OP during
+	      Dynamic Client Registration,
+	      as specified in <a class='info' href='#RegistrationParameter'>Section&nbsp;7.2.1<span> (</span><span class='info'>Providing Information with the &quot;registration&quot; Request Parameter</span><span>)</span></a>.
+	    
+</dd>
+<dt>request</dt>
+<dd>
+	      
+	      OPTIONAL.
+	      Request Object value, as specified in <a class='info' href='#RequestObject'>Section&nbsp;6.1<span> (</span><span class='info'>Passing a Request Object by Value</span><span>)</span></a>.
+	      Encrypting content to Self-Issued OPs is not supported.
+	    
+</dd>
+</dl></blockquote><p>
+	
+</p>
+<p>
+	  Other parameters MAY be sent.
+	  Note that all Claims are returned in the ID Token.
+	
+</p>
+<p>The entire URL MUST NOT exceed 2048 ASCII characters.
+</p>
+<p>
+	    The following is a non-normative example
+	    HTTP 302 redirect response by the Client, which triggers
+	    the User Agent to make an Authentication Request
+	    to the Self-Issued OpenID Provider
+	    (with line wraps within values for display purposes only):
+	  
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  HTTP/1.1 302 Found
+  Location: openid://?
+    response_type=id_token
+    &amp;client_id=https%3A%2F%2Fclient.example.org%2Fcb
+    &amp;scope=openid%20profile
+    &amp;state=af0ifjsldkj
+    &amp;nonce=n-0S6_WzA2Mj
+    &amp;registration=%7B%22logo_uri%22%3A%22https%3A%2F%2F
+      client.example.org%2Flogo.png%22%7D
+</pre></div>
+<a name="SelfIssuedResponse"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.4"></a><h3>7.4.&nbsp;
+Self-Issued OpenID Provider Response</h3>
+
+<p>
+	  OpenID Connect defines the following Claim
+	  for use in Self-Issued OpenID Provider Responses:
+
+	  </p>
+<blockquote class="text"><dl>
+<dt>sub_jwk</dt>
+<dd>
+	      
+	      REQUIRED.
+	      Public key used to check the signature of an ID Token
+	      issued by a Self-Issued OpenID Provider,
+	      as specified in <a class='info' href='#SelfIssued'>Section&nbsp;7<span> (</span><span class='info'>Self-Issued OpenID Provider</span><span>)</span></a>.
+	      The key is a bare key in JWK <a class='info' href='#JWK'>[JWK]<span> (</span><span class='info'>Jones, M., &ldquo;JSON Web Key (JWK),&rdquo; May&nbsp;2015.</span><span>)</span></a> format
+	      (not an X.509 certificate value).
+	      The <tt>sub_jwk</tt> value is a JSON object.
+	      Use of the <tt>sub_jwk</tt> Claim
+	      is NOT RECOMMENDED when the OP is not Self-Issued.
+	    
+</dd>
+</dl></blockquote><p>
+	
+</p>
+<p>
+	  The Self-Issued OpenID Provider response is the same as the normal Implicit Flow
+	  response with the following refinements.  Since it is an Implicit Flow
+	  response, the response parameters will be returned in the URL fragment component,
+	  unless a different Response Mode was specified.
+	
+</p>
+<p>
+	  </p>
+<ol class="text">
+<li>
+	      The <tt>iss</tt> (issuer) Claim Value is
+	      <tt>https://self-issued.me</tt>.
+	    
+</li>
+<li>
+	      A <tt>sub_jwk</tt> Claim is present, with its value being
+	      the public key used to check the signature of the ID Token.
+	    
+</li>
+<li>
+	      The <tt>sub</tt> (subject) Claim
+	      value is the base64url-encoded representation of
+	      the thumbprint of
+	      the key in the <tt>sub_jwk</tt> Claim.
+	      This thumbprint value is computed as
+	      the SHA-256 hash of
+	      the octets of the UTF-8 representation of
+	      a JWK constructed containing only the REQUIRED members to represent the key,
+	      with the member names sorted into lexicographic order,
+	      and with no whitespace or line breaks.
+	      For instance,
+	      when the <tt>kty</tt> value is
+	      <tt>RSA</tt>, the member names
+	      <tt>e</tt>,
+	      <tt>kty</tt>, and
+	      <tt>n</tt>
+	      are the ones present in the constructed JWK used
+	      in the thumbprint computation and appear in that order;
+	      when the <tt>kty</tt> value is
+	      <tt>EC</tt>, the member names
+	      <tt>crv</tt>,
+	      <tt>kty</tt>,
+	      <tt>x</tt>, and
+	      <tt>y</tt>
+	      are present in that order.
+	      Note that this thumbprint calculation is the same as that defined in
+	      the JWK Thumbprint <a class='info' href='#JWK.Thumbprint'>[JWK.Thumbprint]<span> (</span><span class='info'>Jones, M. and N. Sakimura, &ldquo;JSON Web Key (JWK) Thumbprint,&rdquo; September&nbsp;2015.</span><span>)</span></a> specification.
+	    
+</li>
+<li>
+	      No Access Token is returned for accessing a UserInfo Endpoint,
+	      so all Claims returned MUST be in the ID Token.
+	    
+</li>
+</ol><p>
+	
+</p>
+<a name="SelfIssuedValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.5"></a><h3>7.5.&nbsp;
+Self-Issued ID Token Validation</h3>
+
+<p>
+	  To validate the ID Token received, the Client MUST do the following:
+	
+</p>
+<p>
+	  </p>
+<ol class="text">
+<li>
+	      The Client MUST validate that the value of the <tt>iss</tt> (issuer) Claim is <tt>https://self-issued.me</tt>.
+	      If <tt>iss</tt> contains a different value,
+	      the ID Token is not Self-Issued, and instead
+	      it MUST be validated according to
+	      <a class='info' href='#IDTokenValidation'>Section&nbsp;3.1.3.7<span> (</span><span class='info'>ID Token Validation</span><span>)</span></a>.
+	    
+</li>
+<li>
+	      The Client MUST validate that the
+	      <tt>aud</tt> (audience) Claim
+	      contains the value of the <tt>redirect_uri</tt>
+	      that the Client sent in the Authentication Request as an audience.
+	    
+</li>
+<li>
+	      The Client MUST validate the signature of the ID Token according to
+	      <a class='info' href='#JWS'>JWS<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Signature (JWS),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWS] using the algorithm specified in the
+	      <tt>alg</tt> Header Parameter of the JOSE Header,
+	      using the key in the <tt>sub_jwk</tt> Claim;
+	      the key is a bare key in JWK format
+	      (not an X.509 certificate value).
+	    
+</li>
+<li>
+	      The <tt>alg</tt> value SHOULD be the default of
+	      <tt>RS256</tt>.
+	      It MAY also be <tt>ES256</tt>.
+	    
+</li>
+<li>
+	      The Client MUST validate that the <tt>sub</tt> Claim
+	      value is the base64url-encoded representation of
+	      the thumbprint of
+	      the key in the <tt>sub_jwk</tt> Claim,
+	      as specified in <a class='info' href='#SelfIssuedResponse'>Section&nbsp;7.4<span> (</span><span class='info'>Self-Issued OpenID Provider Response</span><span>)</span></a>.
+	    
+</li>
+<li>
+	      The current time MUST be before the time represented by the
+	      <tt>exp</tt> Claim
+	      (possibly allowing for some small leeway to account for clock skew).
+	    
+</li>
+<li>
+	      The <tt>iat</tt> Claim can be used to reject tokens that
+	      were issued too far away from the current time, limiting the amount of
+	      time that nonces need to be stored to prevent attacks.
+	      The acceptable range is Client specific.
+	    
+</li>
+<li>
+	      A <tt>nonce</tt> Claim MUST be present
+	      and its value checked to verify that
+	      it is the same value as the one that was sent in the Authentication Request.
+	      The Client SHOULD check the <tt>nonce</tt> value
+	      for replay attacks.
+	      The precise method for detecting replay attacks is Client specific.
+	    
+</li>
+</ol><p>
+	
+</p>
+<p>The following is a non-normative example of a base64url-decoded
+	  Self-Issued ID Token
+	  (with line wraps within values for display purposes only):
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "iss": "https://self-issued.me",
+   "sub": "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs",
+   "aud": "https://client.example.org/cb",
+   "nonce": "n-0S6_WzA2Mj",
+   "exp": 1311281970,
+   "iat": 1311280970,
+   "sub_jwk": {
+     "kty":"RSA",
+     "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx
+     4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMs
+     tn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2
+     QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbI
+     SD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqb
+     w0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+     "e":"AQAB"
+    }
+  }
+</pre></div>
+<a name="SubjectIDTypes"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8"></a><h3>8.&nbsp;
+Subject Identifier Types</h3>
+
+<p>
+	A Subject Identifier is a locally unique and never
+	reassigned identifier within the Issuer for the End-User,
+	which is intended to be consumed by the Client.
+	Two Subject Identifier types are defined by this specification:
+
+	</p>
+<blockquote class="text"><dl>
+<dt>public</dt>
+<dd>
+	    
+	    This provides the same <tt>sub</tt> (subject) value to all Clients.
+	    It is the default if the provider has no <tt>subject_types_supported</tt>
+	    element in its discovery document.
+	  
+</dd>
+<dt>pairwise</dt>
+<dd>
+	    
+	    This provides a different <tt>sub</tt>
+	    value to each Client, so as not to enable Clients to correlate
+	    the End-User's activities without permission.
+	  
+</dd>
+</dl></blockquote><p>
+      
+</p>
+<p>
+	The OpenID Provider's Discovery document MUST list
+	its supported Subject Identifier types in the
+	<tt>subject_types_supported</tt> element.
+	If there is more than one type listed in the array, the Client MAY elect to
+	provide its preferred identifier type using the
+	<tt>subject_type</tt> parameter during Registration.
+      
+</p>
+<a name="PairwiseAlg"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.1"></a><h3>8.1.&nbsp;
+Pairwise Identifier Algorithm</h3>
+
+<p>
+	  When pairwise Subject Identifiers are used,
+	  the OpenID Provider MUST calculate a unique
+	  <tt>sub</tt> (subject) value for each
+	  Sector Identifier.  The Subject Identifier value MUST NOT be reversible
+	  by any party other than the OpenID Provider.
+	
+</p>
+<p>
+	  Providers that use pairwise <tt>sub</tt> values
+	  and support
+	  <a class='info' href='#OpenID.Registration'>Dynamic Client Registration<span> (</span><span class='info'>Sakimura, N., Bradley, J., and M. Jones, &ldquo;OpenID Connect Dynamic Client Registration 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Registration]
+	  SHOULD use the <tt>sector_identifier_uri</tt> parameter.
+	  It provides a way for a group of websites under common administrative
+	  control to have consistent pairwise <tt>sub</tt>
+	  values independent of the individual domain names.
+	  It also provides a way for Clients to change
+	  <tt>redirect_uri</tt> domains without having to
+	  re-register all of their users.
+	
+</p>
+<p>If the Client has not provided a value for
+	<tt>sector_identifier_uri</tt> in
+	<a class='info' href='#OpenID.Registration'>Dynamic Client Registration<span> (</span><span class='info'>Sakimura, N., Bradley, J., and M. Jones, &ldquo;OpenID Connect Dynamic Client Registration 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Registration],
+	the Sector Identifier
+	used for pairwise identifier calculation is the host component
+	of the registered <tt>redirect_uri</tt>.
+	If there are multiple hostnames in the registered
+	<tt>redirect_uris</tt>, the Client MUST register a
+	<tt>sector_identifier_uri</tt>.
+</p>
+<p>When a <tt>sector_identifier_uri</tt>
+	is provided, the host component of that URL is used as
+	the Sector Identifier for the pairwise identifier calculation.
+	The value of the <tt>sector_identifier_uri</tt>
+	MUST be a URL using the <tt>https</tt> scheme that points to
+	a JSON file containing an array of
+	<tt>redirect_uri</tt> values.
+	The values of the registered <tt>redirect_uris</tt>
+	MUST be included in the elements of the array.
+	
+</p>
+<p>
+	  Any algorithm with the following properties
+	  can be used by OpenID Providers to
+	  calculate pairwise Subject Identifiers:
+
+	  </p>
+<ul class="text">
+<li>
+	      The Subject Identifier value MUST NOT be reversible
+	      by any party other than the OpenID Provider.
+	    
+</li>
+<li>
+	      Distinct Sector Identifier values MUST result in
+	      distinct Subject Identifier values.
+	    
+</li>
+<li>
+	      The algorithm MUST be deterministic.
+	    
+</li>
+</ul><p>
+	
+</p>
+<p>
+	  Three example methods are:
+
+	  </p>
+<ol class="text">
+<li>
+	      The Sector Identifier can be concatenated with a local account ID and a salt
+	      value that is kept secret by the Provider. The concatenated string is then
+	      hashed using an appropriate algorithm.
+	      <br />
+<br />
+
+	      Calculate <tt>sub</tt> = SHA-256 ( sector_identifier || local_account_id || salt ).
+	      <br />
+<br />
+
+	    
+</li>
+<li>
+	      The Sector Identifier can be concatenated with a local account ID and a salt
+	      value that is kept secret by the Provider. The concatenated string is then
+	      encrypted using an appropriate algorithm.
+	      <br />
+<br />
+
+	      Calculate <tt>sub</tt> = AES-128 ( sector_identifier || local_account_id || salt ).
+	      <br />
+<br />
+
+	    
+</li>
+<li>
+	      The Issuer creates a Globally Unique Identifier (GUID) for the pair of
+	      Sector Identifier and local account ID and stores this value.
+	    
+</li>
+</ol><p>
+	
+</p>
+<a name="ClientAuthentication"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.9"></a><h3>9.&nbsp;
+Client Authentication</h3>
+
+<p>
+	This section defines a set of Client Authentication methods
+	that are used by Clients to authenticate to the Authorization Server
+	when using the Token Endpoint.
+	During Client Registration, the RP (Client) MAY register a Client Authentication method.
+	If no method is registered, the default method is <tt>client_secret_basic</tt>.
+      
+</p>
+<p>These Client Authentication methods are:
+</p>
+<p>
+	</p>
+<blockquote class="text"><dl>
+<dt>client_secret_basic</dt>
+<dd>
+	    
+	    Clients that have received a <tt>client_secret</tt> value
+	    from the Authorization Server authenticate with the Authorization Server
+	    in accordance with Section 2.3.1 of <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749] using the HTTP Basic authentication scheme.
+	  
+</dd>
+<dt>client_secret_post</dt>
+<dd>
+	    
+	    Clients that have received a <tt>client_secret</tt> value
+	    from the Authorization Server, authenticate with the Authorization Server
+	    in accordance with Section 2.3.1 of <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749] by including the Client Credentials in the request body.
+	  
+</dd>
+<dt>client_secret_jwt</dt>
+<dd>
+	    
+	    Clients that have received a <tt>client_secret</tt> value
+	    from the Authorization Server create a JWT using an
+	    HMAC SHA algorithm, such as HMAC SHA-256.
+	    The HMAC (Hash-based Message Authentication Code) is calculated using
+	    the octets of the UTF-8 representation of
+	    the <tt>client_secret</tt> as the shared key.
+	  
+</dd>
+<dt></dt>
+<dd>
+	    The Client authenticates in accordance with  <a class='info' href='#OAuth.JWT'>JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants<span> (</span><span class='info'>Jones, M., Campbell, B., and C. Mortimore, &ldquo;JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants,&rdquo; May&nbsp;2015.</span><span>)</span></a> [OAuth.JWT] and
+	    <a class='info' href='#OAuth.Assertions'>Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants<span> (</span><span class='info'>Campbell, B., Mortimore, C., Jones, M., and Y. Goland, &ldquo;Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants,&rdquo; May&nbsp;2015.</span><span>)</span></a> [OAuth.Assertions].
+	    The JWT MUST contain the following REQUIRED Claim Values and
+	    MAY contain the following OPTIONAL Claim Values:
+	  
+</dd>
+<dt></dt>
+<dd>
+	    
+<blockquote class="text"><dl>
+<dt>iss</dt>
+<dd>
+		
+		REQUIRED.
+		Issuer.
+		This MUST contain the <tt>client_id</tt> of the OAuth Client.
+	      
+</dd>
+<dt>sub</dt>
+<dd>
+		
+		REQUIRED.
+		Subject.
+		This MUST contain the <tt>client_id</tt> of the OAuth Client.
+	      
+</dd>
+<dt>aud</dt>
+<dd>
+		
+		REQUIRED.
+		Audience.
+		The <tt>aud</tt> (audience) Claim.
+		Value that identifies the Authorization Server as an intended audience.
+		The Authorization Server MUST verify that it is an intended audience
+		for the token.
+		The Audience SHOULD be the URL of the
+		Authorization Server's Token Endpoint.
+	      
+</dd>
+<dt>jti</dt>
+<dd>
+		
+		REQUIRED.
+		JWT ID.
+		A unique identifier for the token,
+		which can be used to prevent reuse of the token.
+		These tokens MUST only be used once,
+		unless conditions for reuse were negotiated between the parties;
+		any such negotiation is beyond the scope of this specification.
+	      
+</dd>
+<dt>exp</dt>
+<dd>
+		
+		REQUIRED.
+		Expiration time on or after which the JWT MUST NOT be
+		accepted for processing.
+	      
+</dd>
+<dt>iat</dt>
+<dd>
+		
+		OPTIONAL.
+		Time at which the JWT was issued.
+	      
+</dd>
+</dl></blockquote>
+	  
+</dd>
+<dt></dt>
+<dd>
+	    The JWT MAY contain other Claims.
+	    Any Claims used that are not understood MUST be ignored.
+	  
+</dd>
+<dt></dt>
+<dd>The authentication token MUST be sent as the value of the
+	  <a class='info' href='#OAuth.Assertions'>[OAuth.Assertions]<span> (</span><span class='info'>Campbell, B., Mortimore, C., Jones, M., and Y. Goland, &ldquo;Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants,&rdquo; May&nbsp;2015.</span><span>)</span></a>
+	  <tt>client_assertion</tt> parameter.
+</dd>
+<dt></dt>
+<dd>The value of the
+	  <a class='info' href='#OAuth.Assertions'>[OAuth.Assertions]<span> (</span><span class='info'>Campbell, B., Mortimore, C., Jones, M., and Y. Goland, &ldquo;Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants,&rdquo; May&nbsp;2015.</span><span>)</span></a>
+	  <tt>client_assertion_type</tt> parameter
+	  MUST be "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+	  per <a class='info' href='#OAuth.JWT'>[OAuth.JWT]<span> (</span><span class='info'>Jones, M., Campbell, B., and C. Mortimore, &ldquo;JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants,&rdquo; May&nbsp;2015.</span><span>)</span></a>.
+</dd>
+<dt>private_key_jwt</dt>
+<dd>
+	    
+	    Clients that have registered a public key sign a JWT using
+	    that key.
+	    The Client authenticates in accordance with  <a class='info' href='#OAuth.JWT'>JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants<span> (</span><span class='info'>Jones, M., Campbell, B., and C. Mortimore, &ldquo;JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants,&rdquo; May&nbsp;2015.</span><span>)</span></a> [OAuth.JWT] and
+	    <a class='info' href='#OAuth.Assertions'>Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants<span> (</span><span class='info'>Campbell, B., Mortimore, C., Jones, M., and Y. Goland, &ldquo;Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants,&rdquo; May&nbsp;2015.</span><span>)</span></a> [OAuth.Assertions].
+	    The JWT MUST contain the following REQUIRED Claim Values and
+	  MAY contain the following OPTIONAL Claim Values:
+</dd>
+<dt></dt>
+<dd>
+	    
+<blockquote class="text"><dl>
+<dt>iss</dt>
+<dd>
+		
+		REQUIRED.
+		Issuer.
+		This MUST contain the <tt>client_id</tt> of the OAuth Client.
+	      
+</dd>
+<dt>sub</dt>
+<dd>
+		
+		REQUIRED.
+		Subject.
+		This MUST contain the <tt>client_id</tt> of the OAuth Client.
+	      
+</dd>
+<dt>aud</dt>
+<dd>
+		
+		REQUIRED.
+		Audience.
+		The <tt>aud</tt> (audience) Claim.
+		Value that identifies the Authorization Server as an intended audience.
+		The Authorization Server MUST verify that it is an intended audience
+		for the token.
+		The Audience SHOULD be the URL of the
+		Authorization Server's Token Endpoint.
+	      
+</dd>
+<dt>jti</dt>
+<dd>
+		
+		REQUIRED.
+		JWT ID.
+		A unique identifier for the token,
+		which can be used to prevent reuse of the token.
+		These tokens MUST only be used once,
+		unless conditions for reuse were negotiated between the parties;
+		any such negotiation is beyond the scope of this specification.
+	      
+</dd>
+<dt>exp</dt>
+<dd>
+		
+		REQUIRED.
+		Expiration time on or after which the JWT MUST NOT be
+		accepted for processing.
+	      
+</dd>
+<dt>iat</dt>
+<dd>
+		
+		OPTIONAL.
+		Time at which the JWT was issued.
+	      
+</dd>
+</dl></blockquote>
+	  
+</dd>
+<dt></dt>
+<dd>
+	    The JWT MAY contain other Claims.
+	    Any Claims used that are not understood MUST be ignored.
+	  
+</dd>
+<dt></dt>
+<dd>The authentication token MUST be sent as the value of the
+	  <a class='info' href='#OAuth.Assertions'>[OAuth.Assertions]<span> (</span><span class='info'>Campbell, B., Mortimore, C., Jones, M., and Y. Goland, &ldquo;Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants,&rdquo; May&nbsp;2015.</span><span>)</span></a>
+	  <tt>client_assertion</tt> parameter.
+</dd>
+<dt></dt>
+<dd>The value of the
+	  <a class='info' href='#OAuth.Assertions'>[OAuth.Assertions]<span> (</span><span class='info'>Campbell, B., Mortimore, C., Jones, M., and Y. Goland, &ldquo;Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants,&rdquo; May&nbsp;2015.</span><span>)</span></a>
+	  <tt>client_assertion_type</tt> parameter
+	  MUST be "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+	  per <a class='info' href='#OAuth.JWT'>[OAuth.JWT]<span> (</span><span class='info'>Jones, M., Campbell, B., and C. Mortimore, &ldquo;JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants,&rdquo; May&nbsp;2015.</span><span>)</span></a>.
+</dd>
+<dt></dt>
+<dd>
+	    
+<p>
+		For example
+		(with line wraps within values for display purposes only):
+	      
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  POST /token HTTP/1.1
+  Host: server.example.com
+  Content-Type: application/x-www-form-urlencoded
+
+  grant_type=authorization_code&amp;
+    code=i1WsRn1uB1&amp;
+    client_id=s6BhdRkqt3&amp;
+    client_assertion_type=
+    urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&amp;
+    client_assertion=PHNhbWxwOl ... ZT
+</pre></div>
+	  
+</dd>
+<dt>none</dt>
+<dd>
+	    
+	    The Client does not authenticate itself at the Token Endpoint,
+	    either because it uses only the Implicit Flow (and so does not use the Token Endpoint)
+	    or because it is a Public Client with no Client Secret or other authentication mechanism.
+	  
+</dd>
+</dl></blockquote><p>
+      
+</p>
+<a name="SigEnc"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.10"></a><h3>10.&nbsp;
+Signatures and Encryption</h3>
+
+<p>
+	Depending on the transport through which the messages are sent, the
+	integrity of the message might not be guaranteed and the originator of the
+	message might not be authenticated. To mitigate these risks,
+	ID Token, UserInfo Response, Request Object,
+	and Client Authentication JWT values can utilize
+	<a class='info' href='#JWS'>JSON Web Signature (JWS)<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Signature (JWS),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWS] to sign their contents.
+	To achieve message confidentiality, these values can also use
+	<a class='info' href='#JWE'>JSON Web Encryption (JWE)<span> (</span><span class='info'>Jones, M. and J. Hildebrand, &ldquo;JSON Web Encryption (JWE),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWE] to encrypt their contents.
+      
+</p>
+<p>
+	When the message is both signed and encrypted, it MUST be
+	signed first and then encrypted, per <a class='info' href='#SigningOrder'>Section&nbsp;16.14<span> (</span><span class='info'>Signing and Encryption Order</span><span>)</span></a>,
+	with the result being a Nested JWT, as specified in <a class='info' href='#JWT'>[JWT]<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a>.
+	Note that all JWE encryption methods perform integrity checking.
+      
+</p>
+<p>
+	The OP advertises its supported signing and encryption algorithms
+	in its Discovery document
+	or may supply this information by other means.
+	The RP declares its required signing and encryption algorithms
+	in its Dynamic Registration request
+	or may communicate this information by other means.
+      
+</p>
+<p>
+	The OP advertises its public keys
+	via its Discovery document
+	or may supply this information by other means.
+	The RP declares its public keys
+	via its Dynamic Registration request
+	or may communicate this information by other means.
+      
+</p>
+<a name="Signing"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.10.1"></a><h3>10.1.&nbsp;
+Signing</h3>
+
+<p>
+	  The signing party MUST select a signature algorithm
+	  based on the algorithms supported by the recipient.
+	
+</p>
+<p>
+	  </p>
+<blockquote class="text"><dl>
+<dt>Asymmetric Signatures</dt>
+<dd>
+	      
+	      When using RSA or ECDSA Signatures,
+	      the <tt>alg</tt> Header Parameter value
+	      of the JOSE Header MUST be set to an appropriate algorithm
+	      as defined in <a class='info' href='#JWA'>JSON Web Algorithms<span> (</span><span class='info'>Jones, M., &ldquo;JSON Web Algorithms (JWA),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWA].
+	      The private key used to sign the content MUST be associated with
+	      a public key used for signature verification published by the sender
+	      in its JWK Set document.
+	      If there are multiple keys in the referenced JWK Set document, a
+	      <tt>kid</tt> value MUST be provided in the JOSE Header.
+	      The key usage of the respective keys MUST support signing.
+	    
+</dd>
+<dt>Symmetric Signatures</dt>
+<dd>
+	      
+	      When using MAC-based signatures,
+	      the <tt>alg</tt> Header Parameter value
+	      of the JOSE Header MUST be set to a MAC algorithm,
+	      as defined in <a class='info' href='#JWA'>JSON Web Algorithms<span> (</span><span class='info'>Jones, M., &ldquo;JSON Web Algorithms (JWA),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWA].
+	      The MAC key used is
+	      the octets of the UTF-8 representation of
+	      the <tt>client_secret</tt> value.
+	      See <a class='info' href='#SymmetricKeyEntropy'>Section&nbsp;16.19<span> (</span><span class='info'>Symmetric Key Entropy</span><span>)</span></a> for a discussion of
+	      entropy requirements for <tt>client_secret</tt> values.
+	      Symmetric signatures MUST NOT be used by public (non-confidential) Clients
+	      because of their inability to keep secrets.
+	    
+</dd>
+</dl></blockquote><p>
+	
+</p>
+<p>
+	  See <a class='info' href='#NeedForSignedRequests'>Section&nbsp;16.20<span> (</span><span class='info'>Need for Signed Requests</span><span>)</span></a> for Security Considerations
+	  about the need for signed requests.
+	
+</p>
+<a name="RotateSigKeys"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.10.1.1"></a><h3>10.1.1.&nbsp;
+Rotation of Asymmetric Signing Keys</h3>
+
+<p>Rotation of signing keys can be accomplished with the following approach. The signer publishes
+	  its keys in a JWK Set at its <tt>jwks_uri</tt> location
+	  and includes the <tt>kid</tt> of the
+	  signing key in the JOSE Header of each message
+	  to indicate to the verifier which key is to be used to validate the signature. Keys can be rolled over
+	  by periodically adding new keys to the JWK Set at the <tt>jwks_uri</tt> location.
+	  The signer can begin using a new key at its
+	  discretion and signals the change to the verifier using the <tt>kid</tt> value.
+	  The verifier knows to go back to the <tt>jwks_uri</tt> location
+	  to re-retrieve the keys when it sees an unfamiliar
+	  <tt>kid</tt> value. The JWK Set document at the <tt>jwks_uri</tt>
+	  SHOULD retain recently decommissioned signing keys for a reasonable period of time to facilitate a
+	  smooth transition.
+	  
+</p>
+<a name="Encryption"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.10.2"></a><h3>10.2.&nbsp;
+Encryption</h3>
+
+<p>
+	  The encrypting party MUST select an encryption algorithm
+	  based on the algorithms supported by the recipient.
+	
+</p>
+<p>
+	  </p>
+<blockquote class="text"><dl>
+<dt>Asymmetric Encryption: RSA</dt>
+<dd>
+	      
+	      The public key to which the content was encrypted MUST be
+	      a public key used for encryption published by the recipient
+	      in its JWK Set document.
+	      If there are multiple keys in the referenced JWK Set document, a
+	      <tt>kid</tt> value MUST be provided in the JOSE Header.
+	      Use the supported RSA encryption algorithm to encrypt a random
+	      Content Encryption Key to be used for encrypting
+	      the signed JWT.
+	      The key usage of the respective keys MUST include encryption.
+	    
+</dd>
+<dt>Asymmetric Encryption: Elliptic Curve</dt>
+<dd>
+	      
+	      Create an ephemeral Elliptic Curve public key for the <tt>epk</tt>
+	      element of the JOSE Header.
+	      The other public key used for the key agreement computation MUST be
+	      a public key published by the recipient
+	      in its JWK Set document.
+	      If there are multiple keys in the referenced JWK Set document, a
+	      <tt>kid</tt> value MUST be provided in the JOSE Header.
+	      Use the ECDH-ES algorithm to agree upon a
+	      Content Encryption Key to be used for encrypting
+	      the signed JWT.
+	      The key usage of the respective keys MUST support encryption.
+	    
+</dd>
+<dt>Symmetric Encryption</dt>
+<dd>
+	      
+	      The symmetric encryption key is derived from the
+	      <tt>client_secret</tt> value by
+	      using the left-most bits of a truncated SHA-2 hash of
+	      the octets of the UTF-8 representation of
+	      the <tt>client_secret</tt>.
+	      For keys of 256 or fewer bits, SHA-256 is used;
+	      for keys of 257-384 bits, SHA-384 is used;
+	      for keys of 385-512 bits, SHA-512 is used.
+	      The hash value MUST be truncated retaining the left-most bits to the appropriate bit length
+	      for the AES key wrapping or direct encryption algorithm used,
+	      for instance, truncating the SHA-256 hash
+	      to 128 bits for <tt>A128KW</tt>.
+	      If a symmetric key with greater than 512 bits is needed, a different method
+	      of deriving the key from the <tt>client_secret</tt>
+	      would have to be defined by an extension.
+	      Symmetric encryption MUST NOT be used by public (non-confidential) Clients
+	      because of their inability to keep secrets.
+	    
+</dd>
+</dl></blockquote><p>
+	
+</p>
+<p>
+	  See <a class='info' href='#NeedForEncryptedRequests'>Section&nbsp;16.21<span> (</span><span class='info'>Need for Encrypted Requests</span><span>)</span></a> for Security Considerations
+	  about the need for encrypted requests.
+	
+</p>
+<a name="RotateEncKeys"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.10.2.1"></a><h3>10.2.1.&nbsp;
+Rotation of Asymmetric Encryption Keys</h3>
+
+<p>
+	    Rotating encryption keys necessarily uses a different process than the one for signing keys because
+	    the encrypting party starts the process and thus cannot rely on
+	    a change in <tt>kid</tt> as a signal
+	    that keys need to change. The encrypting party
+	    still uses the <tt>kid</tt> Header Parameter in the JWE
+	    to tell the decrypting party which private key to use to decrypt, however, the encrypting party
+	    needs to first select the most appropriate key from those provided in the JWK Set at
+	    the recipient's <tt>jwks_uri</tt> location.
+	  
+</p>
+<p>
+	    To rotate keys, the decrypting party can publish new keys
+	    at its <tt>jwks_uri</tt> location
+	    and remove from the JWK Set those that are being decommissioned.
+	    The <tt>jwks_uri</tt> SHOULD include a <tt>Cache-Control</tt>
+	    header in the response that contains a <tt>max-age</tt> directive,
+	    as defined in <a class='info' href='#RFC7234'>RFC 7234<span> (</span><span class='info'>Fielding, R., Ed., Nottingham, M., Ed., and J. Reschke, Ed., &ldquo;Hypertext Transfer Protocol (HTTP/1.1): Caching,&rdquo; June&nbsp;2014.</span><span>)</span></a> [RFC7234],
+	    which enables the encrypting party to safely cache the JWK Set and not have to re-retrieve
+	    the document for every encryption event. The decrypting party SHOULD remove decommissioned keys
+	    from the JWK Set referenced by <tt>jwks_uri</tt>
+	    but retain them internally for some reasonable
+	    period of time, coordinated with the cache duration, to facilitate a smooth transition between keys
+	    by allowing the encrypting party some time to obtain the new keys. The cache duration SHOULD also
+	    be coordinated with the issuance of new signing keys, as described in <a class='info' href='#RotateSigKeys'>Section&nbsp;10.1.1<span> (</span><span class='info'>Rotation of Asymmetric Signing Keys</span><span>)</span></a>.
+	  
+</p>
+<a name="OfflineAccess"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.11"></a><h3>11.&nbsp;
+Offline Access</h3>
+
+<p>
+	OpenID Connect defines the following <tt>scope</tt> value
+	to request offline access:
+
+	</p>
+<blockquote class="text"><dl>
+<dt>offline_access</dt>
+<dd>
+	    
+	    OPTIONAL. This scope value requests
+	    that an OAuth 2.0 Refresh Token be issued that can be used to
+	    obtain an Access Token that grants access to the End-User's
+	    UserInfo Endpoint even when the End-User is not present (not logged in).
+	  
+</dd>
+</dl></blockquote><p>
+      
+</p>
+<p>
+	When offline access is requested, a <tt>prompt</tt>
+	parameter value of <tt>consent</tt> MUST be used
+	unless other conditions for processing the request permitting offline access
+	to the requested resources are in place.
+	The OP MUST always obtain consent to returning a Refresh Token
+	that enables offline access to the requested resources.
+	A previously saved user consent is not always sufficient to grant offline access.
+      
+</p>
+<p>
+	Upon receipt of a scope parameter containing the
+	<tt>offline_access</tt> value, the Authorization Server:
+
+	</p>
+<ul class="text">
+<li>
+	    MUST ensure that the prompt parameter contains
+	    <tt>consent</tt>
+	    unless other conditions for processing the request permitting offline access
+	    to the requested resources are in place;
+	    unless one or both of these conditions are fulfilled, then
+	    it MUST ignore the <tt>offline_access</tt> request,
+	  
+</li>
+<li>
+	    MUST ignore the <tt>offline_access</tt> request
+	    unless the Client is using a <tt>response_type</tt>
+	    value that would result in an Authorization Code being returned,
+	  
+</li>
+<li>
+	    MUST explicitly receive or have consent for offline access when
+	    the registered <tt>application_type</tt>
+	    is <tt>web</tt>,
+	  
+</li>
+<li>
+	    SHOULD explicitly receive or have consent for offline access when
+	    the registered <tt>application_type</tt>
+	    is <tt>native</tt>.
+	  
+</li>
+</ul><p>
+
+	The use of Refresh Tokens is not exclusive to the
+	<tt>offline_access</tt> use case.
+	The Authorization Server MAY grant Refresh Tokens
+	in other contexts that are beyond the scope of this specification.
+      
+</p>
+<a name="RefreshTokens"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.12"></a><h3>12.&nbsp;
+Using Refresh Tokens</h3>
+
+<p>
+	A request to the Token Endpoint can also use a Refresh Token
+	by using the <tt>grant_type</tt> value
+	<tt>refresh_token</tt>,
+	as described in Section 6 of
+	<a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749].
+	This section defines the behaviors for OpenID Connect
+	Authorization Servers when Refresh Tokens are used.
+      
+</p>
+<a name="RefreshingAccessToken"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.12.1"></a><h3>12.1.&nbsp;
+Refresh Request</h3>
+
+<p>
+	  To refresh an Access Token, the Client MUST
+	  authenticate to the Token Endpoint using the authentication method registered
+	  for its <tt>client_id</tt>, as documented in
+	  <a class='info' href='#ClientAuthentication'>Section&nbsp;9<span> (</span><span class='info'>Client Authentication</span><span>)</span></a>.
+	  The Client sends the parameters via HTTP <tt>POST</tt>
+	  to the Token Endpoint using
+	  Form Serialization, per <a class='info' href='#FormSerialization'>Section&nbsp;13.2<span> (</span><span class='info'>Form Serialization</span><span>)</span></a>.
+	
+</p>
+<p>
+	    The following is a non-normative example of a
+	    Refresh Request
+	    (with line wraps within values for display purposes only):
+	  
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  POST /token HTTP/1.1
+  Host: server.example.com
+  Content-Type: application/x-www-form-urlencoded
+
+  client_id=s6BhdRkqt3
+    &amp;client_secret=some_secret12345
+    &amp;grant_type=refresh_token
+    &amp;refresh_token=8xLOxBtZp8
+    &amp;scope=openid%20profile
+</pre></div>
+<p>
+	  The Authorization Server MUST validate the Refresh Token,
+	  MUST verify that it was issued to the Client,
+	  and must verify that the Client successfully authenticated
+	  it has a Client Authentication method.
+	
+</p>
+<a name="RefreshTokenResponse"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.12.2"></a><h3>12.2.&nbsp;
+Successful Refresh Response</h3>
+
+<p>
+	  Upon successful validation of the Refresh Token,
+	  the response body is the Token Response of <a class='info' href='#TokenResponse'>Section&nbsp;3.1.3.3<span> (</span><span class='info'>Successful Token Response</span><span>)</span></a>
+	  except that it might not contain an <tt>id_token</tt>.
+	
+</p>
+<p>
+	  If an ID Token is returned as a result of a token refresh request,
+	  the following requirements apply:
+	  </p>
+<ul class="text">
+<li>
+	      its <tt>iss</tt> Claim Value MUST be the same as
+	      in the ID Token issued when the original authentication occurred,
+	    
+</li>
+<li>
+	      its <tt>sub</tt> Claim Value MUST be the same as
+	      in the ID Token issued when the original authentication occurred,
+	    
+</li>
+<li>
+	      its <tt>iat</tt> Claim MUST represent
+	      the time that the new ID Token is issued,
+	    
+</li>
+<li>
+	      its <tt>aud</tt> Claim Value MUST be the same as
+	      in the ID Token issued when the original authentication occurred,
+	    
+</li>
+<li>
+	      if the ID Token contains an <tt>auth_time</tt> Claim,
+	      its value MUST represent the time of the original authentication - not
+	      the time that the new ID token is issued,
+	    
+</li>
+<li>
+	      if the implementation is using extensions
+	      (which are beyond the scope of this specification)
+	      that result in
+	      the <tt>azp</tt> (authorized party) Claim being present,
+	      those extensions might specify that
+	      its <tt>azp</tt> Claim Value MUST be the same as
+	      in the ID Token issued when the original authentication occurred;
+	      likewise, they might specify that
+	      if no <tt>azp</tt> Claim was present in the original
+	      ID Token, one MUST NOT be present in the new ID Token,
+	    
+</li>
+<li>
+	      it SHOULD NOT have a <tt>nonce</tt> Claim,
+	      even when the ID Token issued
+	      at the time of the original authentication
+	      contained <tt>nonce</tt>;
+	      however, if it is present,
+	      its value MUST be the same as in the ID Token issued
+	      at the time of the original authentication,
+	      and
+	    
+</li>
+<li>
+	      otherwise, the same rules apply as apply when issuing an ID Token
+	      at the time of the original authentication.
+	    
+</li>
+</ul><p>
+	
+</p>
+<p>
+	    The following is a non-normative example of a
+	    Refresh Response:
+	  
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+  Cache-Control: no-store
+
+  {
+   "access_token": "TlBN45jURg",
+   "token_type": "Bearer",
+   "refresh_token": "9yNOxJtZa5",
+   "expires_in": 3600
+  }
+</pre></div>
+<a name="RefreshErrorResponse"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.12.3"></a><h3>12.3.&nbsp;
+Refresh Error Response</h3>
+
+<p>If the Refresh Request is invalid or unauthorized, the
+	Authorization Server returns the
+	Token Error Response as defined in Section 5.2 of <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749].
+</p>
+<a name="Serializations"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.13"></a><h3>13.&nbsp;
+Serializations</h3>
+
+<p>
+	Messages are serialized using one of the following methods:
+        </p>
+<ol class="text">
+<li>Query String Serialization
+</li>
+<li>Form Serialization
+</li>
+<li>JSON Serialization
+</li>
+</ol><p>
+
+	This section describes the syntax of these serialization methods;
+	other sections describe when they can and must be used.
+	Note that not all methods can be used for all messages.
+      
+</p>
+<a name="QuerySerialization"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.13.1"></a><h3>13.1.&nbsp;
+Query String Serialization</h3>
+
+<p>In order to serialize the parameters using the Query String
+        Serialization, the Client constructs the string by adding the
+        parameters and values to the query component of a URL using the <tt>application/x-www-form-urlencoded</tt> format as
+        defined by <a class='info' href='#W3C.SPSD-html401-20180327'>[W3C.SPSD&#8209;html401&#8209;20180327]<span> (</span><span class='info'>, &ldquo;HTML 4.01 Specification,&rdquo; March&nbsp;2018.</span><span>)</span></a>.
+	Query String Serialization is typically used in
+	HTTP <tt>GET</tt> requests.
+	The same serialization method is also used when adding
+	parameters to the fragment component of a URL.
+	
+</p>
+<p>
+	    The following is a non-normative example of this serialization
+	    (with line wraps within values for display purposes only):
+	  
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /authorize?
+    response_type=code
+    &amp;scope=openid
+    &amp;client_id=s6BhdRkqt3
+    &amp;redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb HTTP/1.1
+  Host: server.example.com
+</pre></div>
+<a name="FormSerialization"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.13.2"></a><h3>13.2.&nbsp;
+Form Serialization</h3>
+
+<p>Parameters and their values are Form Serialized by adding the
+        parameter names and values to the entity body of the HTTP request using
+        the <tt>application/x-www-form-urlencoded</tt> format
+        as defined by <a class='info' href='#W3C.SPSD-html401-20180327'>[W3C.SPSD&#8209;html401&#8209;20180327]<span> (</span><span class='info'>, &ldquo;HTML 4.01 Specification,&rdquo; March&nbsp;2018.</span><span>)</span></a>.
+	Form Serialization is typically used in HTTP <tt>POST</tt> requests.
+</p>
+<p>
+	    The following is a non-normative example of this serialization
+	    (with line wraps within values for display purposes only):
+	  
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  POST /authorize HTTP/1.1
+  Host: server.example.com
+  Content-Type: application/x-www-form-urlencoded
+
+  response_type=code
+    &amp;scope=openid
+    &amp;client_id=s6BhdRkqt3
+    &amp;redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+</pre></div>
+<a name="JSONSerialization"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.13.3"></a><h3>13.3.&nbsp;
+JSON Serialization</h3>
+
+<p>
+	  The parameters are serialized into a JSON object structure by adding each
+	  parameter at the highest structure level. Parameter names and string
+	  values are represented as JSON strings.
+	  Numerical values are represented as JSON numbers.
+	  Boolean values are represented as JSON booleans.
+	  Omitted parameters and parameters with no value SHOULD be omitted
+	  from the object and not represented by
+	  a JSON <tt>null</tt> value, unless otherwise specified.
+	  A parameter MAY have a JSON object or a JSON array as its value.
+	
+</p>
+<p>
+	    The following is a non-normative example of this serialization:
+	  
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "access_token": "SlAV32hkKG",
+   "token_type": "Bearer",
+   "expires_in": 3600,
+   "refresh_token": "8xLOxBtZp8"
+  }
+</pre></div>
+<a name="StringOps"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.14"></a><h3>14.&nbsp;
+String Operations</h3>
+
+<p>
+	Processing some OpenID Connect messages requires comparing
+	values in the messages to known values. For example, the Claim
+	Names returned by the UserInfo Endpoint might be compared to
+	specific Claim Names such as <tt>sub</tt>.  Comparing Unicode <a class='info' href='#UNICODE'>[UNICODE]<span> (</span><span class='info'>The Unicode Consortium, &ldquo;The Unicode Standard,&rdquo; .</span><span>)</span></a> strings,
+	however, has significant security implications.
+      
+</p>
+<p>
+	Therefore, comparisons between JSON strings and other Unicode
+	strings MUST be performed as specified below:
+
+	</p>
+<ol class="text">
+<li>
+	    Remove any JSON applied escaping to produce an array of
+	    Unicode code points.
+	  
+</li>
+<li>
+	    Unicode Normalization <a class='info' href='#USA15'>[USA15]<span> (</span><span class='info'>Whistler, K., &ldquo;Unicode Normalization Forms,&rdquo; August&nbsp;2023.</span><span>)</span></a> MUST NOT
+	    be applied at any point to either the JSON string or to
+	    the string it is to be compared against.
+	  
+</li>
+<li>
+	    Comparisons between the two strings MUST be performed as a
+	    Unicode code point to code point equality comparison.
+	  
+</li>
+</ol><p>
+      
+</p>
+<p>
+	In several places, this specification uses space-delimited
+	lists of strings.  In all such cases, a single ASCII space
+	character (0x20) MUST be used as the delimiter.
+      
+</p>
+<a name="ImplementationConsiderations"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.15"></a><h3>15.&nbsp;
+Implementation Considerations</h3>
+
+<p>
+	This specification defines features used by both Relying Parties and
+	OpenID Providers.
+	It is expected that some OpenID Providers will require
+	static, out-of-band configuration of RPs using them,
+	whereas others will support dynamic usage by RPs without
+	a pre-established relationship between them.
+	For that reason, the mandatory-to-implement features for OPs
+	are listed below in two groups:
+	the first for all OPs and the second for "Dynamic" OpenID Providers.
+      
+</p>
+<a name="ServerMTI"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.15.1"></a><h3>15.1.&nbsp;
+Mandatory to Implement Features for All OpenID Providers</h3>
+
+<p>
+	  All OpenID Providers MUST implement the following features defined in this specification.
+	  This list augments the set of features that are already listed elsewhere
+	  as being "REQUIRED" or are described with a "MUST",
+	  and so is not, by itself, a comprehensive set of implementation requirements for OPs.
+	
+</p>
+<p>
+	  </p>
+<blockquote class="text"><dl>
+<dt>Signing ID Tokens with RSA SHA-256</dt>
+<dd>
+	      
+	      OPs MUST support signing ID Tokens with the RSA SHA-256 algorithm
+	      (an <tt>alg</tt> value of
+	      <tt>RS256</tt>),
+	      unless the OP only supports returning ID Tokens from the Token Endpoint
+	      (as is the case for the Authorization Code Flow)
+	      and only allows Clients to register specifying
+	      <tt>none</tt> as the requested ID Token signing algorithm.
+	    
+</dd>
+<dt>Prompt Parameter</dt>
+<dd>
+	      
+	      OPs MUST support the <tt>prompt</tt> parameter,
+	      as defined in <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a>, including the specified
+	      user interface behaviors such as <tt>none</tt>
+	      and <tt>login</tt>.
+	    
+</dd>
+<dt>Display Parameter</dt>
+<dd>
+	      
+	      OPs MUST support the <tt>display</tt> parameter,
+	      as defined in <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a>.
+	      (Note that the minimum level of support required for this parameter is
+	      simply that its use must not result in an error.)
+	    
+</dd>
+<dt>Preferred Locales</dt>
+<dd>
+	      
+	      OPs MUST support requests for preferred languages and scripts
+	      for the user interface and for Claims via the
+	      <tt>ui_locales</tt> and
+	      <tt>claims_locales</tt> request parameters,
+	      as defined in <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a>.
+	      (Note that the minimum level of support required for these parameters is
+	      simply to have their use not result in errors.)
+	    
+</dd>
+<dt>Authentication Time</dt>
+<dd>
+	      
+	      OPs MUST support returning the time at which the End-User authenticated
+	      via the <tt>auth_time</tt> Claim, when requested,
+	      as defined in <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a>.
+	    
+</dd>
+<dt>Maximum Authentication Age</dt>
+<dd>
+	      
+	      OPs MUST support enforcing a maximum authentication age
+	      via the <tt>max_age</tt> parameter,
+	      as defined in <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a>.
+	    
+</dd>
+<dt>Authentication Context Class Reference</dt>
+<dd>
+	      
+	      OPs MUST support requests for specific
+	      Authentication Context Class Reference values
+	      via the <tt>acr_values</tt> parameter,
+	      as defined in <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a>.
+	      (Note that the minimum level of support required for this parameter is
+	      simply to have its use not result in an error.)
+	    
+</dd>
+</dl></blockquote><p>
+	
+</p>
+<a name="DynamicMTI"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.15.2"></a><h3>15.2.&nbsp;
+Mandatory to Implement Features for Dynamic OpenID Providers</h3>
+
+<p>
+	  In addition to the features listed above,
+	  OpenID Providers supporting dynamic establishment of relationships with RPs
+	  that they do not have a pre-configured relationship with
+	  MUST also implement the following features defined in this and related specifications.
+	
+</p>
+<p>
+	  </p>
+<blockquote class="text"><dl>
+<dt>Response Types</dt>
+<dd>
+	      
+	      These OpenID Providers MUST support the
+	      <tt>id_token</tt> Response Type and
+	      all that are not Self-Issued OPs MUST also support the
+	      <tt>code</tt> and
+	      <tt>id_token&nbsp;token</tt> Response Types.
+	    
+</dd>
+<dt>Discovery</dt>
+<dd>
+	      
+	      These OPs MUST support Discovery,
+	      as defined in
+	      <a class='info' href='#OpenID.Discovery'>OpenID Connect Discovery 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., and E. Jay, &ldquo;OpenID Connect Discovery 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Discovery].
+	    
+</dd>
+<dt>Dynamic Registration</dt>
+<dd>
+	      
+	      These OPs MUST support Dynamic Client Registration,
+	      as defined in
+	      <a class='info' href='#OpenID.Registration'>OpenID Connect Dynamic Client Registration 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., and M. Jones, &ldquo;OpenID Connect Dynamic Client Registration 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Registration].
+	    
+</dd>
+<dt>UserInfo Endpoint</dt>
+<dd>
+	      
+	      All dynamic OPs that issue Access Tokens MUST support the UserInfo Endpoint,
+	      as defined in <a class='info' href='#UserInfo'>Section&nbsp;5.3<span> (</span><span class='info'>UserInfo Endpoint</span><span>)</span></a>.
+	      (Self-Issued OPs do not issue Access Tokens.)
+	    
+</dd>
+<dt>Public Keys Published as Bare Keys</dt>
+<dd>
+	      
+	      These OPs MUST publish their public keys as bare JWK keys
+	      (which MAY also be accompanied by X.509 representations of those keys).
+	    
+</dd>
+<dt>Request URI</dt>
+<dd>
+	      
+	      These OPs MUST support requests made using a Request Object value
+	      that is retrieved from a Request URI that is provided
+	      with the <tt>request_uri</tt> parameter,
+	      as defined in <a class='info' href='#RequestUriParameter'>Section&nbsp;6.2<span> (</span><span class='info'>Passing a Request Object by Reference</span><span>)</span></a>.
+	    
+</dd>
+</dl></blockquote><p>
+	
+</p>
+<a name="DiscoReg"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.15.3"></a><h3>15.3.&nbsp;
+Discovery and Registration</h3>
+
+<p>Some OpenID Connect installations can use a pre-configured set of
+	OpenID Providers and/or Relying Parties. In those cases, it might not be
+	necessary to support dynamic discovery of information about identities
+	or services or dynamic registration of Clients.
+</p>
+<p>However, if installations choose to support unanticipated
+	interactions between Relying Parties and OpenID Providers that do not
+	have pre-configured relationships, they SHOULD accomplish this by
+	implementing the facilities defined in the <a class='info' href='#OpenID.Discovery'>OpenID Connect Discovery 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., and E. Jay, &ldquo;OpenID Connect Discovery 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Discovery] and <a class='info' href='#OpenID.Registration'>OpenID Connect Dynamic Client Registration 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., and M. Jones, &ldquo;OpenID Connect Dynamic Client Registration 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Registration]
+	specifications.
+</p>
+<a name="RPMTI"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.15.4"></a><h3>15.4.&nbsp;
+Mandatory to Implement Features for Relying Parties</h3>
+
+<p>
+	  In general, it is up to Relying Parties which features they use
+	  when interacting with OpenID Providers.
+	  However, some choices are dictated by the nature of their OAuth Client,
+	  such as whether it is a Confidential Client, capable of keeping secrets,
+	  in which case the Authorization Code Flow may be appropriate,
+	  or whether it is a Public Client, for instance, a
+	  User Agent Based Application or a statically registered Native Application,
+	  in which case the Implicit Flow may be appropriate.
+	
+</p>
+<p>
+	  When using OpenID Connect features, those listed as being
+	  "REQUIRED" or are described with a "MUST" are
+	  mandatory to implement, when used by a Relying Party.
+	  Likewise, those features that are described as "OPTIONAL"
+	  need not be used or supported unless they provide value
+	  in the particular application context.
+	  Finally, when interacting with OpenID Providers that support Discovery,
+	  the OP's Discovery document can be used to dynamically determine
+	  which OP features are available for use by the RP.
+      
+</p>
+<p>
+	
+</p>
+<a name="ImplementationNotes"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.15.5"></a><h3>15.5.&nbsp;
+Implementation Notes</h3>
+
+<a name="CodeNotes"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.15.5.1"></a><h3>15.5.1.&nbsp;
+Authorization Code Implementation Notes</h3>
+
+<p>
+	    When using the Authorization Code or Hybrid flows,
+	    an ID Token is returned from the Token Endpoint
+	    in response to a Token Request using an Authorization Code.
+	    Some implementations may choose to encode state about
+	    the ID Token to be returned in the Authorization Code value.
+	    Others may use the Authorization Code value
+	    as an index into a database storing this state.
+	  
+</p>
+<a name="NonceNotes"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.15.5.2"></a><h3>15.5.2.&nbsp;
+Nonce Implementation Notes</h3>
+
+<p>
+	    The <tt>nonce</tt> parameter value needs to include
+	    per-session state and be unguessable to attackers.
+	    One method to achieve this for Web Server Clients is to store a cryptographically random value
+	    as an HttpOnly session cookie and use a cryptographic hash of the value
+	    as the <tt>nonce</tt> parameter.
+	    In that case, the <tt>nonce</tt> in the returned
+	    ID Token is compared to the hash of the session cookie
+	    to detect ID Token replay by third parties.
+	    A related method applicable to JavaScript Clients and other Browser-Based Clients is to store the cryptographically random value
+	    in HTML5 local storage and use a cryptographic hash of this value.
+	  
+</p>
+<a name="FragmentNotes"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.15.5.3"></a><h3>15.5.3.&nbsp;
+Redirect URI Fragment Handling Implementation Notes</h3>
+
+<p>
+	    When response parameters are returned in the Redirection URI fragment value,
+	    the Client needs to have the User Agent parse the fragment encoded values
+	    and pass them to on to the Client's processing logic for consumption.
+	    User Agents that have direct access to cryptographic APIs may be able to be
+	    self-contained, for instance, with all Client code being written in JavaScript.
+	  
+</p>
+<p>
+	    However, if the Client does not run entirely in the User Agent,
+	    one way to achieve this
+	    is to post them to a Web Server Client for validation.
+	  
+</p>
+<p>The following is an example of a JavaScript file that a Client might host at its
+	  <tt>redirect_uri</tt>.  This is loaded by the redirect from
+	  the Authorization Server.  The fragment component is parsed and then sent by <tt>POST</tt> to a URI
+	  that will validate and use the information received.
+</p>
+<p>Following is a non-normative example of a
+	    Redirect URI response:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /cb HTTP/1.1
+  Host: client.example.org
+
+  HTTP/1.1 200 OK
+  Content-Type: text/html
+
+  &lt;script type="text/javascript"&gt;
+
+  // First, parse the query string
+  var params = {}, postBody = location.hash.substring(1),
+      regex = /([^&amp;=]+)=([^&amp;]*)/g, m;
+  while (m = regex.exec(postBody)) {
+    params[decodeURIComponent(m[1])] = decodeURIComponent(m[2]);
+  }
+
+  // And send the token over to the server
+  var req = new XMLHttpRequest();
+  // using POST so query isn't logged
+  req.open('POST', 'https://' + window.location.host +
+                   '/catch_response', true);
+  req.setRequestHeader('Content-Type',
+                       'application/x-www-form-urlencoded');
+
+  req.onreadystatechange = function (e) {
+    if (req.readyState == 4) {
+      if (req.status == 200) {
+  // If the response from the POST is 200 OK, perform a redirect
+        window.location = 'https://'
+          + window.location.host + '/redirect_after_login'
+      }
+  // if the OAuth response is invalid, generate an error message
+      else if (req.status == 400) {
+        alert('There was an error processing the token')
+      } else {
+        alert('Something other than 200 was returned')
+      }
+    }
+  };
+  req.send(postBody);
+</pre></div>
+<a name="CompatibilityNotes"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.15.6"></a><h3>15.6.&nbsp;
+Compatibility Notes</h3>
+
+<p>
+	  NOTE: Potential compatibility issues that were previously described in
+	  the original version of this specification have since been addressed.
+	
+</p>
+<a name="RelatedSpecs"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.15.7"></a><h3>15.7.&nbsp;
+Related Specifications and Implementer's Guides</h3>
+
+<p>
+	  These related OPTIONAL specifications MAY be used in
+	  combination with this specification to provide additional functionality:
+
+	  </p>
+<ul class="text">
+<li>
+	      <a class='info' href='#OpenID.Discovery'>OpenID Connect Discovery 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., and E. Jay, &ldquo;OpenID Connect Discovery 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Discovery] -
+	      Defines how Relying Parties dynamically discover information about OpenID Providers
+	    
+</li>
+<li>
+	      <a class='info' href='#OpenID.Registration'>OpenID Connect Dynamic Client Registration 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., and M. Jones, &ldquo;OpenID Connect Dynamic Client Registration 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Registration] -
+	      Defines how Relying Parties dynamically register with OpenID Providers
+	    
+</li>
+<li>
+	      <a class='info' href='#OAuth.Post'>OAuth 2.0 Form Post Response Mode<span> (</span><span class='info'>Jones, M. and B. Campbell, &ldquo;OAuth 2.0 Form Post Response Mode,&rdquo; April&nbsp;2015.</span><span>)</span></a> [OAuth.Post] -
+	      Defines how to return OAuth 2.0 Authorization Response parameters
+	      (including OpenID Connect Authentication Response parameters)
+	      using HTML form values that are auto-submitted by the User Agent
+	      using HTTP <tt>POST</tt>
+	    
+</li>
+<li>
+	      <a class='info' href='#OpenID.RPInitiated'>OpenID Connect RP-Initiated Logout 1.0<span> (</span><span class='info'>Jones, M., de Medeiros, B., Agarwal, N., Sakimura, N., and J. Bradley, &ldquo;OpenID Connect RP-Initiated Logout 1.0,&rdquo; September&nbsp;2022.</span><span>)</span></a> [OpenID.RPInitiated] -
+	      Defines how a Relying Party
+	      requests that an OpenID Provider log out the End-User
+	    
+</li>
+<li>
+	      <a class='info' href='#OpenID.Session'>OpenID Connect Session Management 1.0<span> (</span><span class='info'>de Medeiros, B., Agarwal, N., Sakimura, N., Bradley, J., and M. Jones, &ldquo;OpenID Connect Session Management 1.0,&rdquo; September&nbsp;2022.</span><span>)</span></a> [OpenID.Session] -
+	      Defines how to manage OpenID Connect sessions, including postMessage-based logout and RP-initiated logout functionality
+	    
+</li>
+<li>
+	      <a class='info' href='#OpenID.FrontChannel'>OpenID Connect Front-Channel Logout 1.0<span> (</span><span class='info'>Jones, M., &ldquo;OpenID Connect Front-Channel Logout 1.0,&rdquo; September&nbsp;2022.</span><span>)</span></a> [OpenID.FrontChannel] -
+	      Defines a front-channel logout mechanism that does not use an OP iframe on RP pages
+	    
+</li>
+<li>
+	      <a class='info' href='#OpenID.BackChannel'>OpenID Connect Back-Channel Logout 1.0<span> (</span><span class='info'>Jones, M. and J. Bradley, &ldquo;OpenID Connect Back-Channel Logout 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.BackChannel] -
+	      Defines a logout mechanism that uses direct back-channel communication between the OP and RPs being logged out
+	    
+</li>
+</ul><p>
+	
+</p>
+<p>
+	  These implementer's guides are intended to serve as self-contained references
+	  for implementers of basic Web-based Relying Parties:
+
+	  </p>
+<ul class="text">
+<li><a class='info' href='#OpenID.Basic'>OpenID Connect Basic Client Implementer's Guide 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;OpenID Connect Basic Client Implementer's Guide 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Basic] -
+	    Implementer's guide containing a subset of this specification
+	    that is intended for use by basic
+	    Web-based Relying Parties using the
+	    OAuth Authorization Code Flow
+</li>
+<li><a class='info' href='#OpenID.Implicit'>OpenID Connect Implicit Client Implementer's Guide 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;OpenID Connect Implicit Client Implementer's Guide 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Implicit] -
+	    Implementer's guide containing a subset of this specification
+	    that is intended for use by basic
+	    Web-based Relying Parties using the
+	    OAuth Implicit Flow
+</li>
+</ul><p>
+	
+</p>
+<a name="Security"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16"></a><h3>16.&nbsp;
+Security Considerations</h3>
+
+<p>
+	This specification references the security considerations defined in
+	Section 10 of <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749], and
+	Section 5 of <a class='info' href='#RFC6750'>OAuth 2.0 Bearer Token Usage<span> (</span><span class='info'>Jones, M. and D. Hardt, &ldquo;The OAuth 2.0 Authorization Framework: Bearer Token Usage,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6750].
+	Furthermore, the <a class='info' href='#RFC6819'>OAuth 2.0 Threat Model and Security
+	Considerations<span> (</span><span class='info'>Lodderstedt, T., Ed., McGloin, M., and P. Hunt, &ldquo;OAuth 2.0 Threat Model and Security Considerations,&rdquo; January&nbsp;2013.</span><span>)</span></a> [RFC6819] specification provides an extensive list of threats and controls
+	that apply to this specification as well,
+	given that it is based upon OAuth 2.0.
+	<a class='info' href='#ISO29115'>ISO/IEC 29115<span> (</span><span class='info'>International Organization for Standardization, &ldquo;ISO/IEC 29115:2013. 	  Information technology - Security techniques - Entity authentication 	  assurance framework,&rdquo; April&nbsp;2013.</span><span>)</span></a> [ISO29115]
+	also provides threats and controls that
+	implementers need to take into account.
+	Implementers are highly advised to
+	read these references in detail and apply the countermeasures described therein.
+      
+</p>
+<p>
+	In addition, the following list of attack vectors and remedies are
+	also considered.
+      
+</p>
+<a name="RequestDisclosure"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.1"></a><h3>16.1.&nbsp;
+Request Disclosure</h3>
+
+<p>If appropriate measures are not taken, a request might be disclosed to
+	an attacker, posing security and privacy threats.
+</p>
+<p>In addition to what is stated in Section 5.1.1 of <a class='info' href='#RFC6819'>[RFC6819]<span> (</span><span class='info'>Lodderstedt, T., Ed., McGloin, M., and P. Hunt, &ldquo;OAuth 2.0 Threat Model and Security Considerations,&rdquo; January&nbsp;2013.</span><span>)</span></a>,
+	this standard provides a way to provide the confidentiality of the request
+	end to end through the
+	use of <tt>request</tt> or <tt>request_uri</tt>
+	parameters, where the content of the <tt>request</tt>
+	is an encrypted JWT with the appropriate key and cipher.
+	This protects even against a compromised User Agent
+	in the case of indirect request.
+</p>
+<a name="ServerMasquerading"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.2"></a><h3>16.2.&nbsp;
+Server Masquerading</h3>
+
+<p>A malicious Server might masquerade as the legitimate server
+	using various means. To detect such an attack, the Client needs to authenticate
+	the server.
+</p>
+<p>In addition to what is stated in Section 5.1.2 of <a class='info' href='#RFC6819'>[RFC6819]<span> (</span><span class='info'>Lodderstedt, T., Ed., McGloin, M., and P. Hunt, &ldquo;OAuth 2.0 Threat Model and Security Considerations,&rdquo; January&nbsp;2013.</span><span>)</span></a>,
+	this standard provides a way to authenticate the Server through either the
+	use of Signed or Encrypted JWTs
+	with an appropriate key and cipher.
+</p>
+<a name="TokenManufacture"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.3"></a><h3>16.3.&nbsp;
+Token Manufacture/Modification</h3>
+
+<p>
+	  An Attacker might generate a bogus token or modify the token contents
+	  (such as Claims values or the signature)
+	  of an existing parseable token, causing the RP to grant
+	  inappropriate access to the Client. For example, an Attacker might modify
+	  the parseable token to extend the validity period; a Client might modify the
+	  parseable token to have access to information that they should not be able to view.
+	
+</p>
+<p>There are two ways to mitigate this attack:
+</p>
+<p>
+	  </p>
+<ol class="text">
+<li>The token can be digitally signed by the OP. The Relying
+	    Party SHOULD validate the digital signature to verify that it was
+	    issued by a legitimate OP.
+</li>
+<li>The token can be sent over a protected channel such as TLS.
+	    See <a class='info' href='#TLSRequirements'>Section&nbsp;16.17<span> (</span><span class='info'>TLS Requirements</span><span>)</span></a> for more information on using TLS.
+	    In this specification, the token is always sent over a TLS protected channel.
+	    Note however, that this measure is only a defense against third party attackers
+	    and is not applicable to the case where the Client is the attacker.
+</li>
+</ol><p>
+	
+</p>
+<a name="AccessTokenDisclosure"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.4"></a><h3>16.4.&nbsp;
+Access Token Disclosure</h3>
+
+<p>
+	  Access Tokens are credentials used to access Protected
+	  Resources, as defined in Section 1.4 of
+	  <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749]. Access Tokens represent
+	  an End-User's authorization and MUST NOT be exposed to
+	  unauthorized parties.
+	
+</p>
+<a name="ResponseDisclosure"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.5"></a><h3>16.5.&nbsp;
+Server Response Disclosure</h3>
+
+<p>
+	  The server response might contain authentication data and Claims
+	  that include sensitive Client information. Disclosure of the
+	  response contents can make the Client vulnerable to other types of
+	  attacks.
+	
+</p>
+<p>
+	  The server response disclosure can be mitigated in the following two
+	  ways:
+	  </p>
+<ol class="text">
+<li>Using the <tt>code</tt> Response Type.
+	    The response is sent over a TLS protected
+	    channel, where the Client is authenticated by the
+	    <tt>client_id</tt> and
+	    <tt>client_secret</tt>.
+</li>
+<li>For other Response Types,
+	    the signed response can be encrypted with the Client's
+	    public key or a shared secret as an encrypted JWT
+	    with an appropriate key and cipher.
+</li>
+</ol><p>
+	
+</p>
+<a name="ServerResponseRepudiation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.6"></a><h3>16.6.&nbsp;
+Server Response Repudiation</h3>
+
+<p>A response might be repudiated by the server if the proper mechanisms are not in place.
+	For example, if a Server does not digitally sign a response, the Server can claim that it was not
+	generated through the services of the Server.
+</p>
+<p>To mitigate this threat, the response MAY be digitally signed by
+	the Server using a key that supports non-repudiation. The Client SHOULD validate
+	the digital signature to verify that it was issued by a legitimate
+	Server and its integrity is intact.
+</p>
+<a name="RequestRepudation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.7"></a><h3>16.7.&nbsp;
+Request Repudiation</h3>
+
+<p>Since it is possible for a
+	compromised or malicious Client to send a request to the wrong party,
+	a Client that was authenticated
+	using only a bearer token can repudiate any transaction.
+	
+</p>
+<p>To mitigate this threat, the Server MAY require that the
+	request be digitally signed by
+	the Client using a key that supports non-repudiation.
+	The Server SHOULD validate
+	the digital signature to verify that it was issued by a legitimate
+	Client and its integrity is intact.
+</p>
+<a name="AccessTokenRedirect"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.8"></a><h3>16.8.&nbsp;
+Access Token Redirect</h3>
+
+<p>An Attacker uses the Access Token generated for one resource to
+	obtain access to a second resource.
+	
+</p>
+<p>To mitigate this threat, the Access Token SHOULD be audience
+	and scope restricted. One way of implementing it is to include
+	the identifier of the resource for whom it was generated as audience.
+	The resource verifies that
+	incoming tokens include its identifier as the audience of the
+	token.
+</p>
+<a name="TokenReuse"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.9"></a><h3>16.9.&nbsp;
+Token Reuse</h3>
+
+<p>An Attacker attempts to use a one-time use token such as
+	an Authorization Code that has already
+	been used once with the intended Resource.
+	To mitigate this threat, the token SHOULD include a timestamp
+	and a short validity lifetime.
+	The Relying Party then checks the timestamp and lifetime values
+	to ensure that the token is currently valid.
+</p>
+<p>Alternatively, the server MAY record the state of the use of
+	the token and check the status for each request.
+</p>
+<a name="AuthCodeCapture"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.10"></a><h3>16.10.&nbsp;
+ Eavesdropping or Leaking Authorization Codes (Secondary Authenticator Capture)</h3>
+
+<p>In addition to the attack patterns described in
+	Section 4.4.1.1 of <a class='info' href='#RFC6819'>[RFC6819]<span> (</span><span class='info'>Lodderstedt, T., Ed., McGloin, M., and P. Hunt, &ldquo;OAuth 2.0 Threat Model and Security Considerations,&rdquo; January&nbsp;2013.</span><span>)</span></a>,
+	an Authorization Code can be captured in the User Agent where the TLS
+	session is terminated if the User Agent is infected by malware.
+	However, capturing it is not useful as long as either
+	Client Authentication or an encrypted response is used.
+	
+</p>
+<a name="TokenSubstitution"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.11"></a><h3>16.11.&nbsp;
+Token Substitution</h3>
+
+<p>
+	  Token Substitution is a class of attacks in which a malicious user
+	  swaps various tokens, including swapping an Authorization Code for
+	  a legitimate user with another token that the attacker has.
+	  One means of accomplishing this is for the attacker to copy
+	  a token out one session and use it in an HTTP message for
+	  a different session, which is easy to do when the token is
+	  available to the browser; this is known as the "cut and paste" attack.
+	
+</p>
+<p>
+	  The Implicit Flow of <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749]
+	  is not designed to mitigate this risk.  In Section 10.16,
+	  it normatively requires that any use of the authorization
+	  process as a form of delegated End-User authentication to the
+	  Client MUST NOT use the Implicit Flow without employing
+	  additional security mechanisms that enable the Client to
+	  determine whether the ID Token and Access Token were issued for its use.
+	
+</p>
+<p>
+	  In OpenID Connect, this is mitigated through mechanisms
+	  provided through the ID Token.  The ID Token is a signed
+	  security token that provides Claims such as
+	  <tt>iss</tt> (issuer),
+	  <tt>sub</tt> (subject),
+	  <tt>aud</tt> (audience),
+	  <tt>at_hash</tt> (access token hash), and
+	  <tt>c_hash</tt> (code hash).  Using the ID Token,
+	  the Client is capable of detecting the Token Substitution Attack.
+	
+</p>
+<p>
+	  The <tt>c_hash</tt> in the ID Token enables
+	  Clients to prevent Authorization Code substitution.
+	  The <tt>at_hash</tt> in the ID Token enables
+	  Clients to prevent Access Token substitution.
+	
+</p>
+<p>
+	  Also, a malicious user may attempt to impersonate a more
+	  privileged user by subverting the communication channel
+	  between the Authorization Endpoint and Client, or the Token Endpoint
+	  and Client, for example by swapping the Authorization Code
+	  or reordering the messages, to convince the Token Endpoint
+	  that the attacker's authorization grant corresponds to a grant
+	  sent on behalf of a more privileged user.
+	
+</p>
+<p>
+	  For the HTTP binding defined by this specification, the
+	  responses to Token Requests are bound to the corresponding
+	  requests by message order in HTTP, as both the response
+	  containing the token and requests are protected by TLS, which
+	  will detect and prevent packet reordering.
+	
+</p>
+<p>
+	  When designing another binding of this specification to a
+	  protocol incapable of strongly binding Token Endpoint
+	  requests to responses, additional mechanisms to
+	  address this issue MUST be utilized. One such mechanism could
+	  be to include an ID Token with a <tt>c_hash</tt>
+	  Claim in the token request and response.
+	
+</p>
+<a name="TimingAttack"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.12"></a><h3>16.12.&nbsp;
+Timing Attack</h3>
+
+<p>A timing attack enables the attacker to
+	obtain an unnecessary large amount of information through the elapsed time
+	differences in the code paths taken by successful and unsuccessful decryption operations or
+	successful and unsuccessful signature validation of a message.
+	It can be used to reduce the effective key length of the
+	cipher used.
+</p>
+<p>Implementations SHOULD NOT terminate the validation process
+	at the instant of the finding an error but SHOULD continue
+	running until all the octets have been processed to avoid this attack.
+</p>
+<a name="OtherCryptoAttacks"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.13"></a><h3>16.13.&nbsp;
+Other Crypto Related Attacks</h3>
+
+<p>There are various crypto related attacks possible depending on the
+	method used for encryption and signature / integrity checking.
+	Implementers need to consult the Security Considerations
+	for the <a class='info' href='#JWT'>JWT<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWT] specification and
+	specifications that it references
+	to avoid the vulnerabilities
+	identified in these specifications.
+	
+</p>
+<a name="SigningOrder"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.14"></a><h3>16.14.&nbsp;
+Signing and Encryption Order</h3>
+
+<p>
+	  Signatures over encrypted text are not considered valid
+	  in many jurisdictions.
+	  Therefore, for integrity and non-repudiation,
+	  this specification requires signing
+	  the plain text JSON Claims, when signing is performed.
+	  If both signing and encryption are desired, it is performed on
+	  the JWS containing the signed Claims,
+	  with the result being a Nested JWT, as specified in <a class='info' href='#JWT'>[JWT]<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a>.
+	  Note that since all JWE encryption algorithms provide integrity protection,
+	  there is no need to separately sign the encrypted content.
+	
+</p>
+<a name="IssuerIdentifier"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.15"></a><h3>16.15.&nbsp;
+Issuer Identifier</h3>
+
+<p>OpenID Connect supports multiple Issuers per Host and Port combination.
+	The issuer returned by discovery MUST exactly match the value of
+	<tt>iss</tt> in the ID Token.
+</p>
+<p>
+	  OpenID Connect treats the path component of any Issuer URI as
+	  being part of the Issuer Identifier.  For instance, the subject
+	  "1234" with an Issuer Identifier of "https://example.com" is not
+	  equivalent to the subject "1234" with an Issuer Identifier of
+	  "https://example.com/sales".
+	
+</p>
+<p>
+	  It is RECOMMENDED that only a single Issuer per host be used.
+	  However, if a host supports multiple tenants,
+	  multiple Issuers for that host may be needed.
+	
+</p>
+<a name="ImplicitFlowThreats"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.16"></a><h3>16.16.&nbsp;
+Implicit Flow Threats</h3>
+
+<p>In the Implicit Flow, the Access Token is returned in the
+        fragment component of the Client's <tt>redirect_uri</tt> through HTTPS, thus it is
+        protected between the OP and the User Agent, and between the User Agent and the
+        RP. The only place it can be captured is the User Agent where the
+        TLS session is terminated, which is possible if the User Agent is
+        infected by malware or under the control of a malicious party.
+</p>
+<a name="TLSRequirements"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.17"></a><h3>16.17.&nbsp;
+TLS Requirements</h3>
+
+<p>
+	  Implementations MUST support TLS.
+	  Which version(s) ought to be implemented will vary over
+	  time and depend on the widespread deployment and known
+	  security vulnerabilities at the time of implementation.
+	  Implementations SHOULD follow the guidance in
+	  BCP 195 <a class='info' href='#RFC8996'>[RFC8996]<span> (</span><span class='info'>Moriarty, K. and S. Farrell, &ldquo;Deprecating TLS 1.0 and TLS 1.1,&rdquo; March&nbsp;2021.</span><span>)</span></a> <a class='info' href='#RFC9325'>[RFC9325]<span> (</span><span class='info'>Sheffer, Y., Saint-Andre, P., and T. Fossati, &ldquo;Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS),&rdquo; November&nbsp;2022.</span><span>)</span></a>,
+	  which provides recommendations and requirements
+	  for improving the security of deployed services that use TLS.
+	
+</p>
+<p>
+	  To protect against information disclosure and tampering,
+	  confidentiality protection MUST be applied using TLS
+	  with a ciphersuite that provides confidentiality and
+	  integrity protection.
+	
+</p>
+<p>
+	  Whenever TLS is used, a TLS server certificate check
+	  MUST be performed, per <a class='info' href='#RFC6125'>RFC 6125<span> (</span><span class='info'>Saint-Andre, P. and J. Hodges, &ldquo;Representation and Verification of Domain-Based Application Service Identity within Internet Public Key Infrastructure Using X.509 (PKIX) Certificates in the Context of Transport Layer Security (TLS),&rdquo; March&nbsp;2011.</span><span>)</span></a> [RFC6125].
+	
+</p>
+<a name="TokenLifetime"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.18"></a><h3>16.18.&nbsp;
+Lifetimes of Access Tokens and Refresh Tokens</h3>
+
+<p>Access Tokens might not be revocable by the Authorization Server.
+	Access Token lifetimes SHOULD therefore be kept to single use or
+	very short lifetimes.
+</p>
+<p>
+	  If ongoing access to the UserInfo Endpoint or other Protected Resources is required,
+	  a Refresh Token can be used. The Client can then exchange the Refresh Token at
+	  the Token Endpoint for a fresh short-lived Access Token that can be used to
+	  access the resource.
+	
+</p>
+<p>
+	  The Authorization Server SHOULD clearly identify long-term grants to the User
+	  during Authorization.
+	  The Authorization Server SHOULD provide a mechanism for the End-User to revoke
+	  Access Tokens and Refresh Tokens granted to a Client.
+	
+</p>
+<a name="SymmetricKeyEntropy"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.19"></a><h3>16.19.&nbsp;
+Symmetric Key Entropy</h3>
+
+<p>
+	  In <a class='info' href='#Signing'>Section&nbsp;10.1<span> (</span><span class='info'>Signing</span><span>)</span></a> and <a class='info' href='#Encryption'>Section&nbsp;10.2<span> (</span><span class='info'>Encryption</span><span>)</span></a>, keys are derived
+	  from the <tt>client_secret</tt> value.
+	  Thus, when used with symmetric signing or encryption operations,
+	  <tt>client_secret</tt> values MUST contain
+	  sufficient entropy to generate cryptographically strong keys.
+	  Also, <tt>client_secret</tt> values MUST also contain
+	  at least the minimum of number of octets required for MAC keys for the
+	  particular algorithm used.
+	  So for instance, for <tt>HS256</tt>, the
+	  <tt>client_secret</tt> value MUST contain
+	  at least 32 octets (and almost certainly SHOULD contain more,
+	  since <tt>client_secret</tt> values are
+	  likely to use a restricted alphabet).
+	
+</p>
+<a name="NeedForSignedRequests"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.20"></a><h3>16.20.&nbsp;
+Need for Signed Requests</h3>
+
+<p>
+	  In some situations, Clients might need to use signed requests to ensure that
+	  the desired request parameters are delivered to the OP without having
+	  been tampered with.  For instance, the <tt>max_age</tt>
+	  and <tt>acr_values</tt> provide more assurance about
+	  the nature of the authentication performed when delivered in signed requests.
+	
+</p>
+<a name="NeedForEncryptedRequests"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.21"></a><h3>16.21.&nbsp;
+Need for Encrypted Requests</h3>
+
+<p>
+	  In some situations, knowing the contents of an OpenID Connect request can,
+	  in and of itself, reveal sensitive information about the End-User.
+	  For instance, knowing that the Client is requesting a particular Claim or
+	  that it is requesting that a particular authentication method be used
+	  can reveal sensitive information about the End-User.
+	  OpenID Connect enables requests to be encrypted to the OpenID Provider
+	  to prevent such potentially sensitive information from being revealed.
+	
+</p>
+<a name="HTTP307Redirects"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.22"></a><h3>16.22.&nbsp;
+HTTP 307 Redirects</h3>
+
+<p>
+	  HTTP 307 redirects send a POST request to the party being redirected to
+	  that contains all the form data from the previous request.
+	  This can leak credentials intended for the OpenID Provider to the Relying Party.
+	  Therefore, HTTP 307 redirects MUST NOT be used when redirecting to the Redirection URI.
+	  Likewise, while HTTP 302 redirects are typically implemented in a way that does not do this,
+	  the use of HTTP 303 redirect is preferable, as it is defined not to do this.
+	
+</p>
+<a name="iOSCustomSchemes"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.16.23"></a><h3>16.23.&nbsp;
+Custom URI Schemes on iOS</h3>
+
+<p>
+	  Note that on iOS, multiple applications can register as handlers for a custom URI scheme,
+	  therefore it is not deterministic that the calling application will receive the Authentication Reply
+	  from the Self-Issued OpenID Provider.
+	  Use of a claimed URI is an alternative to using the <tt>openid:</tt> custom URI scheme.
+	
+</p>
+<p>
+	  While it is possible to assign handlers to custom URI schemes
+	  and it is possible that the operating system could help the End-User select the correct handler,
+	  it is not possible to guarantee that the handler for a given custom URI scheme has not been replaced
+	  by a subsequently installed native application.
+	  At the time of this writing, there appears to be no fool-proof mitigation for this vulnerability.
+	
+</p>
+<a name="Privacy"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.17"></a><h3>17.&nbsp;
+Privacy Considerations</h3>
+
+<a name="PII"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.17.1"></a><h3>17.1.&nbsp;
+Personally Identifiable Information</h3>
+
+<p>The UserInfo Response typically contains Personally Identifiable
+	Information (PII). As such, End-User consent for the release of the information
+	for the specified purpose should be obtained at or prior to the
+	authorization time in accordance with relevant regulations. The purpose
+	of use is typically registered in association with the <tt>redirect_uris</tt>.
+</p>
+<p>Only necessary UserInfo data should be stored at the Client and the
+	Client SHOULD associate the received data with the purpose of use
+	statement.
+</p>
+<a name="AccessMonitoring"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.17.2"></a><h3>17.2.&nbsp;
+Data Access Monitoring</h3>
+
+<p>
+	  The Resource Server SHOULD make End-Users' UserInfo access logs
+	  available to them so that they can monitor who accessed their data.
+	
+</p>
+<a name="Correlation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.17.3"></a><h3>17.3.&nbsp;
+Correlation</h3>
+
+<p>To protect the End-User from possible correlation among Clients, the
+	use of a Pairwise Pseudonymous Identifier (PPID) as the
+	<tt>sub</tt> (subject) SHOULD be considered.
+</p>
+<a name="OfflineAccessPrivacy"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.17.4"></a><h3>17.4.&nbsp;
+Offline Access</h3>
+
+<p>
+	  Offline access enables access to Claims when the user is not present,
+	  posing greater privacy risk than the Claims transfer when the user is present.
+	  Therefore, it is prudent to obtain explicit consent for
+	  offline access to resources.
+	  This specification mandates the use of the <tt>prompt</tt>
+	  parameter to obtain consent unless it is already known that the
+	  request complies with the conditions for processing the request in each jurisdiction.
+	
+</p>
+<p>
+	  When an Access Token is returned via the User Agent
+	  using the Implicit Flow or Hybrid Flow, there is
+	  a greater risk of it being exposed to an attacker, who could
+	  later use it to access the UserInfo endpoint.
+	  If the Access Token does not enable offline access and the server
+	  can differentiate whether the Client request has been made
+	  offline or online, the risk will be substantially reduced.
+	  Therefore, this specification mandates ignoring
+	  the offline access request when the Access Token is
+	  transmitted through the User Agent.
+	  Note that differentiating between online and offline access
+	  from the server can be difficult especially for native clients.
+	  The server may well have to rely on heuristics.
+	  Also, the risk of exposure for the Access Token delivered
+	  through the User Agent for the Response Types of
+	  <tt>code&nbsp;token</tt> and
+	  <tt>token</tt> is the same.
+	  Thus, the implementations should be prepared to detect
+	  whether the Access Token was issued through the User Agent
+	  or directly from the Token Endpoint and deny offline access
+	  if the token was issued through the User Agent.
+	
+</p>
+<p>
+	  Note that although these provisions require an explicit
+	  consent dialogue through the <tt>prompt</tt> parameter,
+	  the mere fact that the user pressed an "accept" button etc.,
+	  might not constitute a valid consent.
+	  Developers should be aware that for the act of consent to
+	  be valid, typically, the impact of the terms have to be
+	  understood by the End-User, the consent must be freely given
+	  and not forced (i.e., other options have to be available),
+	  and the terms must fair and equitable.
+	  In general, it is advisable for the service to follow the
+	  required privacy principles in each jurisdiction and rely on
+	  other conditions for processing the request than simply explicit consent,
+	  as online self-service "explicit consent" often does not
+	  form a valid consent in some jurisdictions.
+	
+</p>
+<a name="IANA"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.18"></a><h3>18.&nbsp;
+IANA Considerations</h3>
+
+<a name="ClaimsRegistry"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.18.1"></a><h3>18.1.&nbsp;
+JSON Web Token Claims Registration</h3>
+
+<p>
+	  This specification registers the following Claims
+	  in the IANA
+	  "JSON Web Token Claims" registry <a class='info' href='#IANA.JWT.Claims'>[IANA.JWT.Claims]<span> (</span><span class='info'>IANA, &ldquo;JSON Web Token Claims,&rdquo; .</span><span>)</span></a>
+	  established by <a class='info' href='#JWT'>[JWT]<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a>.
+	
+</p>
+<a name="ClaimsContents"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.18.1.1"></a><h3>18.1.1.&nbsp;
+Registry Contents</h3>
+
+<p> 
+	  </p>
+<ul class="text">
+<li>
+	      Claim Name: <tt>name</tt>
+	    
+</li>
+<li>
+	      Claim Description: Full name
+	    
+</li>
+<li>
+	      Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	    
+</li>
+<li>
+	      Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	    
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>given_name</tt>
+	      
+</li>
+<li>
+		Claim Description: Given name(s) or first name(s)
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>family_name</tt>
+	      
+</li>
+<li>
+		Claim Description: Surname(s) or last name(s)
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>middle_name</tt>
+	      
+</li>
+<li>
+		Claim Description: Middle name(s)
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>nickname</tt>
+	      
+</li>
+<li>
+		Claim Description: Casual name
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>preferred_username</tt>
+	      
+</li>
+<li>
+		Claim Description: Shorthand name by which the End-User wishes to be referred to
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>profile</tt>
+	      
+</li>
+<li>
+		Claim Description: Profile page URL
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>picture</tt>
+	      
+</li>
+<li>
+		Claim Description: Profile picture URL
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>website</tt>
+	      
+</li>
+<li>
+		Claim Description: Web page or blog URL
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>email</tt>
+	      
+</li>
+<li>
+		Claim Description: Preferred e-mail address
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>email_verified</tt>
+	      
+</li>
+<li>
+		Claim Description: True if the e-mail address has been verified; otherwise false
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>gender</tt>
+	      
+</li>
+<li>
+		Claim Description: Gender
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>birthdate</tt>
+	      
+</li>
+<li>
+		Claim Description: Birthday
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>zoneinfo</tt>
+	      
+</li>
+<li>
+		Claim Description: Time zone
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>locale</tt>
+	      
+</li>
+<li>
+		Claim Description: Locale
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>phone_number</tt>
+	      
+</li>
+<li>
+		Claim Description: Preferred telephone number
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>phone_number_verified</tt>
+	      
+</li>
+<li>
+		Claim Description: True if the phone number has been verified; otherwise false
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>address</tt>
+	      
+</li>
+<li>
+		Claim Description: Preferred postal address
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>updated_at</tt>
+	      
+</li>
+<li>
+		Claim Description: Time the information was last updated
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#StandardClaims'>Section&nbsp;5.1<span> (</span><span class='info'>Standard Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>azp</tt>
+	      
+</li>
+<li>
+		Claim Description: Authorized party - the party to which the ID Token was issued
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>nonce</tt>
+	      
+</li>
+<li>
+		Claim Description: Value used to associate a Client session with an ID Token
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>auth_time</tt>
+	      
+</li>
+<li>
+		Claim Description: Time when the authentication occurred
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>at_hash</tt>
+	      
+</li>
+<li>
+		Claim Description: Access Token hash value
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>c_hash</tt>
+	      
+</li>
+<li>
+		Claim Description: Code hash value
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#HybridIDToken'>Section&nbsp;3.3.2.11<span> (</span><span class='info'>ID Token</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>acr</tt>
+	      
+</li>
+<li>
+		Claim Description: Authentication Context Class Reference
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>amr</tt>
+	      
+</li>
+<li>
+		Claim Description: Authentication Methods References
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#IDToken'>Section&nbsp;2<span> (</span><span class='info'>ID Token</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>sub_jwk</tt>
+	      
+</li>
+<li>
+		Claim Description: Public key used to check the signature of an ID Token
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#SelfIssuedResponse'>Section&nbsp;7.4<span> (</span><span class='info'>Self-Issued OpenID Provider Response</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>_claim_names</tt>
+	      
+</li>
+<li>
+		Claim Description: JSON object whose member names are the Claim Names for the Aggregated and Distributed Claims
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#AggregatedDistributedClaims'>Section&nbsp;5.6.2<span> (</span><span class='info'>Aggregated and Distributed Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>
+		Claim Name: <tt>_claim_sources</tt>
+	      
+</li>
+<li>
+		Claim Description: JSON object whose member names are referenced by the member values of the <tt>_claim_names</tt> member
+	      
+</li>
+<li>
+		Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification Document(s): <a class='info' href='#AggregatedDistributedClaims'>Section&nbsp;5.6.2<span> (</span><span class='info'>Aggregated and Distributed Claims</span><span>)</span></a> of this specification
+	      
+</li>
+</ul><p>
+	  
+</p>
+<a name="OAuthParametersRegistry"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.18.2"></a><h3>18.2.&nbsp;
+OAuth Parameters Registration</h3>
+
+<p>
+	  This specification registers the following parameters
+	  in the IANA
+	  "OAuth Parameters" registry <a class='info' href='#IANA.OAuth.Parameters'>[IANA.OAuth.Parameters]<span> (</span><span class='info'>IANA, &ldquo;OAuth Parameters,&rdquo; .</span><span>)</span></a>
+	  established by <a class='info' href='#RFC6749'>RFC 6749<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749].
+	
+</p>
+<a name="ParametersContents"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.18.2.1"></a><h3>18.2.1.&nbsp;
+Registry Contents</h3>
+
+<p> 
+	  </p>
+<ul class="text">
+<li>Parameter name: <tt>nonce</tt>
+</li>
+<li>Parameter usage location: Authorization Request
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a> of this specification
+</li>
+<li>Related information: None
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Parameter name: <tt>display</tt>
+</li>
+<li>Parameter usage location: Authorization Request
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a> of this specification
+</li>
+<li>Related information: None
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Parameter name: <tt>prompt</tt>
+</li>
+<li>Parameter usage location: Authorization Request
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a> of this specification
+</li>
+<li>Related information: None
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Parameter name: <tt>max_age</tt>
+</li>
+<li>Parameter usage location: Authorization Request
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a> of this specification
+</li>
+<li>Related information: None
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Parameter name: <tt>ui_locales</tt>
+</li>
+<li>Parameter usage location: Authorization Request
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a> of this specification
+</li>
+<li>Related information: None
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Parameter name: <tt>claims_locales</tt>
+</li>
+<li>Parameter usage location: Authorization Request
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#ClaimsLanguagesAndScripts'>Section&nbsp;5.2<span> (</span><span class='info'>Claims Languages and Scripts</span><span>)</span></a> of this specification
+</li>
+<li>Related information: None
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Parameter name: <tt>id_token_hint</tt>
+</li>
+<li>Parameter usage location: Authorization Request
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a> of this specification
+</li>
+<li>Related information: None
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Parameter name: <tt>login_hint</tt>
+</li>
+<li>Parameter usage location: Authorization Request
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a> of this specification
+</li>
+<li>Related information: None
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Parameter name: <tt>acr_values</tt>
+</li>
+<li>Parameter usage location: Authorization Request
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthorizationEndpoint'>Section&nbsp;3.1.2<span> (</span><span class='info'>Authorization Endpoint</span><span>)</span></a> of this specification
+</li>
+<li>Related information: None
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Parameter name: <tt>claims</tt>
+</li>
+<li>Parameter usage location: Authorization Request
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#ClaimsParameter'>Section&nbsp;5.5<span> (</span><span class='info'>Requesting Claims using the &quot;claims&quot; Request Parameter</span><span>)</span></a> of this specification
+</li>
+<li>Related information: None
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Parameter name: <tt>registration</tt>
+</li>
+<li>Parameter usage location: Authorization Request
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#RegistrationParameter'>Section&nbsp;7.2.1<span> (</span><span class='info'>Providing Information with the &quot;registration&quot; Request Parameter</span><span>)</span></a> of this specification
+</li>
+<li>Related information: None
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Parameter name: <tt>request</tt>
+</li>
+<li>Parameter usage location: Authorization Request
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#JWTRequests'>Section&nbsp;6<span> (</span><span class='info'>Passing Request Parameters as JWTs</span><span>)</span></a> of this specification
+</li>
+<li>Related information: None
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Parameter name: <tt>request_uri</tt>
+</li>
+<li>Parameter usage location: Authorization Request
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#JWTRequests'>Section&nbsp;6<span> (</span><span class='info'>Passing Request Parameters as JWTs</span><span>)</span></a> of this specification
+</li>
+<li>Related information: None
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Parameter name: <tt>id_token</tt>
+</li>
+<li>Parameter usage location: Authorization Response,
+	      Access Token Response
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#TokenResponse'>Section&nbsp;3.1.3.3<span> (</span><span class='info'>Successful Token Response</span><span>)</span></a> of this specification
+</li>
+<li>Related information: None
+</li>
+</ul><p>
+	  
+</p>
+<a name="OAuthErrorRegistry"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.18.3"></a><h3>18.3.&nbsp;
+OAuth Extensions Error Registration</h3>
+
+<p>
+	  This specification registers the following errors
+	  in the IANA
+	  "OAuth Extensions Error" registry <a class='info' href='#IANA.OAuth.Parameters'>[IANA.OAuth.Parameters]<span> (</span><span class='info'>IANA, &ldquo;OAuth Parameters,&rdquo; .</span><span>)</span></a>
+	  established by <a class='info' href='#RFC6749'>RFC 6749<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749].
+	
+</p>
+<a name="ErrorContents"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.18.3.1"></a><h3>18.3.1.&nbsp;
+Registry Contents</h3>
+
+<p> 
+	    </p>
+<ul class="text">
+<li>Error name: <tt>interaction_required</tt>
+</li>
+<li>Error usage location: Authorization Endpoint
+</li>
+<li>Related protocol extension: OpenID Connect
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthError'>Section&nbsp;3.1.2.6<span> (</span><span class='info'>Authentication Error Response</span><span>)</span></a> of this specification
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Error name: <tt>login_required</tt>
+</li>
+<li>Error usage location: Authorization Endpoint
+</li>
+<li>Related protocol extension: OpenID Connect
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthError'>Section&nbsp;3.1.2.6<span> (</span><span class='info'>Authentication Error Response</span><span>)</span></a> of this specification
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Error name: <tt>account_selection_required</tt>
+</li>
+<li>Error usage location: Authorization Endpoint
+</li>
+<li>Related protocol extension: OpenID Connect
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthError'>Section&nbsp;3.1.2.6<span> (</span><span class='info'>Authentication Error Response</span><span>)</span></a> of this specification
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Error name: <tt>consent_required</tt>
+</li>
+<li>Error usage location: Authorization Endpoint
+</li>
+<li>Related protocol extension: OpenID Connect
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthError'>Section&nbsp;3.1.2.6<span> (</span><span class='info'>Authentication Error Response</span><span>)</span></a> of this specification
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Error name: <tt>invalid_request_uri</tt>
+</li>
+<li>Error usage location: Authorization Endpoint
+</li>
+<li>Related protocol extension: OpenID Connect
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthError'>Section&nbsp;3.1.2.6<span> (</span><span class='info'>Authentication Error Response</span><span>)</span></a> of this specification
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Error name: <tt>invalid_request_object</tt>
+</li>
+<li>Error usage location: Authorization Endpoint
+</li>
+<li>Related protocol extension: OpenID Connect
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthError'>Section&nbsp;3.1.2.6<span> (</span><span class='info'>Authentication Error Response</span><span>)</span></a> of this specification
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Error name: <tt>request_not_supported</tt>
+</li>
+<li>Error usage location: Authorization Endpoint
+</li>
+<li>Related protocol extension: OpenID Connect
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthError'>Section&nbsp;3.1.2.6<span> (</span><span class='info'>Authentication Error Response</span><span>)</span></a> of this specification
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Error name: <tt>request_uri_not_supported</tt>
+</li>
+<li>Error usage location: Authorization Endpoint
+</li>
+<li>Related protocol extension: OpenID Connect
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthError'>Section&nbsp;3.1.2.6<span> (</span><span class='info'>Authentication Error Response</span><span>)</span></a> of this specification
+</li>
+</ul><p>
+	  
+</p>
+<p>
+	    </p>
+<ul class="text">
+<li>Error name: <tt>registration_not_supported</tt>
+</li>
+<li>Error usage location: Authorization Endpoint
+</li>
+<li>Related protocol extension: OpenID Connect
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>Specification document(s): <a class='info' href='#AuthError'>Section&nbsp;3.1.2.6<span> (</span><span class='info'>Authentication Error Response</span><span>)</span></a> of this specification
+</li>
+</ul><p>
+	  
+</p>
+<a name="URISchemeRegistry"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.18.4"></a><h3>18.4.&nbsp;
+URI Scheme Registration</h3>
+
+<p>
+	  This specification registers the following URI scheme
+	  in the IANA
+	  "Uniform Resource Identifier (URI) Schemes" registry <a class='info' href='#IANA.URISchemes'>[IANA.URISchemes]<span> (</span><span class='info'>IANA, &ldquo;Uniform Resource Identifier (URI) Schemes,&rdquo; .</span><span>)</span></a>
+	  established by <a class='info' href='#RFC7595'>RFC 7595<span> (</span><span class='info'>Thaler, D., Ed., Hansen, T., and T. Hardie, &ldquo;Guidelines and Registration Procedures for URI Schemes,&rdquo; June&nbsp;2015.</span><span>)</span></a> [RFC7595].
+	
+</p>
+<a name="URISchemeContents"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.18.4.1"></a><h3>18.4.1.&nbsp;
+Registry Contents</h3>
+
+<p>
+	    
+	    </p>
+<ul class="text">
+<li>Scheme name: <tt>openid</tt>
+</li>
+<li>Status: Permanent
+</li>
+<li>Applications/protocols that use this scheme name: OpenID Connect
+</li>
+<li>Contact: Michael B. Jones - michael_b_jones@hotmail.com
+</li>
+<li>Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+</li>
+<li>References: <a class='info' href='#SelfIssuedRequest'>Section&nbsp;7.3<span> (</span><span class='info'>Self-Issued OpenID Provider Request</span><span>)</span></a> of this specification
+</li>
+</ul><p>
+	  
+</p>
+<a name="rfc.references"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.19"></a><h3>19.&nbsp;
+References</h3>
+
+<a name="rfc.references1"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<h3>19.1.&nbsp;Normative References</h3>
+<table width="99%" border="0">
+<tr><td class="author-text" valign="top"><a name="CORS">[CORS]</a></td>
+<td class="author-text">Opera Software ASA, &ldquo;<a href="http://www.w3.org/TR/access-control/">Cross-Origin Resource Sharing</a>,&rdquo; July&nbsp;2010.</td></tr>
+<tr><td class="author-text" valign="top"><a name="E.164">[E.164]</a></td>
+<td class="author-text">International Telecommunication Union, &ldquo;<a href="https://www.itu.int/rec/T-REC-E.164-201011-I/en">E.164: The international public telecommunication numbering plan</a>,&rdquo; 2010.</td></tr>
+<tr><td class="author-text" valign="top"><a name="IANA.AMR">[IANA.AMR]</a></td>
+<td class="author-text">IANA, &ldquo;<a href="https://www.iana.org/assignments/authentication-method-reference-values">Authentication Method Reference Values</a>.&rdquo;</td></tr>
+<tr><td class="author-text" valign="top"><a name="IANA.JWT.Claims">[IANA.JWT.Claims]</a></td>
+<td class="author-text">IANA, &ldquo;<a href="https://www.iana.org/assignments/jwt">JSON Web Token Claims</a>.&rdquo;</td></tr>
+<tr><td class="author-text" valign="top"><a name="IANA.Language">[IANA.Language]</a></td>
+<td class="author-text">IANA, &ldquo;<a href="https://www.iana.org/assignments/language-subtag-registry">Language Subtag Registry</a>.&rdquo;</td></tr>
+<tr><td class="author-text" valign="top"><a name="IANA.OAuth.Parameters">[IANA.OAuth.Parameters]</a></td>
+<td class="author-text">IANA, &ldquo;<a href="https://www.iana.org/assignments/oauth-parameters">OAuth Parameters</a>.&rdquo;</td></tr>
+<tr><td class="author-text" valign="top"><a name="IANA.URISchemes">[IANA.URISchemes]</a></td>
+<td class="author-text">IANA, &ldquo;<a href="https://www.iana.org/assignments/uri-schemes">Uniform Resource Identifier (URI) Schemes</a>.&rdquo;</td></tr>
+<tr><td class="author-text" valign="top"><a name="IANA.time-zones">[IANA.time-zones]</a></td>
+<td class="author-text">IANA, &ldquo;<a href="https://www.iana.org/time-zones">Time Zone Database</a>.&rdquo;</td></tr>
+<tr><td class="author-text" valign="top"><a name="ISO29115">[ISO29115]</a></td>
+<td class="author-text">International Organization for Standardization, &ldquo;<a href="https://www.iso.org/standard/45138.html">ISO/IEC 29115:2013.
+	  Information technology - Security techniques - Entity authentication
+	  assurance framework</a>,&rdquo; ISO/IEC&nbsp;29115:2013, April&nbsp;2013.</td></tr>
+<tr><td class="author-text" valign="top"><a name="ISO3166-1">[ISO3166-1]</a></td>
+<td class="author-text">International Organization for
+	    Standardization, &ldquo;<a href="https://www.iso.org/standard/72482.html">ISO 3166-1:2020. Codes for the representation of names of
+	  countries and their subdivisions - Part 1: Country codes</a>,&rdquo; August&nbsp;2020.</td></tr>
+<tr><td class="author-text" valign="top"><a name="ISO639">[ISO639]</a></td>
+<td class="author-text">International Organization for
+	    Standardization, &ldquo;<a href="https://www.iso.org/standard/74575.html">ISO 639:2023. Code for individual languages and language groups</a>,&rdquo; November&nbsp;2023.</td></tr>
+<tr><td class="author-text" valign="top"><a name="ISO8601-1">[ISO8601-1]</a></td>
+<td class="author-text">International Organization for
+	    Standardization, &ldquo;<a href="https://www.iso.org/standard/81801.html">ISO 8601-1:2019/Amd 1:2022. Date and time - Representations for information interchange - Part 1: Basic rules</a>,&rdquo; October&nbsp;2022.</td></tr>
+<tr><td class="author-text" valign="top"><a name="JWA">[JWA]</a></td>
+<td class="author-text">Jones, M., &ldquo;<a href="https://www.rfc-editor.org/info/rfc7518">JSON Web Algorithms (JWA)</a>,&rdquo; RFC&nbsp;7518, DOI&nbsp;10.17487/RFC7518, May&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="JWE">[JWE]</a></td>
+<td class="author-text">Jones, M. and J. Hildebrand, &ldquo;<a href="https://www.rfc-editor.org/info/rfc7516">JSON Web Encryption (JWE)</a>,&rdquo; RFC&nbsp;7516, DOI&nbsp;10.17487/RFC7516, May&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="JWK">[JWK]</a></td>
+<td class="author-text">Jones, M., &ldquo;<a href="https://www.rfc-editor.org/info/rfc7517">JSON Web Key (JWK)</a>,&rdquo; RFC&nbsp;7517, DOI&nbsp;10.17487/RFC7517, May&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="JWS">[JWS]</a></td>
+<td class="author-text">Jones, M., Bradley, J., and N. Sakimura, &ldquo;<a href="https://www.rfc-editor.org/info/rfc7515">JSON Web Signature (JWS)</a>,&rdquo; RFC&nbsp;7515, DOI&nbsp;10.17487/RFC7515, May&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="JWT">[JWT]</a></td>
+<td class="author-text">Jones, M., Bradley, J., and N. Sakimura, &ldquo;<a href="https://www.rfc-editor.org/info/rfc7519">JSON Web Token (JWT)</a>,&rdquo; RFC&nbsp;7519, DOI&nbsp;10.17487/RFC7519, May&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OAuth.Assertions">[OAuth.Assertions]</a></td>
+<td class="author-text">Campbell, B., Mortimore, C., Jones, M., and Y. Goland, &ldquo;<a href="https://www.rfc-editor.org/info/rfc7521">Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants</a>,&rdquo; RFC&nbsp;7521, DOI&nbsp;10.17487/RFC7521, May&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OAuth.JWT">[OAuth.JWT]</a></td>
+<td class="author-text">Jones, M., Campbell, B., and C. Mortimore, &ldquo;<a href="https://www.rfc-editor.org/info/rfc7523">JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants</a>,&rdquo; RFC&nbsp;7523, DOI&nbsp;10.17487/RFC7523, May&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OAuth.Responses">[OAuth.Responses]</a></td>
+<td class="author-text">de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;<a href="https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html">OAuth 2.0 Multiple Response Type Encoding Practices</a>,&rdquo; February&nbsp;2014.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.Discovery">[OpenID.Discovery]</a></td>
+<td class="author-text">Sakimura, N., Bradley, J., Jones, M., and E. Jay, &ldquo;<a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OpenID Connect Discovery 1.0</a>,&rdquo; December&nbsp;2023.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.Registration">[OpenID.Registration]</a></td>
+<td class="author-text">Sakimura, N., Bradley, J., and M. Jones, &ldquo;<a href="https://openid.net/specs/openid-connect-registration-1_0.html">OpenID Connect Dynamic Client Registration 1.0</a>,&rdquo; December&nbsp;2023.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC20">[RFC20]</a></td>
+<td class="author-text">Cerf, V., &ldquo;<a href="https://www.rfc-editor.org/info/rfc20">ASCII format for Network Interchange</a>,&rdquo; STD&nbsp;80, RFC&nbsp;20, DOI&nbsp;10.17487/RFC0020, October&nbsp;1969.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC2119">[RFC2119]</a></td>
+<td class="author-text">Bradner, S., &ldquo;<a href="https://www.rfc-editor.org/info/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>,&rdquo; BCP&nbsp;14, RFC&nbsp;2119, DOI&nbsp;10.17487/RFC2119, March&nbsp;1997.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC3339">[RFC3339]</a></td>
+<td class="author-text">Klyne, G. and C. Newman, &ldquo;<a href="https://www.rfc-editor.org/info/rfc3339">Date and Time on the Internet: Timestamps</a>,&rdquo; RFC&nbsp;3339, DOI&nbsp;10.17487/RFC3339, July&nbsp;2002.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC3629">[RFC3629]</a></td>
+<td class="author-text">Yergeau, F., &ldquo;<a href="https://www.rfc-editor.org/info/rfc3629">UTF-8, a transformation format of ISO 10646</a>,&rdquo; STD&nbsp;63, RFC&nbsp;3629, DOI&nbsp;10.17487/RFC3629, November&nbsp;2003.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC3966">[RFC3966]</a></td>
+<td class="author-text">Schulzrinne, H., &ldquo;<a href="https://www.rfc-editor.org/info/rfc3966">The tel URI for Telephone Numbers</a>,&rdquo; RFC&nbsp;3966, DOI&nbsp;10.17487/RFC3966, December&nbsp;2004.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC3986">[RFC3986]</a></td>
+<td class="author-text">Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;<a href="https://www.rfc-editor.org/info/rfc3986">Uniform Resource Identifier (URI): Generic Syntax</a>,&rdquo; STD&nbsp;66, RFC&nbsp;3986, DOI&nbsp;10.17487/RFC3986, January&nbsp;2005.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC5322">[RFC5322]</a></td>
+<td class="author-text">Resnick, P., Ed., &ldquo;<a href="https://www.rfc-editor.org/info/rfc5322">Internet Message Format</a>,&rdquo; RFC&nbsp;5322, DOI&nbsp;10.17487/RFC5322, October&nbsp;2008.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC5646">[RFC5646]</a></td>
+<td class="author-text">Phillips, A., Ed. and M. Davis, Ed., &ldquo;<a href="https://www.rfc-editor.org/info/rfc5646">Tags for Identifying Languages</a>,&rdquo; BCP&nbsp;47, RFC&nbsp;5646, DOI&nbsp;10.17487/RFC5646, September&nbsp;2009.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC6125">[RFC6125]</a></td>
+<td class="author-text">Saint-Andre, P. and J. Hodges, &ldquo;<a href="https://www.rfc-editor.org/info/rfc6125">Representation and Verification of Domain-Based Application Service Identity within Internet Public Key Infrastructure Using X.509 (PKIX) Certificates in the Context of Transport Layer Security (TLS)</a>,&rdquo; RFC&nbsp;6125, DOI&nbsp;10.17487/RFC6125, March&nbsp;2011.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC6711">[RFC6711]</a></td>
+<td class="author-text">Johansson, L., &ldquo;<a href="https://www.rfc-editor.org/info/rfc6711">An IANA Registry for Level of Assurance (LoA) Profiles</a>,&rdquo; RFC&nbsp;6711, DOI&nbsp;10.17487/RFC6711, August&nbsp;2012.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC6749">[RFC6749]</a></td>
+<td class="author-text">Hardt, D., Ed., &ldquo;<a href="https://www.rfc-editor.org/info/rfc6749">The OAuth 2.0 Authorization Framework</a>,&rdquo; RFC&nbsp;6749, DOI&nbsp;10.17487/RFC6749, October&nbsp;2012.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC6750">[RFC6750]</a></td>
+<td class="author-text">Jones, M. and D. Hardt, &ldquo;<a href="https://www.rfc-editor.org/info/rfc6750">The OAuth 2.0 Authorization Framework: Bearer Token Usage</a>,&rdquo; RFC&nbsp;6750, DOI&nbsp;10.17487/RFC6750, October&nbsp;2012.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC6819">[RFC6819]</a></td>
+<td class="author-text">Lodderstedt, T., Ed., McGloin, M., and P. Hunt, &ldquo;<a href="https://www.rfc-editor.org/info/rfc6819">OAuth 2.0 Threat Model and Security Considerations</a>,&rdquo; RFC&nbsp;6819, DOI&nbsp;10.17487/RFC6819, January&nbsp;2013.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC7230">[RFC7230]</a></td>
+<td class="author-text">Fielding, R., Ed. and J. Reschke, Ed., &ldquo;<a href="https://www.rfc-editor.org/info/rfc7230">Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</a>,&rdquo; RFC&nbsp;7230, DOI&nbsp;10.17487/RFC7230, June&nbsp;2014.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC7231">[RFC7231]</a></td>
+<td class="author-text">Fielding, R., Ed. and J. Reschke, Ed., &ldquo;<a href="https://www.rfc-editor.org/info/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>,&rdquo; RFC&nbsp;7231, DOI&nbsp;10.17487/RFC7231, June&nbsp;2014.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC7234">[RFC7234]</a></td>
+<td class="author-text">Fielding, R., Ed., Nottingham, M., Ed., and J. Reschke, Ed., &ldquo;<a href="https://www.rfc-editor.org/info/rfc7234">Hypertext Transfer Protocol (HTTP/1.1): Caching</a>,&rdquo; RFC&nbsp;7234, DOI&nbsp;10.17487/RFC7234, June&nbsp;2014.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC8176">[RFC8176]</a></td>
+<td class="author-text">Jones, M., Hunt, P., and A. Nadalin, &ldquo;<a href="https://www.rfc-editor.org/info/rfc8176">Authentication Method Reference Values</a>,&rdquo; RFC&nbsp;8176, DOI&nbsp;10.17487/RFC8176, June&nbsp;2017.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC8259">[RFC8259]</a></td>
+<td class="author-text">Bray, T., Ed., &ldquo;<a href="https://www.rfc-editor.org/info/rfc8259">The JavaScript Object Notation (JSON) Data Interchange Format</a>,&rdquo; STD&nbsp;90, RFC&nbsp;8259, DOI&nbsp;10.17487/RFC8259, December&nbsp;2017.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC8996">[RFC8996]</a></td>
+<td class="author-text">Moriarty, K. and S. Farrell, &ldquo;<a href="https://www.rfc-editor.org/info/rfc8996">Deprecating TLS 1.0 and TLS 1.1</a>,&rdquo; BCP&nbsp;195, RFC&nbsp;8996, DOI&nbsp;10.17487/RFC8996, March&nbsp;2021.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC9325">[RFC9325]</a></td>
+<td class="author-text">Sheffer, Y., Saint-Andre, P., and T. Fossati, &ldquo;<a href="https://www.rfc-editor.org/info/rfc9325">Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS)</a>,&rdquo; BCP&nbsp;195, RFC&nbsp;9325, DOI&nbsp;10.17487/RFC9325, November&nbsp;2022.</td></tr>
+<tr><td class="author-text" valign="top"><a name="UNICODE">[UNICODE]</a></td>
+<td class="author-text">The Unicode Consortium, &ldquo;<a href="http://www.unicode.org/versions/latest/">The Unicode Standard</a>.&rdquo;</td></tr>
+<tr><td class="author-text" valign="top"><a name="USA15">[USA15]</a></td>
+<td class="author-text">Whistler, K., &ldquo;<a href="https://www.unicode.org/reports/tr15/">Unicode Normalization Forms</a>,&rdquo; Unicode Standard Annex&nbsp;15, August&nbsp;2023.</td></tr>
+<tr><td class="author-text" valign="top"><a name="W3C.SPSD-html401-20180327">[W3C.SPSD-html401-20180327]</a></td>
+<td class="author-text">&ldquo;<a href="https://www.w3.org/TR/2018/SPSD-html401-20180327/">HTML 4.01 Specification</a>,&rdquo; W3C REC&nbsp;SPSD-html401-20180327, W3C&nbsp;SPSD-html401-20180327, March&nbsp;2018.</td></tr>
+</table>
+
+<a name="rfc.references2"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<h3>19.2.&nbsp;Informative References</h3>
+<table width="99%" border="0">
+<tr><td class="author-text" valign="top"><a name="JWK.Thumbprint">[JWK.Thumbprint]</a></td>
+<td class="author-text">Jones, M. and N. Sakimura, &ldquo;<a href="https://www.rfc-editor.org/info/rfc7638">JSON Web Key (JWK) Thumbprint</a>,&rdquo; RFC&nbsp;7638, DOI&nbsp;10.17487/RFC7638, September&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OAuth.Post">[OAuth.Post]</a></td>
+<td class="author-text">Jones, M. and B. Campbell, &ldquo;<a href="https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html">OAuth 2.0 Form Post Response Mode</a>,&rdquo; April&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.2.0">[OpenID.2.0]</a></td>
+<td class="author-text">OpenID Foundation, &ldquo;<a href="https://openid.net/specs/openid-authentication-2_0.html">OpenID Authentication 2.0</a>,&rdquo; December&nbsp;2007.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.BackChannel">[OpenID.BackChannel]</a></td>
+<td class="author-text">Jones, M. and J. Bradley, &ldquo;<a href="https://openid.net/specs/openid-connect-backchannel-1_0.html">OpenID Connect Back-Channel Logout 1.0</a>,&rdquo; December&nbsp;2023.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.Basic">[OpenID.Basic]</a></td>
+<td class="author-text">Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;<a href="https://openid.net/specs/openid-connect-basic-1_0.html">OpenID Connect Basic Client Implementer's Guide 1.0</a>,&rdquo; December&nbsp;2023.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.Core.Errata1">[OpenID.Core.Errata1]</a></td>
+<td class="author-text">Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;<a href="https://openid.net/specs/openid-connect-core-1_0-errata1.html">OpenID Connect Core 1.0 incorporating errata set 1</a>,&rdquo; November&nbsp;2014.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.Core.Final">[OpenID.Core.Final]</a></td>
+<td class="author-text">Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;<a href="https://openid.net/specs/openid-connect-core-1_0-final.html">OpenID Connect Core 1.0 (final)</a>,&rdquo; February&nbsp;2014.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.FrontChannel">[OpenID.FrontChannel]</a></td>
+<td class="author-text">Jones, M., &ldquo;<a href="https://openid.net/specs/openid-connect-frontchannel-1_0.html">OpenID Connect Front-Channel Logout 1.0</a>,&rdquo; September&nbsp;2022.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.Implicit">[OpenID.Implicit]</a></td>
+<td class="author-text">Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;<a href="https://openid.net/specs/openid-connect-implicit-1_0.html">OpenID Connect Implicit Client Implementer's Guide 1.0</a>,&rdquo; December&nbsp;2023.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.PAPE">[OpenID.PAPE]</a></td>
+<td class="author-text">Recordon, D., Jones, M., Bufu, J., Ed., Daugherty, J., Ed., and N. Sakimura, &ldquo;<a href="https://openid.net/specs/openid-provider-authentication-policy-extension-1_0.html">OpenID Provider
+	  Authentication Policy Extension 1.0</a>,&rdquo; December&nbsp;2008.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.RPInitiated">[OpenID.RPInitiated]</a></td>
+<td class="author-text">Jones, M., de Medeiros, B., Agarwal, N., Sakimura, N., and J. Bradley, &ldquo;<a href="https://openid.net/specs/openid-connect-rpinitiated-1_0.html">OpenID Connect RP-Initiated Logout 1.0</a>,&rdquo; September&nbsp;2022.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.Session">[OpenID.Session]</a></td>
+<td class="author-text">de Medeiros, B., Agarwal, N., Sakimura, N., Bradley, J., and M. Jones, &ldquo;<a href="https://openid.net/specs/openid-connect-session-1_0.html">OpenID Connect Session Management 1.0</a>,&rdquo; September&nbsp;2022.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC4949">[RFC4949]</a></td>
+<td class="author-text">Shirey, R., &ldquo;<a href="https://www.rfc-editor.org/info/rfc4949">Internet Security Glossary, Version 2</a>,&rdquo; FYI&nbsp;36, RFC&nbsp;4949, DOI&nbsp;10.17487/RFC4949, August&nbsp;2007.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC7595">[RFC7595]</a></td>
+<td class="author-text">Thaler, D., Ed., Hansen, T., and T. Hardie, &ldquo;<a href="https://www.rfc-editor.org/info/rfc7595">Guidelines and Registration Procedures for URI Schemes</a>,&rdquo; BCP&nbsp;35, RFC&nbsp;7595, DOI&nbsp;10.17487/RFC7595, June&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC9101">[RFC9101]</a></td>
+<td class="author-text">Sakimura, N., Bradley, J., and M. Jones, &ldquo;<a href="https://www.rfc-editor.org/info/rfc9101">The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR)</a>,&rdquo; RFC&nbsp;9101, DOI&nbsp;10.17487/RFC9101, August&nbsp;2021.</td></tr>
+<tr><td class="author-text" valign="top"><a name="X.1252">[X.1252]</a></td>
+<td class="author-text">International Telecommunication Union, &ldquo;<a href="https://www.itu.int/SG-CP/example_docs/ITU-T-REC/ITU-T-REC_E.pdf">ITU-T Recommendation X.1252 - Cyberspace security - Identity management
+	  - Baseline identity management terms and definitions</a>,&rdquo; ITU-T&nbsp;X.1252, April&nbsp;2010.</td></tr>
+</table>
+
+<a name="AuthorizationExamples"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.A"></a><h3>Appendix A.&nbsp;
+Authorization Examples</h3>
+
+<p>
+	The following are non-normative examples of Authorization Requests with
+	different <tt>response_type</tt> values and their responses
+	(with line wraps within values for display purposes only):
+      
+</p>
+<a name="codeExample"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.A.1"></a><h3>A.1.&nbsp;
+Example using response_type=code</h3>
+<div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /authorize?
+    response_type=code
+    &amp;client_id=s6BhdRkqt3
+    &amp;redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+    &amp;scope=openid%20profile%20email
+    &amp;nonce=n-0S6_WzA2Mj
+    &amp;state=af0ifjsldkj HTTP/1.1
+  Host: server.example.com
+
+  HTTP/1.1 302 Found
+  Location: https://client.example.org/cb?
+    code=Qcb0Orv1zh30vL1MPRsbm-diHiMwcLyZvn1arpZv-Jxf_11jnpEX3Tgfvk
+    &amp;state=af0ifjsldkj
+</pre></div>
+<a name="id_tokenExample"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.A.2"></a><h3>A.2.&nbsp;
+Example using response_type=id_token</h3>
+<div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /authorize?
+    response_type=id_token
+    &amp;client_id=s6BhdRkqt3
+    &amp;redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+    &amp;scope=openid%20profile%20email
+    &amp;nonce=n-0S6_WzA2Mj
+    &amp;state=af0ifjsldkj HTTP/1.1
+  Host: server.example.com
+
+  HTTP/1.1 302 Found
+  Location: https://client.example.org/cb#
+    id_token=eyJraWQiOiIxZTlnZGs3IiwiYWxnIjoiUlMyNTYifQ.
+    ewogImlzcyI6ICJodHRwczovL3NlcnZlci5leGFtcGxlLmNvbSIsCiAic3ViIjog
+    IjI0ODI4OTc2MTAwMSIsCiAiYXVkIjogInM2QmhkUmtxdDMiLAogIm5vbmNlIjog
+    Im4tMFM2X1d6QTJNaiIsCiAiZXhwIjogMTMxMTI4MTk3MCwKICJpYXQiOiAxMzEx
+    MjgwOTcwLAogIm5hbWUiOiAiSmFuZSBEb2UiLAogImdpdmVuX25hbWUiOiAiSmFu
+    ZSIsCiAiZmFtaWx5X25hbWUiOiAiRG9lIiwKICJnZW5kZXIiOiAiZmVtYWxlIiwK
+    ICJiaXJ0aGRhdGUiOiAiMDAwMC0xMC0zMSIsCiAiZW1haWwiOiAiamFuZWRvZUBl
+    eGFtcGxlLmNvbSIsCiAicGljdHVyZSI6ICJodHRwOi8vZXhhbXBsZS5jb20vamFu
+    ZWRvZS9tZS5qcGciCn0.
+    NTibBYW_ZoNHGm4ZrWCqYA9oJaxr1AVrJCze6FEcac4t_EOQiJFbD2nVEPkUXPuM
+    shKjjTn7ESLIFUnfHq8UKTGibIC8uqrBgQAcUQFMeWeg-PkLvDTHk43Dn4_aNrxh
+    mWwMNQfkjqx3wd2Fvta9j8yG2Qn790Gwb5psGcmBhqMJUUnFrGpyxQDhFIzzodmP
+    okM7tnUxBNj-JuES_4CE-BvZICH4jKLp0TMu-WQsVst0ss-vY2RPdU1MzL59mq_e
+    Kk8Rv9XhxIr3WteA2ZlrgVyT0cwH3hlCnRUsLfHtIEb8k1Y_WaqKUu3DaKPxqRi6
+    u0rN7RO2uZYPzC454xe-mg
+    &amp;state=af0ifjsldkj
+</pre></div>
+<p>
+	  The value of the <tt>id_token</tt> parameter is the ID Token,
+	  which is a signed JWT,
+	  containing three base64url-encoded segments separated by period ('.') characters.
+	  The first segment represents the JOSE Header.
+	  Base64url decoding it will result in the following set of Header Parameters:
+	
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {"kid":"1e9gdk7","alg":"RS256"}
+</pre></div>
+<p>
+	  The <tt>alg</tt> value represents the algorithm
+	  that was used to sign the JWT, in this case
+	  <tt>RS256</tt>, representing RSASSA-PKCS1-v1_5 using SHA-256.
+	  The <tt>kid</tt> value is a key identifier used
+	  in identifying the key to be used to verify the signature.
+	  If the <tt>kid</tt> value is unknown to the RP,
+	  it needs to retrieve the contents of the OP's JWK Set again
+	  to obtain the OP's current set of keys.
+	
+</p>
+<p>
+	    The second segment represents the Claims in the ID Token.
+	    Verifying and decoding the ID Token will yield the following Claims:
+	  
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "iss": "https://server.example.com",
+   "sub": "248289761001",
+   "aud": "s6BhdRkqt3",
+   "nonce": "n-0S6_WzA2Mj",
+   "exp": 1311281970,
+   "iat": 1311280970,
+   "name": "Jane Doe",
+   "given_name": "Jane",
+   "family_name": "Doe",
+   "gender": "female",
+   "birthdate": "0000-10-31",
+   "email": "janedoe@example.com",
+   "picture": "http://example.com/janedoe/me.jpg"
+  }
+</pre></div>
+<p>
+	  The third segment represents the ID Token signature,
+	  which is verified as described in <a class='info' href='#JWS'>[JWS]<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Signature (JWS),&rdquo; May&nbsp;2015.</span><span>)</span></a>.
+	
+</p>
+<a name="id_token-tokenExample"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.A.3"></a><h3>A.3.&nbsp;
+Example using response_type=id_token&nbsp;token</h3>
+<div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /authorize?
+    response_type=id_token%20token
+    &amp;client_id=s6BhdRkqt3
+    &amp;redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+    &amp;scope=openid%20profile%20email
+    &amp;nonce=n-0S6_WzA2Mj
+    &amp;state=af0ifjsldkj HTTP/1.1
+  Host: server.example.com
+
+  HTTP/1.1 302 Found
+  Location: https://client.example.org/cb#
+    access_token=jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y
+    &amp;token_type=Bearer
+    &amp;id_token=eyJraWQiOiIxZTlnZGs3IiwiYWxnIjoiUlMyNTYifQ.
+    ewogImlzcyI6ICJodHRwczovL3NlcnZlci5leGFtcGxlLmNvbSIsCiAic3ViIjog
+    IjI0ODI4OTc2MTAwMSIsCiAiYXVkIjogInM2QmhkUmtxdDMiLAogIm5vbmNlIjog
+    Im4tMFM2X1d6QTJNaiIsCiAiZXhwIjogMTMxMTI4MTk3MCwKICJpYXQiOiAxMzEx
+    MjgwOTcwLAogImF0X2hhc2giOiAiNzdRbVVQdGpQZnpXdEYyQW5wSzlSUSIKfQ.
+    kdqTmftlaXg5WBYBr1wkxhkqCGZPc0k8vTiV5g2jj67jQ7XkrDamYx2bOkZLdZrp
+    MPIzkdYB1nZI_G8vQGQuamRhJcEIt21kblGPZ-yhEhdkAiZIZLu38rChalDS2Mh0
+    glE_rke5XXRhmqqoEFFdziFdnO3p61-7y51co84OEAZvARSINQaOWIzvioRfs4zw
+    IFOaT33Vpxfqr8HDyh31zo9eBW2dSQuCa071z0ENWChWoPliK1JCo_Bk9eDg2uwo
+    2ZwhsvHzj6TMQ0lYOTzufSlSmXIKfjlOsb3nftQeR697_hA-nMZyAdL8_NRfaC37
+    XnAbW8WB9wCfECp7cuNuOg
+    &amp;state=af0ifjsldkj
+</pre></div>
+<p>
+	    Verifying and decoding the ID Token will yield the following Claims:
+	  
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "iss": "https://server.example.com",
+   "sub": "248289761001",
+   "aud": "s6BhdRkqt3",
+   "nonce": "n-0S6_WzA2Mj",
+   "exp": 1311281970,
+   "iat": 1311280970,
+   "at_hash": "77QmUPtjPfzWtF2AnpK9RQ"
+  }
+</pre></div>
+<a name="code-id_tokenExample"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.A.4"></a><h3>A.4.&nbsp;
+Example using response_type=code&nbsp;id_token</h3>
+<div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /authorize?
+    response_type=code%20id_token
+    &amp;client_id=s6BhdRkqt3
+    &amp;redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+    &amp;scope=openid%20profile%20email
+    &amp;nonce=n-0S6_WzA2Mj
+    &amp;state=af0ifjsldkj HTTP/1.1
+  Host: server.example.com
+
+  HTTP/1.1 302 Found
+  Location: https://client.example.org/cb#
+    code=Qcb0Orv1zh30vL1MPRsbm-diHiMwcLyZvn1arpZv-Jxf_11jnpEX3Tgfvk
+    &amp;id_token=eyJraWQiOiIxZTlnZGs3IiwiYWxnIjoiUlMyNTYifQ.
+    ewogImlzcyI6ICJodHRwczovL3NlcnZlci5leGFtcGxlLmNvbSIsCiAic3ViIjog
+    IjI0ODI4OTc2MTAwMSIsCiAiYXVkIjogInM2QmhkUmtxdDMiLAogIm5vbmNlIjog
+    Im4tMFM2X1d6QTJNaiIsCiAiZXhwIjogMTMxMTI4MTk3MCwKICJpYXQiOiAxMzEx
+    MjgwOTcwLAogImNfaGFzaCI6ICJMRGt0S2RvUWFrM1BrMGNuWHhDbHRBIgp9.
+    MRPihYtNIcwKTZ_mcMSPfreVytGR4jfl1Tzbv4tH5Jr4WqONs2lUWrIEpZ2joKbZ
+    fAGlouAqwqSYpfR3FQYKYvdgnZ3kjIJ_5M4fAARXHVSciGyhfqB-OhDUMXSHzFHi
+    GKNY9TKSgRfiXf_314WRujpqaDtj2uoXbppobYXvAZIxWtsOein0-t91LDS39EW4
+    frNWAopKTBBi_XJPlpLVynWTDvNleEBP6UxIMgYJBKlqsP7RGfHTGk3ReXDacR7R
+    GZlIVGa-0qRyDzvNqD7xfu9aYufUP0oBGqdBGgFVNmwJ7rmB0gdPtC2eJsXq9svC
+    gBBfhRQZxhx1iLJjNc9nSw
+    &amp;state=af0ifjsldkj
+</pre></div>
+<p>
+	    Verifying and decoding the ID Token will yield the following Claims:
+	  
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "iss": "https://server.example.com",
+   "sub": "248289761001",
+   "aud": "s6BhdRkqt3",
+   "nonce": "n-0S6_WzA2Mj",
+   "exp": 1311281970,
+   "iat": 1311280970,
+   "c_hash": "LDktKdoQak3Pk0cnXxCltA"
+  }
+</pre></div>
+<a name="code-tokenExample"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.A.5"></a><h3>A.5.&nbsp;
+Example using response_type=code&nbsp;token</h3>
+<div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /authorize?
+    response_type=code%20token
+    &amp;client_id=s6BhdRkqt3
+    &amp;redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+    &amp;scope=openid%20profile%20email
+    &amp;nonce=n-0S6_WzA2Mj
+    &amp;state=af0ifjsldkj HTTP/1.1
+  Host: server.example.com
+
+  HTTP/1.1 302 Found
+  Location: https://client.example.org/cb#
+    code=Qcb0Orv1zh30vL1MPRsbm-diHiMwcLyZvn1arpZv-Jxf_11jnpEX3Tgfvk
+    &amp;access_token=jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y
+    &amp;token_type=Bearer
+    &amp;state=af0ifjsldkj
+</pre></div>
+<a name="code-id_token-tokenExample"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.A.6"></a><h3>A.6.&nbsp;
+Example using response_type=code&nbsp;id_token&nbsp;token</h3>
+<div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /authorize?
+    response_type=code%20id_token%20token
+    &amp;client_id=s6BhdRkqt3
+    &amp;redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+    &amp;scope=openid%20profile%20email
+    &amp;nonce=n-0S6_WzA2Mj
+    &amp;state=af0ifjsldkj HTTP/1.1
+  Host: server.example.com
+
+  HTTP/1.1 302 Found
+  Location: https://client.example.org/cb#
+    code=Qcb0Orv1zh30vL1MPRsbm-diHiMwcLyZvn1arpZv-Jxf_11jnpEX3Tgfvk
+    &amp;access_token=jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y
+    &amp;token_type=Bearer
+    &amp;id_token=eyJraWQiOiIxZTlnZGs3IiwiYWxnIjoiUlMyNTYifQ.
+    ewogImlzcyI6ICJodHRwczovL3NlcnZlci5leGFtcGxlLmNvbSIsCiAic3ViIjog
+    IjI0ODI4OTc2MTAwMSIsCiAiYXVkIjogInM2QmhkUmtxdDMiLAogIm5vbmNlIjog
+    Im4tMFM2X1d6QTJNaiIsCiAiZXhwIjogMTMxMTI4MTk3MCwKICJpYXQiOiAxMzEx
+    MjgwOTcwLAogImF0X2hhc2giOiAiNzdRbVVQdGpQZnpXdEYyQW5wSzlSUSIsCiAi
+    Y19oYXNoIjogIkxEa3RLZG9RYWszUGswY25YeENsdEEiCn0.
+    A2OhhJzbUNaCbNLqNaqetGLJoxB3ujVbq_HLYSOWgWCJ3-B__YxlqIg8gpeL0Vhv
+    rWX0mwz7w_pGTRN4JdgsI0xAlT5fob1ZPnrazgonSyzaXcg2bgD896SsBSlG_8JX
+    6JKaztXifn8k2gy65Me-sMyQrRF8xv_q1CeC871sZpMjJzy5nx65BTI17vcXjntZ
+    HADv6o2CrHrEdHp8xSlnTLiiIqgDOmKlpkeqqOBK6dqa4rXZlSqMAUm1LYZmtb2D
+    8sHvQsxTbWlBkX7VZaTSqMJ487s4ZIEea8Bw4KGVOntQue4VhBjBnQ4bQKhB_47D
+    xlWpSyOWdy3cer_zxKrfvw
+    &amp;state=af0ifjsldkj
+</pre></div>
+<p>
+	    Verifying and decoding the ID Token will yield the following Claims:
+	  
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "iss": "https://server.example.com",
+   "sub": "248289761001",
+   "aud": "s6BhdRkqt3",
+   "nonce": "n-0S6_WzA2Mj",
+   "exp": 1311281970,
+   "iat": 1311280970,
+   "at_hash": "77QmUPtjPfzWtF2AnpK9RQ",
+   "c_hash": "LDktKdoQak3Pk0cnXxCltA"
+  }
+</pre></div>
+<a name="ExampleRSAKey"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.A.7"></a><h3>A.7.&nbsp;
+RSA Key Used in Examples</h3>
+
+<p>
+	    The following RSA public key, represented in JWK format, can be used to
+	    validate the ID Token signatures in the above examples
+	    (with line wraps within values for display purposes only):
+	  
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  {
+   "kty":"RSA",
+   "kid":"1e9gdk7",
+   "n":"w7Zdfmece8iaB0kiTY8pCtiBtzbptJmP28nSWwtdjRu0f2GFpajvWE4VhfJA
+        jEsOcwYzay7XGN0b-X84BfC8hmCTOj2b2eHT7NsZegFPKRUQzJ9wW8ipn_aD
+        JWMGDuB1XyqT1E7DYqjUCEOD1b4FLpy_xPn6oV_TYOfQ9fZdbE5HGxJUzeku
+        GcOKqOQ8M7wfYHhHHLxGpQVgL0apWuP2gDDOdTtpuld4D2LK1MZK99s9gaSj
+        RHE8JDb1Z4IGhEcEyzkxswVdPndUWzfvWBBWXWxtSUvQGBRkuy1BHOa4sP6F
+        KjWEeeF7gm7UMs2Nm2QUgNZw6xvEDGaLk4KASdIxRQ",
+   "e":"AQAB"
+  }
+</pre></div>
+<a name="Acknowledgements"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.B"></a><h3>Appendix B.&nbsp;
+Acknowledgements</h3>
+
+<p>As a successor version of OpenID, this specification heavily relies
+      on ideas explored in <a class='info' href='#OpenID.2.0'>OpenID Authentication 2.0<span> (</span><span class='info'>OpenID Foundation, &ldquo;OpenID Authentication 2.0,&rdquo; December&nbsp;2007.</span><span>)</span></a> [OpenID.2.0]. Please
+      refer to Appendix C of OpenID Authentication 2.0 for the full list of
+      the contributors for that specification.
+</p>
+<p>
+	In addition, the OpenID Community would like to thank the following people for
+	their contributions to this specification:
+      
+</p>
+<p>
+	</p>
+<blockquote class="text">
+<p>Naveen Agarwal (Naveen.Agarwal@microsoft.com), Microsoft (was at Google)
+</p>
+<p>Amanda Anganes (aanganes@mitre.org), MITRE
+</p>
+<p>Casper Biering (cb@peercraft.com), Peercraft
+</p>
+<p>John Bradley (ve7jtb@ve7jtb.com), Yubico (was at Ping Identity)
+</p>
+<p>Tim Bray (tbray@textuality.com), independent (was at Google)
+</p>
+<p>Johnny Bufu (johnny.bufu@gmail.com), independent (was at Janrain)
+</p>
+<p>Brian Campbell (bcampbell@pingidentity.com), Ping Identity
+</p>
+<p>Blaine Cook (romeda@gmail.com), independent
+</p>
+<p>Breno de Medeiros (breno@google.com), Google
+</p>
+<p>Pamela Dingle (Pamela.Dingle@microsoft.com), Microsoft (was at Ping Identity)
+</p>
+<p>Vladimir Dzhuvinov (vladimir@connect2id.com), Connect2id (was at Nimbus Directory Services)
+</p>
+<p>George Fletcher (gffletch@aol.com), Capital One (was at AOL)
+</p>
+<p>Roland Hedberg (roland@catalogix.se), independent (was at University of Ume&aring;)
+</p>
+<p>Ryo Ito (ryo.ito@mixi.co.jp), mixi, Inc.
+</p>
+<p>Edmund Jay (ejay@mgi1.com), Illumila
+</p>
+<p>Michael B. Jones (michael_b_jones@hotmail.com), Self-Issued Consulting (was at Microsoft)
+</p>
+<p>Torsten Lodderstedt (torsten@lodderstedt.net), independent (was at Deutsche Telekom)
+</p>
+<p>James Manger (James.H.Manger@team.telstra.com), Telstra
+</p>
+<p>Nov Matake (nov@matake.jp), independent
+</p>
+<p>Chuck Mortimore (charliemortimore@gmail.com), Disney (was at Salesforce)
+</p>
+<p>Anthony Nadalin (nadalin@prodigy.net), independent (was at Microsoft)
+</p>
+<p>Hideki Nara (hdknr@ic-tact.co.jp), Tact Communications
+</p>
+<p>Axel Nennker (axel.nennker@telekom.de), Deutsche Telekom
+</p>
+<p>David Recordon (recordond@gmail.com), independent (was at Facebook)
+</p>
+<p>Justin Richer (justin@bspk.io), Bespoke Engineering (was at MITRE)
+</p>
+<p>Nat Sakimura (nat@nat.consulting), NAT.Consulting (was at NRI)
+</p>
+<p>Luke Shepard (luke@lukeshepard.com), Facebook
+</p>
+<p>Andreas &Aring;kre Solberg (Andreas.Solberg@sikt.no), Sikt (was at UNINET)
+</p>
+<p>Paul Tarjan (paul@paultarjan.com), Facebook
+</p>
+</blockquote><p>
+      
+</p>
+<a name="Notices"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.C"></a><h3>Appendix C.&nbsp;
+Notices</h3>
+
+<p>Copyright (c) 2023 The OpenID Foundation.
+</p>
+<p>
+	The OpenID Foundation (OIDF) grants to any Contributor, developer,
+	implementer, or other interested party a non-exclusive, royalty free,
+	worldwide copyright license to reproduce, prepare derivative works from,
+	distribute, perform and display, this Implementers Draft or
+	Final Specification solely for the purposes of (i) developing
+	specifications, and (ii) implementing Implementers Drafts and
+	Final Specifications based on such documents, provided that attribution
+	be made to the OIDF as the source of the material, but that such attribution
+	does not indicate an endorsement by the OIDF.
+      
+</p>
+<p>
+	The technology described in this specification was
+	made available from contributions from various sources,
+	including members of the OpenID Foundation and others.
+	Although the OpenID Foundation has taken steps to help ensure
+	that the technology is available for distribution, it takes
+	no position regarding the validity or scope of any intellectual
+	property or other rights that might be claimed to pertain to
+	the implementation or use of the technology described in
+	this specification or the extent to which any license under
+	such rights might or might not be available; neither does it
+	represent that it has made any independent effort to identify
+	any such rights.  The OpenID Foundation and the contributors
+	to this specification make no (and hereby expressly disclaim any)
+	warranties (express, implied, or otherwise), including implied
+	warranties of merchantability, non-infringement, fitness for
+	a particular purpose, or title, related to this specification,
+	and the entire risk as to implementing this specification is
+	assumed by the implementer.  The OpenID Intellectual
+	Property Rights policy requires contributors to offer
+	a patent promise not to assert certain patent claims against
+	other contributors and against implementers.  The OpenID Foundation invites
+	any interested party to bring to its attention any copyrights,
+	patents, patent applications, or other proprietary rights
+	that may cover technology that may be required to practice
+	this specification.
+      
+</p>
+<a name="rfc.authors"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<h3>Authors' Addresses</h3>
+<table width="99%" border="0" cellpadding="0" cellspacing="0">
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Nat Sakimura</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">NAT.Consulting</td></tr>
+<tr><td class="author" align="right">Email:&nbsp;</td>
+<td class="author-text"><a href="mailto:nat@nat.consulting">nat@nat.consulting</a></td></tr>
+<tr><td class="author" align="right">URI:&nbsp;</td>
+<td class="author-text"><a href="https://nat.sakimura.org/">https://nat.sakimura.org/</a></td></tr>
+<tr cellpadding="3"><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">John Bradley</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Yubico</td></tr>
+<tr><td class="author" align="right">Email:&nbsp;</td>
+<td class="author-text"><a href="mailto:ve7jtb@ve7jtb.com">ve7jtb@ve7jtb.com</a></td></tr>
+<tr><td class="author" align="right">URI:&nbsp;</td>
+<td class="author-text"><a href="http://www.thread-safe.com/">http://www.thread-safe.com/</a></td></tr>
+<tr cellpadding="3"><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Michael B. Jones</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Self-Issued Consulting</td></tr>
+<tr><td class="author" align="right">Email:&nbsp;</td>
+<td class="author-text"><a href="mailto:michael_b_jones@hotmail.com">michael_b_jones@hotmail.com</a></td></tr>
+<tr><td class="author" align="right">URI:&nbsp;</td>
+<td class="author-text"><a href="https://self-issued.info/">https://self-issued.info/</a></td></tr>
+<tr cellpadding="3"><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Breno de Medeiros</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Google</td></tr>
+<tr><td class="author" align="right">Email:&nbsp;</td>
+<td class="author-text"><a href="mailto:breno@google.com">breno@google.com</a></td></tr>
+<tr><td class="author" align="right">URI:&nbsp;</td>
+<td class="author-text"><a href="https://stackoverflow.com/users/311376/breno">https://stackoverflow.com/users/311376/breno</a></td></tr>
+<tr cellpadding="3"><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Chuck Mortimore</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Disney</td></tr>
+<tr><td class="author" align="right">Email:&nbsp;</td>
+<td class="author-text"><a href="mailto:charliemortimore@gmail.com">charliemortimore@gmail.com</a></td></tr>
+<tr><td class="author" align="right">URI:&nbsp;</td>
+<td class="author-text"><a href="https://twitter.com/cmort">https://twitter.com/cmort</a></td></tr>
+</table>
+</body></html>

--- a/rfc/openid-connect-discovery-1_0.html
+++ b/rfc/openid-connect-discovery-1_0.html
@@ -1,0 +1,2431 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en"><head><title>Final: OpenID Connect Discovery 1.0 incorporating errata set 2</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta name="description" content="OpenID Connect Discovery 1.0 incorporating errata set 2">
+<meta name="generator" content="xml2rfc v1.37pre1 (http://xml.resource.org/)">
+<style type='text/css'><!--
+        body {
+                font-family: verdana, charcoal, helvetica, arial, sans-serif;
+                font-size: small; color: #000; background-color: #FFF;
+                margin: 2em;
+        }
+        h1, h2, h3, h4, h5, h6 {
+                font-family: helvetica, monaco, "MS Sans Serif", arial, sans-serif;
+                font-weight: bold; font-style: normal;
+        }
+        h1 { color: #900; background-color: transparent; text-align: right; }
+        h3 { color: #333; background-color: transparent; }
+
+        td.RFCbug {
+                font-size: x-small; text-decoration: none;
+                width: 30px; height: 30px; padding-top: 2px;
+                text-align: justify; vertical-align: middle;
+                background-color: #000;
+        }
+        td.RFCbug span.RFC {
+                font-family: monaco, charcoal, geneva, "MS Sans Serif", helvetica, verdana, sans-serif;
+                font-weight: bold; color: #666;
+        }
+        td.RFCbug span.hotText {
+                font-family: charcoal, monaco, geneva, "MS Sans Serif", helvetica, verdana, sans-serif;
+                font-weight: normal; text-align: center; color: #FFF;
+        }
+
+        table.TOCbug { width: 30px; height: 15px; }
+        td.TOCbug {
+                text-align: center; width: 30px; height: 15px;
+                color: #FFF; background-color: #900;
+        }
+        td.TOCbug a {
+                font-family: monaco, charcoal, geneva, "MS Sans Serif", helvetica, sans-serif;
+                font-weight: bold; font-size: x-small; text-decoration: none;
+                color: #FFF; background-color: transparent;
+        }
+
+        td.header {
+                font-family: arial, helvetica, sans-serif; font-size: x-small;
+                vertical-align: top; width: 33%;
+                color: #FFF; background-color: #666;
+        }
+        td.author { font-weight: bold; font-size: x-small; margin-left: 4em; }
+        td.author-text { font-size: x-small; }
+
+        /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+        a.info {
+                /* This is the key. */
+                position: relative;
+                z-index: 24;
+                text-decoration: none;
+        }
+        a.info:hover {
+                z-index: 25;
+                color: #FFF; background-color: #900;
+        }
+        a.info span { display: none; }
+        a.info:hover span.info {
+                /* The span will display just on :hover state. */
+                display: block;
+                position: absolute;
+                font-size: smaller;
+                top: 2em; left: -5em; width: 15em;
+                padding: 2px; border: 1px solid #333;
+                color: #900; background-color: #EEE;
+                text-align: left;
+        }
+
+        a { font-weight: bold; }
+        a:link    { color: #900; background-color: transparent; }
+        a:visited { color: #633; background-color: transparent; }
+        a:active  { color: #633; background-color: transparent; }
+
+        p { margin-left: 2em; margin-right: 2em; }
+        p.copyright { font-size: x-small; }
+        p.toc { font-size: small; font-weight: bold; margin-left: 3em; }
+        table.toc { margin: 0 0 0 3em; padding: 0; border: 0; vertical-align: text-top; }
+        td.toc { font-size: small; font-weight: bold; vertical-align: text-top; }
+
+        ol.text { margin-left: 2em; margin-right: 2em; }
+        ul.text { margin-left: 2em; margin-right: 2em; }
+        li      { margin-left: 3em; }
+
+        /* RFC-2629 <spanx>s and <artwork>s. */
+        em     { font-style: italic; }
+        strong { font-weight: bold; }
+        dfn    { font-weight: bold; font-style: normal; }
+        cite   { font-weight: normal; font-style: normal; }
+        tt     { color: #036; }
+        tt, pre, pre dfn, pre em, pre cite, pre span {
+                font-family: "Courier New", Courier, monospace; font-size: small;
+        }
+        pre {
+                text-align: left; padding: 4px;
+                color: #000; background-color: #CCC;
+        }
+        pre dfn  { color: #900; }
+        pre em   { color: #66F; background-color: #FFC; font-weight: normal; }
+        pre .key { color: #33C; font-weight: bold; }
+        pre .id  { color: #900; }
+        pre .str { color: #000; background-color: #CFF; }
+        pre .val { color: #066; }
+        pre .rep { color: #909; }
+        pre .oth { color: #000; background-color: #FCF; }
+        pre .err { background-color: #FCC; }
+
+        /* RFC-2629 <texttable>s. */
+        table.all, table.full, table.headers, table.none {
+                font-size: small; text-align: center; border-width: 2px;
+                vertical-align: top; border-collapse: collapse;
+        }
+        table.all, table.full { border-style: solid; border-color: black; }
+        table.headers, table.none { border-style: none; }
+        th {
+                font-weight: bold; border-color: black;
+                border-width: 2px 2px 3px 2px;
+        }
+        table.all th, table.full th { border-style: solid; }
+        table.headers th { border-style: none none solid none; }
+        table.none th { border-style: none; }
+        table.all td {
+                border-style: solid; border-color: #333;
+                border-width: 1px 2px;
+        }
+        table.full td, table.headers td, table.none td { border-style: none; }
+
+        hr { height: 1px; }
+        hr.insert {
+                width: 80%; border-style: none; border-width: 0;
+                color: #CCC; background-color: #CCC;
+        }
+--></style>
+</head>
+<body>
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<table summary="layout" width="66%" border="0" cellpadding="0" cellspacing="0"><tr><td><table summary="layout" width="100%" border="0" cellpadding="2" cellspacing="1">
+<tr><td class="header">Final</td><td class="header">N. Sakimura</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">NAT.Consulting (was at NRI)</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">J. Bradley</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">Yubico (was at Ping Identity)</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">M. Jones</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">Self-Issued Consulting (was at</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">Microsoft)</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">E. Jay</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">Illumila</td></tr>
+<tr><td class="header">&nbsp;</td><td class="header">December 15, 2023</td></tr>
+</table></td></tr></table>
+<h1><br />OpenID Connect Discovery 1.0 incorporating errata set 2</h1>
+
+<h3>Abstract</h3>
+
+<p>OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0
+      protocol. It enables Clients to verify the identity of the End-User based
+      on the authentication performed by an Authorization Server, as well as to
+      obtain basic profile information about the End-User in an interoperable and
+      REST-like manner.
+</p>
+<p>
+	This specification defines a mechanism for an OpenID Connect Relying Party
+	to discover the End-User's OpenID Provider
+	and obtain information needed to interact with it,
+	including its OAuth 2.0 endpoint locations.
+      
+</p><a name="toc"></a><br /><hr />
+<h3>Table of Contents</h3>
+<p class="toc">
+<a href="#Introduction">1.</a>&nbsp;
+Introduction<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#rnc">1.1.</a>&nbsp;
+Requirements Notation and Conventions<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#Terminology">1.2.</a>&nbsp;
+Terminology<br />
+<a href="#IssuerDiscovery">2.</a>&nbsp;
+OpenID Provider Issuer Discovery<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#IdentifierNormalization">2.1.</a>&nbsp;
+Identifier Normalization<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#IdentifierTypes">2.1.1.</a>&nbsp;
+User Input Identifier Types<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#NormalizationSteps">2.1.2.</a>&nbsp;
+Normalization Steps<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#Examples">2.2.</a>&nbsp;
+Non-Normative Examples<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#EmailSyntax">2.2.1.</a>&nbsp;
+User Input using E-Mail Address Syntax<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#URLSyntax">2.2.2.</a>&nbsp;
+User Input using URL Syntax<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#HostPortExample">2.2.3.</a>&nbsp;
+User Input using Hostname and Port Syntax<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#AcctURISyntax">2.2.4.</a>&nbsp;
+User Input using "acct" URI Syntax<br />
+<a href="#ProviderMetadata">3.</a>&nbsp;
+OpenID Provider Metadata<br />
+<a href="#ProviderConfig">4.</a>&nbsp;
+Obtaining OpenID Provider Configuration Information<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ProviderConfigurationRequest">4.1.</a>&nbsp;
+OpenID Provider Configuration Request<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ProviderConfigurationResponse">4.2.</a>&nbsp;
+OpenID Provider Configuration Response<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#ProviderConfigurationValidation">4.3.</a>&nbsp;
+OpenID Provider Configuration Validation<br />
+<a href="#StringOps">5.</a>&nbsp;
+String Operations<br />
+<a href="#ImplementationConsiderations">6.</a>&nbsp;
+Implementation Considerations<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#CompatibilityNotes">6.1.</a>&nbsp;
+Compatibility Notes<br />
+<a href="#Security">7.</a>&nbsp;
+Security Considerations<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#TLSRequirements">7.1.</a>&nbsp;
+TLS Requirements<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#Impersonation">7.2.</a>&nbsp;
+Impersonation Attacks<br />
+<a href="#IANA">8.</a>&nbsp;
+IANA Considerations<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#WellKnownRegistry">8.1.</a>&nbsp;
+Well-Known URI Registry<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#WellKnownContents">8.1.1.</a>&nbsp;
+Registry Contents<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#MetadataRegistry">8.2.</a>&nbsp;
+OAuth Authorization Server Metadata Registry<br />
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="#MetadataContents">8.2.1.</a>&nbsp;
+Registry Contents<br />
+<a href="#rfc.references1">9.</a>&nbsp;
+References<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#rfc.references1">9.1.</a>&nbsp;
+Normative References<br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#rfc.references2">9.2.</a>&nbsp;
+Informative References<br />
+<a href="#Acknowledgements">Appendix&nbsp;A.</a>&nbsp;
+Acknowledgements<br />
+<a href="#Notices">Appendix&nbsp;B.</a>&nbsp;
+Notices<br />
+<a href="#rfc.authors">&#167;</a>&nbsp;
+Authors' Addresses<br />
+</p>
+<br clear="all" />
+
+<a name="Introduction"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.1"></a><h3>1.&nbsp;
+Introduction</h3>
+
+<p>
+	OpenID Connect 1.0 is a simple identity layer on top of the OAuth 2.0
+	<a class='info' href='#RFC6749'>[RFC6749]<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a>
+	protocol. It enables Clients to verify the identity of the End-User based
+	on the authentication performed by an Authorization Server, as well as to
+	obtain basic profile information about the End-User in an interoperable and
+	REST-like manner.
+      
+</p>
+<p>
+	In order for an OpenID Connect Relying Party to utilize OpenID Connect services for
+	an End-User, the RP needs to know where the OpenID Provider is.
+	OpenID Connect uses <a class='info' href='#RFC7033'>WebFinger<span> (</span><span class='info'>Jones, P., Salgueiro, G., Jones, M., and J. Smarr, &ldquo;WebFinger,&rdquo; September&nbsp;2013.</span><span>)</span></a> [RFC7033] to locate
+	the OpenID Provider for an End-User.
+	This process is described in <a class='info' href='#IssuerDiscovery'>Section&nbsp;2<span> (</span><span class='info'>OpenID Provider Issuer Discovery</span><span>)</span></a>.
+      
+</p>
+<p>
+	Once the OpenID Provider has been identified,
+	the configuration information for that OP
+	is retrieved from a well-known location as a JSON <a class='info' href='#RFC8259'>[RFC8259]<span> (</span><span class='info'>Bray, T., Ed., &ldquo;The JavaScript Object Notation (JSON) Data Interchange Format,&rdquo; December&nbsp;2017.</span><span>)</span></a> document,
+	including its OAuth 2.0 endpoint locations.
+	This process is described in <a class='info' href='#ProviderConfig'>Section&nbsp;4<span> (</span><span class='info'>Obtaining OpenID Provider Configuration Information</span><span>)</span></a>.
+      
+</p>
+<p>
+	The previous versions of this specification are:
+	</p>
+<ul class="text">
+<li><a class='info' href='#OpenID.Discovery.Errata1'>OpenID Connect Discovery 1.0 incorporating errata set 1<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., and E. Jay, &ldquo;OpenID Connect Discovery 1.0 incorporating errata set 1,&rdquo; November&nbsp;2014.</span><span>)</span></a> [OpenID.Discovery.Errata1]
+</li>
+<li><a class='info' href='#OpenID.Discovery.Final'>OpenID Connect Discovery 1.0 (final)<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., and E. Jay, &ldquo;OpenID Connect Discovery 1.0 (final),&rdquo; February&nbsp;2014.</span><span>)</span></a> [OpenID.Discovery.Final]
+</li>
+</ul><p>
+      
+</p>
+<a name="rnc"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.1.1"></a><h3>1.1.&nbsp;
+Requirements Notation and Conventions</h3>
+
+<p>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+	"SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+	document are to be interpreted as described in <a class='info' href='#RFC2119'>RFC 2119<span> (</span><span class='info'>Bradner, S., &ldquo;Key words for use in RFCs to Indicate Requirement Levels,&rdquo; March&nbsp;1997.</span><span>)</span></a> [RFC2119].
+</p>
+<p>
+	  In the .txt version of this specification,
+	  values are quoted to indicate that they are to be taken literally.
+	  When using these values in protocol messages,
+	  the quotes MUST NOT be used as part of the value.
+	  In the HTML version of this specification,
+	  values to be taken literally are indicated by
+	  the use of <tt>this fixed-width font</tt>.
+	
+</p>
+<p>
+	  All uses of <a class='info' href='#JWS'>JSON Web Signature (JWS)<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Signature (JWS),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWS]
+	  and <a class='info' href='#JWE'>JSON Web Encryption (JWE)<span> (</span><span class='info'>Jones, M. and J. Hildebrand, &ldquo;JSON Web Encryption (JWE),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWE]
+	  data structures in this specification utilize
+	  the JWS Compact Serialization or the JWE Compact Serialization;
+	  the JWS JSON Serialization and the JWE JSON Serialization are not used.
+	
+</p>
+<a name="Terminology"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.1.2"></a><h3>1.2.&nbsp;
+Terminology</h3>
+
+<p>
+	  This specification uses the terms "Authorization Code",
+	  "Authorization Endpoint", "Authorization Server",
+	  "Client", "Client Authentication", "Client Secret",
+	  "Grant Type",
+	  "Response Type", and "Token Endpoint"
+	  defined by <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749],
+	  the terms "Claim Name", "Claim Value", and "JSON Web Token (JWT)"
+	  defined by <a class='info' href='#JWT'>JSON Web Token (JWT)<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a> [JWT],
+	  and the terms defined by
+	  <a class='info' href='#OpenID.Core'>OpenID Connect Core 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;OpenID Connect Core 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Core] and
+	  <a class='info' href='#OAuth.Responses'>OAuth 2.0 Multiple Response Type Encoding Practices<span> (</span><span class='info'>de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;OAuth 2.0 Multiple Response Type Encoding Practices,&rdquo; February&nbsp;2014.</span><span>)</span></a> [OAuth.Responses].
+	
+</p>
+<p>
+	  This specification also defines the following terms:
+	  </p>
+<blockquote class="text"><dl>
+<dt>Resource</dt>
+<dd>
+	      
+	      Entity that is the target of a request in WebFinger.
+	    
+</dd>
+<dt>Host</dt>
+<dd>
+	      
+	      Server where a WebFinger service is hosted.
+	    
+</dd>
+<dt>Identifier</dt>
+<dd>
+	      
+	     Value that uniquely characterizes an Entity in a specific context.
+	    
+</dd>
+<dt></dt>
+<dd>
+	      NOTE: This specification defines various kinds of Identifiers, designed for use in different contexts.
+	      Examples include URLs using the <tt>https</tt> scheme and e-mail addresses.
+	    
+</dd>
+</dl></blockquote><p>
+	
+</p>
+<p>
+	  IMPORTANT NOTE TO READERS: The terminology definitions in
+	  this section are a normative portion of this specification,
+	  imposing requirements upon implementations.  All the
+	  capitalized words in the text of this specification, such as
+	  "Identifier", reference these defined terms.
+	  Whenever the reader encounters them, their definitions
+	  found in this section must be followed.
+	
+</p>
+<a name="IssuerDiscovery"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.2"></a><h3>2.&nbsp;
+OpenID Provider Issuer Discovery</h3>
+
+<p>
+	OpenID Provider Issuer discovery is the process of determining
+	the location of the OpenID Provider.
+      
+</p>
+<p>
+	Issuer discovery is OPTIONAL; if a Relying Party knows the
+	OP's Issuer location through an out-of-band mechanism, it can skip this step
+	and proceed to <a class='info' href='#ProviderConfig'>Section&nbsp;4<span> (</span><span class='info'>Obtaining OpenID Provider Configuration Information</span><span>)</span></a>.
+      
+</p>
+<p>
+	The following information is needed to perform issuer discovery
+	using <a class='info' href='#RFC7033'>WebFinger<span> (</span><span class='info'>Jones, P., Salgueiro, G., Jones, M., and J. Smarr, &ldquo;WebFinger,&rdquo; September&nbsp;2013.</span><span>)</span></a> [RFC7033]:
+      
+</p>
+<p></p>
+<blockquote class="text"><dl>
+<dt>resource</dt>
+<dd>
+	    
+	    Identifier for the target End-User that is the
+	    subject of the discovery request.
+	  
+</dd>
+<dt>host</dt>
+<dd>
+	    
+	    Server where a WebFinger service is hosted.
+	  
+</dd>
+<dt>rel</dt>
+<dd>
+	    
+	    URI identifying the type of service whose location is being requested.
+	  
+</dd>
+</dl></blockquote>
+
+<p>OpenID Connect uses the following discoverable
+      <tt>rel</tt> value in
+      <a class='info' href='#RFC7033'>WebFinger<span> (</span><span class='info'>Jones, P., Salgueiro, G., Jones, M., and J. Smarr, &ldquo;WebFinger,&rdquo; September&nbsp;2013.</span><span>)</span></a> [RFC7033]:
+</p><table class="all" align="center" border="0" cellpadding="2" cellspacing="2">
+<col align="left"><col align="left">
+<tr><th align="left">Rel Type</th><th align="left">URI</th></tr>
+<tr>
+<td align="left">OpenID Connect Issuer</td>
+<td align="left">http://openid.net/specs/connect/1.0/issuer</td>
+</tr>
+</table>
+<br clear="all" />
+
+<p>
+	To start discovery of OpenID endpoints, the End-User supplies an
+	Identifier to the Relying Party.
+	Any Web input form MUST employ Cross-Site Request Forgery (CSRF) prevention <a class='info' href='#OWASP.CSRF'>[OWASP.CSRF]<span> (</span><span class='info'>OWASP, &ldquo;Cross-Site Request Forgery Prevention Cheat Sheet,&rdquo; .</span><span>)</span></a>.
+      
+</p>
+<p>
+      The RP applies
+      normalization rules to the Identifier to determine the Resource and Host.
+      Then it makes an HTTP <tt>GET</tt> request to the Host's
+      <a class='info' href='#RFC7033'>WebFinger<span> (</span><span class='info'>Jones, P., Salgueiro, G., Jones, M., and J. Smarr, &ldquo;WebFinger,&rdquo; September&nbsp;2013.</span><span>)</span></a> [RFC7033]
+      endpoint with the <tt>resource</tt>
+      parameter to obtain the location of the
+      requested service.
+      Use of the <tt>rel</tt> parameter in the request with a value of
+      <tt>http://openid.net/specs/connect/1.0/issuer</tt>
+      is also RECOMMENDED to narrow the response to the specific link relation type needed.
+      
+</p>
+<p>
+      All WebFinger communication MUST utilize TLS
+      in the manner described in <a class='info' href='#TLSRequirements'>Section&nbsp;7.1<span> (</span><span class='info'>TLS Requirements</span><span>)</span></a>.
+      The WebFinger endpoint SHOULD support the use of
+      <a class='info' href='#CORS'>Cross-Origin Resource Sharing (CORS)<span> (</span><span class='info'>Opera Software ASA, &ldquo;Cross-Origin Resource Sharing,&rdquo; July&nbsp;2010.</span><span>)</span></a> [CORS]
+      and/or other methods as appropriate
+      to enable JavaScript Clients and other Browser-Based Clients to access it.
+      
+</p>
+<p>
+	The Issuer location MUST be returned in the WebFinger response
+	as the value of the <tt>href</tt> member of
+	a <tt>links</tt> array element
+	with <tt>rel</tt> member value
+	<tt>http://openid.net/specs/connect/1.0/issuer</tt>.
+	(Per Section 7 of <a class='info' href='#RFC7033'>WebFinger<span> (</span><span class='info'>Jones, P., Salgueiro, G., Jones, M., and J. Smarr, &ldquo;WebFinger,&rdquo; September&nbsp;2013.</span><span>)</span></a> [RFC7033], obtaining the
+	WebFinger response may first involve following some redirects.)
+      
+</p>
+<p>
+	The returned Issuer location MUST be a URI <a class='info' href='#RFC3986'>RFC 3986<span> (</span><span class='info'>Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;Uniform Resource Identifier (URI): Generic Syntax,&rdquo; January&nbsp;2005.</span><span>)</span></a> [RFC3986]
+	with a scheme component that MUST be <tt>https</tt>,
+	a host component, and optionally, port and path components
+	and no query or fragment components.
+	Note that since the Host and Resource values determined from
+	the user input Identifier,
+	as described in <a class='info' href='#IdentifierNormalization'>Section&nbsp;2.1<span> (</span><span class='info'>Identifier Normalization</span><span>)</span></a>,
+	are used as input to a WebFinger request,
+	which can return an Issuer value using a completely different
+	scheme, host, port, and path, no relationship can be assumed between
+	the user input Identifier string and the resulting Issuer location.
+      
+</p>
+<a name="IdentifierNormalization"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.2.1"></a><h3>2.1.&nbsp;
+Identifier Normalization</h3>
+
+<p>
+	  The purpose of Identifier normalization is to determine normalized
+	  Resource and Host values from the user input Identifier.
+	  These are then used as WebFinger request parameters
+	  to discover the Issuer location.
+	
+</p>
+<p>
+          The user input Identifier SHOULD be a URL or URI relative reference
+          defined in <a class='info' href='#RFC3986'>RFC 3986<span> (</span><span class='info'>Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;Uniform Resource Identifier (URI): Generic Syntax,&rdquo; January&nbsp;2005.</span><span>)</span></a> [RFC3986].
+          The user input Identifier MUST
+          include the authority component.
+        
+</p>
+<p>
+          NOTE: A URI relative reference includes a string that looks like
+          an e-mail address in the form of <tt>userinfo@host</tt>.
+          This is a valid authority component of a URI
+          but excludes various possible extra strings allowed in
+          <tt>addr-spec</tt> syntax of
+          <a class='info' href='#RFC5322'>RFC 5322<span> (</span><span class='info'>Resnick, P., Ed., &ldquo;Internet Message Format,&rdquo; October&nbsp;2008.</span><span>)</span></a> [RFC5322].
+        
+</p>
+<p>
+	  The Identifier normalization rules MAY be extended by
+	  additional specifications to enable other identifier types
+	  such as telephone numbers or <a class='info' href='#XRI_Syntax_2.0'>XRIs<span> (</span><span class='info'>Reed, D. and D. McAlpin, &ldquo;Extensible Resource Identifier (XRI) Syntax V2.0,&rdquo; November&nbsp;2005.</span><span>)</span></a> [XRI_Syntax_2.0] to also be used.
+	
+</p>
+<a name="IdentifierTypes"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.2.1.1"></a><h3>2.1.1.&nbsp;
+User Input Identifier Types</h3>
+
+<p>
+            A user input Identifier can be categorized into the following
+            types, which require different normalization processes:
+          
+</p>
+<p>
+            </p>
+<ol class="text">
+<li>User input Identifiers starting with the <a class='info' href='#XRI_Syntax_2.0'>XRI<span> (</span><span class='info'>Reed, D. and D. McAlpin, &ldquo;Extensible Resource Identifier (XRI) Syntax V2.0,&rdquo; November&nbsp;2005.</span><span>)</span></a> [XRI_Syntax_2.0] global context
+              symbols ('=','@', and '!') are RESERVED.  Processing of
+              these identifiers is out of scope for this
+              specification.
+</li>
+<li>All other user input Identifiers MUST be treated as
+	      a URI in one of the forms
+            <tt>scheme "://" authority path-abempty [ "?" query ] [ "#" fragment ]</tt>
+            or
+            <tt>authority path-abempty [ "?" query ] [ "#" fragment ]</tt>
+	    or
+	    <tt>scheme ":" path-rootless</tt>,
+            per <a class='info' href='#RFC3986'>RFC 3986<span> (</span><span class='info'>Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;Uniform Resource Identifier (URI): Generic Syntax,&rdquo; January&nbsp;2005.</span><span>)</span></a> [RFC3986].
+              
+</li>
+</ol><p>
+          
+</p>
+<p>
+	    NOTE: The user input Identifier MAY be in the form
+            of <tt>userinfo@host</tt>.
+            For the End-User, this would normally be perceived as being an e-mail address.
+	    However, it is also
+            a valid userpart "@" host section of an <tt>acct</tt> URI
+	    <a class='info' href='#RFC7565'>[RFC7565]<span> (</span><span class='info'>Saint-Andre, P., &ldquo;The 'acct' URI Scheme,&rdquo; May&nbsp;2015.</span><span>)</span></a>,
+	    and this specification
+            treats it such as to exclude various
+            extra strings allowed in <tt>addr-spec</tt> of
+            <a class='info' href='#RFC5322'>RFC 5322<span> (</span><span class='info'>Resnick, P., Ed., &ldquo;Internet Message Format,&rdquo; October&nbsp;2008.</span><span>)</span></a> [RFC5322].
+          
+</p>
+<a name="NormalizationSteps"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.2.1.2"></a><h3>2.1.2.&nbsp;
+Normalization Steps</h3>
+
+<p>
+            A string of any other type is interpreted as
+            a URI in one of the forms
+            <tt>scheme "://" authority path-abempty [ "?" query ] [ "#" fragment ]</tt>
+            or
+            <tt>authority path-abempty [ "?" query ] [ "#" fragment ]</tt>
+	    or
+	    <tt>scheme ":" path-rootless</tt>
+            per <a class='info' href='#RFC3986'>RFC 3986<span> (</span><span class='info'>Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;Uniform Resource Identifier (URI): Generic Syntax,&rdquo; January&nbsp;2005.</span><span>)</span></a> [RFC3986]
+            and is normalized according to the following rules:
+          
+</p>
+<p>
+            </p>
+<ol class="text">
+<li>
+                If the user input Identifier does not have an
+                <a class='info' href='#RFC3986'>RFC 3986<span> (</span><span class='info'>Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;Uniform Resource Identifier (URI): Generic Syntax,&rdquo; January&nbsp;2005.</span><span>)</span></a> [RFC3986] scheme component,
+                the string is interpreted as
+                <tt>[userinfo "@"] host [":" port] path-abempty [ "?" query ] [ "#" fragment ]</tt>
+                per <a class='info' href='#RFC3986'>RFC 3986<span> (</span><span class='info'>Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;Uniform Resource Identifier (URI): Generic Syntax,&rdquo; January&nbsp;2005.</span><span>)</span></a> [RFC3986].
+		Examples are
+		<tt>example.com</tt>,
+		<tt>joe@example.com</tt>,
+		<tt>example.com/joe</tt>, and
+		<tt>example.com:8080</tt>.
+	      
+</li>
+<li>
+		If the userinfo and host components are present and all of the
+		scheme, path, query, port, and fragment components are absent,
+                the <tt>acct</tt> scheme is assumed.
+                In this case, the normalized URI is formed by
+                prefixing <tt>acct:</tt> to the string as the scheme.
+                Per <a class='info' href='#RFC7565'>The 'acct' URI Scheme<span> (</span><span class='info'>Saint-Andre, P., &ldquo;The 'acct' URI Scheme,&rdquo; May&nbsp;2015.</span><span>)</span></a> [RFC7565],
+                if there is an at-sign character ('@') in the userinfo component, it needs to be
+                percent-encoded, as described in <a class='info' href='#RFC3986'>RFC 3986<span> (</span><span class='info'>Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;Uniform Resource Identifier (URI): Generic Syntax,&rdquo; January&nbsp;2005.</span><span>)</span></a> [RFC3986].
+		Examples are
+		<tt>joe@example.com</tt> and
+		<tt>Jane.Doe@example.com</tt>.
+	      
+</li>
+<li>
+		For all other inputs without a scheme component,
+		the <tt>https</tt> scheme is assumed,
+                and the normalized URI is formed by
+                prefixing <tt>https://</tt> to the string as the scheme.
+		Examples are
+		<tt>example.com</tt>,
+		<tt>example.com/joe</tt>,
+		<tt>example.com:8080</tt>, and
+		<tt>joe@example.com:8080</tt>.
+              
+</li>
+<li>
+		When the input contains an explicit scheme such as
+		<tt>acct</tt> or <tt>https</tt>
+		that matches the RFC 3986
+		<tt>scheme ":" path-rootless</tt> syntax,
+		no input normalization is performed.
+		Examples are
+		<tt>https://example.com</tt>,
+		<tt>https://example.com/joe</tt>,
+		<tt>https://joe@example.com:8080</tt>, and
+		<tt>acct:joe@example.com</tt>.
+	      
+</li>
+<li>
+		If the resulting URI contains a fragment component, it MUST be
+		stripped off, together with the fragment delimiter
+		character "#".
+	      
+</li>
+</ol><p>
+          
+</p>
+<p>
+            The <a class='info' href='#RFC7033'>WebFinger<span> (</span><span class='info'>Jones, P., Salgueiro, G., Jones, M., and J. Smarr, &ldquo;WebFinger,&rdquo; September&nbsp;2013.</span><span>)</span></a> [RFC7033] Resource
+	    in this case is the resulting URI, and
+            the WebFinger Host is the authority component.
+          
+</p>
+<p>
+            NOTE: Since the definition of <tt>authority</tt>
+            in <a class='info' href='#RFC3986'>RFC 3986<span> (</span><span class='info'>Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;Uniform Resource Identifier (URI): Generic Syntax,&rdquo; January&nbsp;2005.</span><span>)</span></a> [RFC3986]
+            is <tt>[ userinfo "@" ] host [ ":" port ]</tt>,
+            it is legal to have a user input identifier like
+            <tt>userinfo@host:port</tt>, e.g.,
+            <tt>alice@example.com:8080</tt>.
+          
+</p>
+<a name="Examples"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.2.2"></a><h3>2.2.&nbsp;
+Non-Normative Examples</h3>
+
+<a name="EmailSyntax"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.2.2.1"></a><h3>2.2.1.&nbsp;
+User Input using E-Mail Address Syntax</h3>
+
+<p>To find the Issuer for the given user input
+          in the form of an e-mail address <tt>joe@example.com</tt>,
+	  the WebFinger parameters are as follows:
+</p><table class="full" align="center" border="0" cellpadding="2" cellspacing="2">
+<col align="left"><col align="left">
+<tr><th align="left">WebFinger Parameter</th><th align="left">Value</th></tr>
+<tr>
+<td align="left">resource</td>
+<td align="left">acct:joe@example.com</td>
+</tr>
+<tr>
+<td align="left">host</td>
+<td align="left">example.com</td>
+</tr>
+<tr>
+<td align="left">rel</td>
+<td align="left">http://openid.net/specs/connect/1.0/issuer</td>
+</tr>
+</table>
+<br clear="all" />
+
+<p>
+	    Note that in this case, the <tt>acct:</tt> scheme
+	    <a class='info' href='#RFC7565'>[RFC7565]<span> (</span><span class='info'>Saint-Andre, P., &ldquo;The 'acct' URI Scheme,&rdquo; May&nbsp;2015.</span><span>)</span></a> is prepended to the Identifier.
+	  
+</p>
+<p>
+	    
+<p>The RP would make the
+	      following WebFinger request to discover the Issuer location
+	      (with line wraps within lines for display purposes only):
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /.well-known/webfinger
+    ?resource=acct%3Ajoe%40example.com
+    &amp;rel=http%3A%2F%2Fopenid.net%2Fspecs%2Fconnect%2F1.0%2Fissuer
+    HTTP/1.1
+  Host: example.com
+
+  HTTP/1.1 200 OK
+  Content-Type: application/jrd+json
+
+  {
+   "subject": "acct:joe@example.com",
+   "links":
+    [
+     {
+      "rel": "http://openid.net/specs/connect/1.0/issuer",
+      "href": "https://server.example.com"
+     }
+    ]
+  }
+</pre></div>
+	  
+
+<a name="URLSyntax"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.2.2.2"></a><h3>2.2.2.&nbsp;
+User Input using URL Syntax</h3>
+
+<p>To find the Issuer for the given URL,
+          <tt>https://example.com/joe</tt>, the WebFinger
+          parameters are as follows:
+</p><table class="full" align="center" border="0" cellpadding="2" cellspacing="2">
+<col align="left"><col align="left">
+<tr><th align="left">WebFinger Parameter</th><th align="left">Value</th></tr>
+<tr>
+<td align="left">resource</td>
+<td align="left">https://example.com/joe</td>
+</tr>
+<tr>
+<td align="left">host</td>
+<td align="left">example.com</td>
+</tr>
+<tr>
+<td align="left">rel</td>
+<td align="left">http://openid.net/specs/connect/1.0/issuer</td>
+</tr>
+</table>
+<br clear="all" />
+
+<p>
+<p>The RP would make the
+	    following WebFinger request to discover the Issuer location
+	    (with line wraps within lines for display purposes only):
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /.well-known/webfinger
+    ?resource=https%3A%2F%2Fexample.com%2Fjoe
+    &amp;rel=http%3A%2F%2Fopenid.net%2Fspecs%2Fconnect%2F1.0%2Fissuer
+    HTTP/1.1
+  Host: example.com
+
+  HTTP/1.1 200 OK
+  Content-Type: application/jrd+json
+
+  {
+   "subject": "https://example.com/joe",
+   "links":
+    [
+     {
+      "rel": "http://openid.net/specs/connect/1.0/issuer",
+      "href": "https://server.example.com"
+     }
+    ]
+  }
+</pre></div>
+
+<a name="HostPortExample"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.2.2.3"></a><h3>2.2.3.&nbsp;
+User Input using Hostname and Port Syntax</h3>
+
+<p>
+            If the user input is in the form of
+            <tt>host:port</tt>, e.g., example.com:8080,
+            then it is assumed as the authority component of the URL.
+          
+</p>
+<p>To find the Issuer for the given
+          hostname, <tt>example.com:8080</tt>, the WebFinger
+          parameters are as follows:
+</p><table class="full" align="center" border="0" cellpadding="2" cellspacing="2">
+<col align="left"><col align="left">
+<tr><th align="left">WebFinger Parameter</th><th align="left">Value</th></tr>
+<tr>
+<td align="left">resource</td>
+<td align="left">https://example.com:8080/</td>
+</tr>
+<tr>
+<td align="left">host</td>
+<td align="left">example.com:8080</td>
+</tr>
+<tr>
+<td align="left">rel</td>
+<td align="left">http://openid.net/specs/connect/1.0/issuer</td>
+</tr>
+</table>
+<br clear="all" />
+
+<p>
+<p>The RP would make the
+	    following WebFinger request to discover the Issuer location
+	    (with line wraps within lines for display purposes only):
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /.well-known/webfinger
+    ?resource=https%3A%2F%2Fexample.com%3A8080%2F
+    &amp;rel=http%3A%2F%2Fopenid.net%2Fspecs%2Fconnect%2F1.0%2Fissuer
+    HTTP/1.1
+  Host: example.com:8080
+
+  HTTP/1.1 200 OK
+  Content-Type: application/jrd+json
+
+  {
+   "subject": "https://example.com:8080/",
+   "links":
+    [
+     {
+      "rel": "http://openid.net/specs/connect/1.0/issuer",
+      "href": "https://server.example.com"
+     }
+    ]
+  }
+</pre></div>
+
+<a name="AcctURISyntax"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.2.2.4"></a><h3>2.2.4.&nbsp;
+User Input using "acct" URI Syntax</h3>
+
+<p>To find the Issuer for the given user input
+          in the form of an account URI
+          <tt>acct:juliet%40capulet.example@shopping.example.com</tt>,
+	  the WebFinger parameters are as follows:
+</p><table class="full" align="center" border="0" cellpadding="2" cellspacing="2">
+<col align="left"><col align="left">
+<tr><th align="left">WebFinger Parameter</th><th align="left">Value</th></tr>
+<tr>
+<td align="left">resource</td>
+<td align="left">acct:juliet%40capulet.example@shopping.example.com</td>
+</tr>
+<tr>
+<td align="left">host</td>
+<td align="left">shopping.example.com</td>
+</tr>
+<tr>
+<td align="left">rel</td>
+<td align="left">http://openid.net/specs/connect/1.0/issuer</td>
+</tr>
+</table>
+<br clear="all" />
+
+<p>
+	    
+<p>The RP would make the
+	      following WebFinger request to discover the Issuer location
+	      (with line wraps within lines for display purposes only):
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /.well-known/webfinger
+    ?resource=acct%3Ajuliet%2540capulet.example%40shopping.example.com
+    &amp;rel=http%3A%2F%2Fopenid.net%2Fspecs%2Fconnect%2F1.0%2Fissuer
+    HTTP/1.1
+  Host: shopping.example.com
+
+  HTTP/1.1 200 OK
+  Content-Type: application/jrd+json
+
+  {
+   "subject": "acct:juliet%40capulet.example@shopping.example.com",
+   "links":
+    [
+     {
+      "rel": "http://openid.net/specs/connect/1.0/issuer",
+      "href": "https://server.example.com"
+     }
+    ]
+  }
+</pre></div>
+	  
+
+<p>
+	    NOTE:  It is common for sites to use e-mail addresses as local identifiers
+	    for accounts at those sites, even though the domain in the e-mail address
+	    is not one controlled by the site.
+	    For instance, the site <tt>example.org</tt>
+	    might have a local account named <tt>joe@example.com</tt>.
+	    This specification uses <tt>acct:</tt> URIs
+	    as defined by <a class='info' href='#RFC7565'>[RFC7565]<span> (</span><span class='info'>Saint-Andre, P., &ldquo;The 'acct' URI Scheme,&rdquo; May&nbsp;2015.</span><span>)</span></a> to represent such accounts
+	    during WebFinger discovery.
+	    Such an example is
+	    <tt>acct:joe%40example.com@example.org</tt>.
+	    End-Users MAY input
+	    values like <tt>joe@example.com@example.org</tt>
+	    to initiate discovery on such accounts.
+	  
+</p>
+<a name="ProviderMetadata"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.3"></a><h3>3.&nbsp;
+OpenID Provider Metadata</h3>
+
+<p>
+	OpenID Providers have metadata describing their configuration.
+	These OpenID Provider Metadata values are used by OpenID Connect:
+
+	</p>
+<blockquote class="text"><dl>
+<dt>issuer</dt>
+<dd>
+	    
+	    REQUIRED.
+	    URL using the <tt>https</tt> scheme with no query or fragment components that the OP asserts as its
+	    Issuer Identifier.
+	    If Issuer discovery is supported (see <a class='info' href='#IssuerDiscovery'>Section&nbsp;2<span> (</span><span class='info'>OpenID Provider Issuer Discovery</span><span>)</span></a>),
+	    this value MUST be identical to the issuer value returned by WebFinger.
+	    This also MUST be identical to the <tt>iss</tt> Claim value
+	    in ID Tokens issued from this Issuer.
+	  
+</dd>
+<dt>authorization_endpoint</dt>
+<dd>
+	    
+	    REQUIRED.
+	    URL of the OP's OAuth 2.0 Authorization Endpoint
+	    <a class='info' href='#OpenID.Core'>[OpenID.Core]<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;OpenID Connect Core 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a>.
+	    This URL MUST use the <tt>https</tt> scheme and MAY contain
+	    port, path, and query parameter components.
+	  
+</dd>
+<dt>token_endpoint</dt>
+<dd>
+	    
+	    URL of the OP's OAuth 2.0 Token Endpoint
+	    <a class='info' href='#OpenID.Core'>[OpenID.Core]<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;OpenID Connect Core 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a>.
+	    This is REQUIRED unless only the Implicit Flow is used.
+	    This URL MUST use the <tt>https</tt> scheme and MAY contain
+	    port, path, and query parameter components.
+	  
+</dd>
+<dt>userinfo_endpoint</dt>
+<dd>
+	    
+	    RECOMMENDED.
+	    URL of the OP's UserInfo Endpoint <a class='info' href='#OpenID.Core'>[OpenID.Core]<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;OpenID Connect Core 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a>.
+	    This URL MUST use the <tt>https</tt> scheme and MAY contain
+	    port, path, and query parameter components.
+	  
+</dd>
+<dt>jwks_uri</dt>
+<dd>
+	    
+	    REQUIRED.
+	    URL of the OP's JWK Set <a class='info' href='#JWK'>[JWK]<span> (</span><span class='info'>Jones, M., &ldquo;JSON Web Key (JWK),&rdquo; May&nbsp;2015.</span><span>)</span></a> document,
+	    which MUST use the <tt>https</tt> scheme.
+	    This contains the signing key(s) the RP uses to validate signatures from the OP.
+	    The JWK Set MAY also contain the Server's encryption key(s),
+	    which are used by RPs to encrypt requests to the Server.
+	    When both signing and encryption keys are made available,
+	    a <tt>use</tt> (public key use) parameter
+	    value is REQUIRED for all keys in the referenced JWK Set
+	    to indicate each key's intended usage.
+	    Although some algorithms allow the same key to be used for
+	    both signatures and encryption, doing so is
+	    NOT RECOMMENDED, as it is less secure.
+	    The JWK <tt>x5c</tt> parameter MAY be used
+	    to provide X.509 representations of keys provided.  When used, the bare key
+	    values MUST still be present and MUST match those in the certificate.
+	    The JWK Set MUST NOT contain private or symmetric key values.
+	  
+</dd>
+<dt>registration_endpoint</dt>
+<dd>
+	    
+	    RECOMMENDED.
+	    URL of the OP's Dynamic Client Registration Endpoint <a class='info' href='#OpenID.Registration'>[OpenID.Registration]<span> (</span><span class='info'>Sakimura, N., Bradley, J., and M. Jones, &ldquo;OpenID Connect Dynamic Client Registration 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a>,
+	    which MUST use the <tt>https</tt> scheme.
+	  
+</dd>
+<dt>scopes_supported</dt>
+<dd>
+	    
+	    RECOMMENDED.
+	    JSON array containing a list of the <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749] scope values that this server
+	    supports. The server MUST support the <tt>openid</tt>
+	    scope value.
+	    Servers MAY choose not to advertise some supported scope values
+	    even when this parameter is used, although those defined in
+	    <a class='info' href='#OpenID.Core'>[OpenID.Core]<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;OpenID Connect Core 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> SHOULD be listed, if supported.
+	  
+</dd>
+<dt>response_types_supported</dt>
+<dd>
+	    
+	    REQUIRED.
+	    JSON array containing a list of the OAuth 2.0
+	    <tt>response_type</tt> values that this
+	    OP supports.
+	    Dynamic OpenID Providers MUST support the <tt>code</tt>,
+	    <tt>id_token</tt>, and the <tt>id_token token</tt>
+	    Response Type values.
+	  
+</dd>
+<dt>response_modes_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    JSON array containing a list of the OAuth 2.0
+	    <tt>response_mode</tt> values that this
+	    OP supports, as specified in
+	    <a class='info' href='#OAuth.Responses'>OAuth 2.0 Multiple Response Type Encoding Practices<span> (</span><span class='info'>de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;OAuth 2.0 Multiple Response Type Encoding Practices,&rdquo; February&nbsp;2014.</span><span>)</span></a> [OAuth.Responses].
+	    If omitted, the default for Dynamic OpenID Providers is
+	    <tt>["query", "fragment"]</tt>.
+	  
+</dd>
+<dt>grant_types_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    JSON array containing a list of the OAuth 2.0
+	    Grant Type values that this
+	    OP supports. Dynamic OpenID Providers MUST support the
+	    <tt>authorization_code</tt> and
+	    <tt>implicit</tt> Grant Type values
+	    and MAY support other Grant Types.
+	    If omitted, the default value is
+	    <tt>["authorization_code", "implicit"]</tt>.
+	  
+</dd>
+<dt>acr_values_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    JSON array containing a list of the Authentication Context Class References
+	    that this OP supports.
+	  
+</dd>
+<dt>subject_types_supported</dt>
+<dd>
+	    
+	    REQUIRED.
+	    JSON array containing a list of the Subject Identifier types that
+	    this OP supports. Valid types include
+	    <tt>pairwise</tt> and
+	    <tt>public</tt>.
+	  
+</dd>
+<dt>id_token_signing_alg_values_supported</dt>
+<dd>
+	    
+	    REQUIRED.
+	    JSON array containing a list of the JWS signing algorithms
+	    (<tt>alg</tt> values)
+	    supported by the OP for the ID Token
+	    to encode the Claims in a JWT <a class='info' href='#JWT'>[JWT]<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a>.
+	    The algorithm <tt>RS256</tt> MUST be included.
+	    The value <tt>none</tt> MAY be supported
+	    but MUST NOT be used
+	    unless the Response Type used returns no ID Token from the
+	    Authorization Endpoint
+	    (such as when using the Authorization Code Flow).
+	  
+</dd>
+<dt>id_token_encryption_alg_values_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    JSON array containing a list of the JWE encryption algorithms
+	    (<tt>alg</tt> values)
+	    supported by the OP for the ID Token
+	    to encode the Claims in a JWT <a class='info' href='#JWT'>[JWT]<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a>.
+	  
+</dd>
+<dt>id_token_encryption_enc_values_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    JSON array containing a list of the JWE encryption algorithms
+	    (<tt>enc</tt> values)
+	    supported by the OP for the ID Token
+	    to encode the Claims in a JWT <a class='info' href='#JWT'>[JWT]<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a>.
+	  
+</dd>
+<dt>userinfo_signing_alg_values_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    JSON array containing a list of the JWS <a class='info' href='#JWS'>[JWS]<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Signature (JWS),&rdquo; May&nbsp;2015.</span><span>)</span></a> signing algorithms
+	    (<tt>alg</tt> values) <a class='info' href='#JWA'>[JWA]<span> (</span><span class='info'>Jones, M., &ldquo;JSON Web Algorithms (JWA),&rdquo; May&nbsp;2015.</span><span>)</span></a>
+	    supported by the UserInfo Endpoint
+	    to encode the Claims in a JWT <a class='info' href='#JWT'>[JWT]<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a>.
+	    The value <tt>none</tt> MAY be included.
+	  
+</dd>
+<dt>userinfo_encryption_alg_values_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    JSON array containing a list of the JWE <a class='info' href='#JWE'>[JWE]<span> (</span><span class='info'>Jones, M. and J. Hildebrand, &ldquo;JSON Web Encryption (JWE),&rdquo; May&nbsp;2015.</span><span>)</span></a> encryption algorithms
+	    (<tt>alg</tt> values) <a class='info' href='#JWA'>[JWA]<span> (</span><span class='info'>Jones, M., &ldquo;JSON Web Algorithms (JWA),&rdquo; May&nbsp;2015.</span><span>)</span></a>
+	    supported by the UserInfo Endpoint
+	    to encode the Claims in a JWT <a class='info' href='#JWT'>[JWT]<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a>.
+	  
+</dd>
+<dt>userinfo_encryption_enc_values_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    JSON array containing a list of the JWE encryption algorithms
+	    (<tt>enc</tt> values) <a class='info' href='#JWA'>[JWA]<span> (</span><span class='info'>Jones, M., &ldquo;JSON Web Algorithms (JWA),&rdquo; May&nbsp;2015.</span><span>)</span></a>
+	    supported by the UserInfo Endpoint
+	    to encode the Claims in a JWT <a class='info' href='#JWT'>[JWT]<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a>.
+	  
+</dd>
+<dt>request_object_signing_alg_values_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    JSON array containing a list of the JWS signing algorithms
+	    (<tt>alg</tt> values)
+	    supported by the OP for Request Objects, which are described in
+	    Section 6.1 of <a class='info' href='#OpenID.Core'>OpenID Connect Core 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;OpenID Connect Core 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Core].
+	    These algorithms are used both when the Request Object is passed by value
+	    (using the <tt>request</tt> parameter)
+	    and when it is passed by reference
+	    (using the <tt>request_uri</tt> parameter).
+	    Servers SHOULD support <tt>none</tt> and <tt>RS256</tt>.
+	  
+</dd>
+<dt>request_object_encryption_alg_values_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    JSON array containing a list of the JWE encryption algorithms
+	    (<tt>alg</tt> values)
+	    supported by the OP for Request Objects.
+	    These algorithms are used both when the Request Object is passed by value
+	    and when it is passed by reference.
+	  
+</dd>
+<dt>request_object_encryption_enc_values_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    JSON array containing a list of the JWE encryption algorithms
+	    (<tt>enc</tt> values)
+	    supported by the OP for Request Objects.
+	    These algorithms are used both when the Request Object is passed by value
+	    and when it is passed by reference.
+	  
+</dd>
+<dt>token_endpoint_auth_methods_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    JSON array containing a list of Client Authentication
+	    methods supported by this Token Endpoint. The options are
+	    <tt>client_secret_post</tt>,
+	    <tt>client_secret_basic</tt>,
+	    <tt>client_secret_jwt</tt>, and
+	    <tt>private_key_jwt</tt>, as described in
+	    Section 9 of <a class='info' href='#OpenID.Core'>OpenID Connect Core 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;OpenID Connect Core 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Core].
+	    Other authentication methods MAY be defined by extensions.
+	    If omitted, the default is <tt>client_secret_basic</tt> --
+	    the HTTP Basic Authentication Scheme specified in
+	    Section 2.3.1 of <a class='info' href='#RFC6749'>OAuth 2.0<span> (</span><span class='info'>Hardt, D., Ed., &ldquo;The OAuth 2.0 Authorization Framework,&rdquo; October&nbsp;2012.</span><span>)</span></a> [RFC6749].
+	  
+</dd>
+<dt>token_endpoint_auth_signing_alg_values_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    JSON array containing a list of the JWS signing algorithms
+	    (<tt>alg</tt> values)
+	    supported by the Token Endpoint for the signature on
+	    the JWT <a class='info' href='#JWT'>[JWT]<span> (</span><span class='info'>Jones, M., Bradley, J., and N. Sakimura, &ldquo;JSON Web Token (JWT),&rdquo; May&nbsp;2015.</span><span>)</span></a> used to authenticate the Client
+	    at the Token Endpoint for the <tt>private_key_jwt</tt>
+	    and <tt>client_secret_jwt</tt> authentication methods.
+	    Servers SHOULD support <tt>RS256</tt>.
+	    The value <tt>none</tt> MUST NOT be used.
+	  
+</dd>
+<dt>display_values_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    JSON array containing a list of the <tt>display</tt>
+	    parameter values that the OpenID Provider supports.
+	    These values are described in
+	    Section 3.1.2.1 of <a class='info' href='#OpenID.Core'>OpenID Connect Core 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;OpenID Connect Core 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Core].
+	  
+</dd>
+<dt>claim_types_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    JSON array containing a list of the Claim Types
+	    that the OpenID Provider supports.
+	    These Claim Types are described in
+	    Section 5.6 of <a class='info' href='#OpenID.Core'>OpenID Connect Core 1.0<span> (</span><span class='info'>Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;OpenID Connect Core 1.0,&rdquo; December&nbsp;2023.</span><span>)</span></a> [OpenID.Core].
+	    Values defined by this specification are <tt>normal</tt>,
+	    <tt>aggregated</tt>, and <tt>distributed</tt>.
+	    If omitted, the implementation supports
+	    only <tt>normal</tt> Claims.
+	  
+</dd>
+<dt>claims_supported</dt>
+<dd>
+	    
+	    RECOMMENDED.
+	    JSON array containing a list of the Claim Names of the Claims
+	    that the OpenID Provider MAY be able to supply values for.
+	    Note that for privacy or other reasons, this might not be an exhaustive list.
+	  
+</dd>
+<dt>service_documentation</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    URL of a page containing human-readable information that
+	    developers might want or need to know when using the OpenID Provider.
+	    In particular, if the OpenID Provider does not support Dynamic Client Registration,
+	    then information on how to register Clients needs to be provided in this documentation.
+	  
+</dd>
+<dt>claims_locales_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    Languages and scripts supported for values in Claims being returned,
+	    represented as a JSON array of
+	    <a class='info' href='#RFC5646'>BCP47<span> (</span><span class='info'>Phillips, A., Ed. and M. Davis, Ed., &ldquo;Tags for Identifying Languages,&rdquo; September&nbsp;2009.</span><span>)</span></a> [RFC5646] language tag values.
+	    Not all languages and scripts are necessarily supported for all Claim values.
+	  
+</dd>
+<dt>ui_locales_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    Languages and scripts supported for the user interface,
+	    represented as a JSON array of
+	    <a class='info' href='#RFC5646'>BCP47<span> (</span><span class='info'>Phillips, A., Ed. and M. Davis, Ed., &ldquo;Tags for Identifying Languages,&rdquo; September&nbsp;2009.</span><span>)</span></a> [RFC5646] language tag values.
+	  
+</dd>
+<dt>claims_parameter_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    Boolean value specifying whether the OP supports use of the
+	    <tt>claims</tt> parameter,
+	    with <tt>true</tt> indicating support.
+	    If omitted, the default value is <tt>false</tt>.
+	  
+</dd>
+<dt>request_parameter_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    Boolean value specifying whether the OP supports use of the
+	    <tt>request</tt> parameter,
+	    with <tt>true</tt> indicating support.
+	    If omitted, the default value is <tt>false</tt>.
+	  
+</dd>
+<dt>request_uri_parameter_supported</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    Boolean value specifying whether the OP supports use of the
+	    <tt>request_uri</tt> parameter,
+	    with <tt>true</tt> indicating support.
+	    If omitted, the default value is <tt>true</tt>.
+	  
+</dd>
+<dt>require_request_uri_registration</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    Boolean value specifying whether the OP requires any
+	    <tt>request_uri</tt> values used to be pre-registered
+	    using the <tt>request_uris</tt> registration parameter.
+	    Pre-registration is REQUIRED when the value is <tt>true</tt>.
+	    If omitted, the default value is <tt>false</tt>.
+	  
+</dd>
+<dt>op_policy_uri</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    URL that the OpenID Provider provides to the person registering
+	    the Client to read about the OP's requirements on how
+	    the Relying Party can use the data provided by the OP.
+	    The registration process SHOULD display this
+	    URL to the person registering the Client if it is given.
+	  
+</dd>
+<dt>op_tos_uri</dt>
+<dd>
+	    
+	    OPTIONAL.
+	    URL that the OpenID Provider provides to the person registering
+	    the Client to read about the OpenID Provider's terms of service.
+	    The registration process SHOULD display this
+	    URL to the person registering the Client if it is given.
+	  
+</dd>
+</dl></blockquote><p>
+      
+</p>
+<p>
+	The
+	Token Endpoint,
+	UserInfo Endpoint,
+	<tt>jwks_uri</tt> endpoint,
+	Dynamic Client Registration Endpoint,
+	and any other endpoints directly accessed by Clients
+	SHOULD support the use of
+	<a class='info' href='#CORS'>Cross-Origin Resource Sharing (CORS)<span> (</span><span class='info'>Opera Software ASA, &ldquo;Cross-Origin Resource Sharing,&rdquo; July&nbsp;2010.</span><span>)</span></a> [CORS]
+	and/or other methods as appropriate
+	to enable JavaScript Clients and other Browser-Based Clients to access them.
+	The use of CORS at the Authorization Endpoint is NOT RECOMMENDED
+	as it is redirected to by the client and not directly accessed.
+      
+</p>
+<p>
+	Additional OpenID Provider Metadata parameters MAY also be used.
+	Some are defined by other specifications,
+	such as
+	<a class='info' href='#OpenID.Session'>OpenID Connect Session Management 1.0<span> (</span><span class='info'>de Medeiros, B., Agarwal, N., Sakimura, N., Bradley, J., and M. Jones, &ldquo;OpenID Connect Session Management 1.0,&rdquo; September&nbsp;2022.</span><span>)</span></a> [OpenID.Session].
+      
+</p>
+<a name="ProviderConfig"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4"></a><h3>4.&nbsp;
+Obtaining OpenID Provider Configuration Information</h3>
+
+<p>
+	Using the Issuer location discovered
+	as described in <a class='info' href='#IssuerDiscovery'>Section&nbsp;2<span> (</span><span class='info'>OpenID Provider Issuer Discovery</span><span>)</span></a> or by other means,
+	the OpenID Provider's configuration information can be retrieved.
+      
+</p>
+<p>
+	OpenID Providers supporting Discovery
+	MUST make a JSON document available at the path formed by
+	concatenating the string
+	<tt>/.well-known/openid-configuration</tt> to the
+	Issuer.
+	The syntax and semantics of <tt>.well-known</tt> are defined in <a class='info' href='#RFC5785'>RFC 5785<span> (</span><span class='info'>Nottingham, M. and E. Hammer-Lahav, &ldquo;Defining Well-Known Uniform Resource Identifiers (URIs),&rdquo; April&nbsp;2010.</span><span>)</span></a> [RFC5785] and apply to the Issuer value
+	when it contains no path component. <tt>openid-configuration</tt>
+	MUST point to a JSON document compliant with this specification and
+	MUST be returned using the <tt>application/json</tt> content type.
+	The <tt>openid-configuration</tt> endpoint SHOULD support the use of
+	<a class='info' href='#CORS'>Cross-Origin Resource Sharing (CORS)<span> (</span><span class='info'>Opera Software ASA, &ldquo;Cross-Origin Resource Sharing,&rdquo; July&nbsp;2010.</span><span>)</span></a> [CORS]
+	and/or other methods as appropriate
+	to enable JavaScript Clients and other Browser-Based Clients to access it.
+      
+</p>
+<a name="ProviderConfigurationRequest"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.1"></a><h3>4.1.&nbsp;
+OpenID Provider Configuration Request</h3>
+
+<p>
+	  An OpenID Provider's configuration information MUST be retrieved using an HTTP
+	  <tt>GET</tt> request at the previously specified path.
+	
+</p>
+<p>
+	  The RP would make the following request to the
+	  Issuer <tt>https://example.com</tt>
+	  to obtain its Configuration information,
+	  since the Issuer contains no path component:
+	
+</p>
+<p>
+	  </p>
+<div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /.well-known/openid-configuration HTTP/1.1
+  Host: example.com
+</pre></div><p>
+
+	
+</p>
+<p>
+	  If the
+	  Issuer value contains a path component, any terminating
+	  <tt>/</tt> MUST be removed before appending
+	  <tt>/.well-known/openid-configuration</tt>.
+	  The RP would make the following request to the
+	  Issuer <tt>https://example.com/issuer1</tt>
+	  to obtain its configuration information,
+	  since the Issuer contains a path component:
+	
+</p>
+<p>
+	  </p>
+<div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  GET /issuer1/.well-known/openid-configuration HTTP/1.1
+  Host: example.com
+</pre></div><p>
+
+	
+</p>
+<p>
+	  Using path components enables supporting multiple issuers per host.
+	  This is required in some multi-tenant hosting configurations.
+	  This use of <tt>.well-known</tt> is for supporting
+	  multiple issuers per host; unlike its use in
+	  <a class='info' href='#RFC5785'>RFC 5785<span> (</span><span class='info'>Nottingham, M. and E. Hammer-Lahav, &ldquo;Defining Well-Known Uniform Resource Identifiers (URIs),&rdquo; April&nbsp;2010.</span><span>)</span></a> [RFC5785], it does not provide
+	  general information about the host.
+	
+</p>
+<a name="ProviderConfigurationResponse"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.2"></a><h3>4.2.&nbsp;
+OpenID Provider Configuration Response</h3>
+
+<p>The response is a set of Claims about the OpenID Provider's
+        configuration, including all necessary endpoints and
+        public key location information.
+        A successful response MUST use the 200 OK HTTP status code and return
+	a JSON object using the <tt>application/json</tt> content type
+	that contains a set of Claims as its members
+	that are a subset of the Metadata values defined in
+	<a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a>.
+	Other Claims MAY also be returned.
+</p>
+<p>Claims that return multiple values are represented as JSON arrays.
+	Claims with zero elements MUST be omitted from the response.
+</p>
+<p>
+	  An error response uses the applicable HTTP status code value.
+	
+</p>
+<p>
+	  
+<p>The following is a non-normative example response:
+</p><div style='display: table; width: 0; margin-left: 3em; margin-right: auto'><pre>
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+
+  {
+   "issuer":
+     "https://server.example.com",
+   "authorization_endpoint":
+     "https://server.example.com/connect/authorize",
+   "token_endpoint":
+     "https://server.example.com/connect/token",
+   "token_endpoint_auth_methods_supported":
+     ["client_secret_basic", "private_key_jwt"],
+   "token_endpoint_auth_signing_alg_values_supported":
+     ["RS256", "ES256"],
+   "userinfo_endpoint":
+     "https://server.example.com/connect/userinfo",
+   "check_session_iframe":
+     "https://server.example.com/connect/check_session",
+   "end_session_endpoint":
+     "https://server.example.com/connect/end_session",
+   "jwks_uri":
+     "https://server.example.com/jwks.json",
+   "registration_endpoint":
+     "https://server.example.com/connect/register",
+   "scopes_supported":
+     ["openid", "profile", "email", "address",
+      "phone", "offline_access"],
+   "response_types_supported":
+     ["code", "code id_token", "id_token", "id_token token"],
+   "acr_values_supported":
+     ["urn:mace:incommon:iap:silver",
+      "urn:mace:incommon:iap:bronze"],
+   "subject_types_supported":
+     ["public", "pairwise"],
+   "userinfo_signing_alg_values_supported":
+     ["RS256", "ES256", "HS256"],
+   "userinfo_encryption_alg_values_supported":
+     ["RSA-OAEP-256", "A128KW"],
+   "userinfo_encryption_enc_values_supported":
+     ["A128CBC-HS256", "A128GCM"],
+   "id_token_signing_alg_values_supported":
+     ["RS256", "ES256", "HS256"],
+   "id_token_encryption_alg_values_supported":
+     ["RSA-OAEP-256", "A128KW"],
+   "id_token_encryption_enc_values_supported":
+     ["A128CBC-HS256", "A128GCM"],
+   "request_object_signing_alg_values_supported":
+     ["none", "RS256", "ES256"],
+   "display_values_supported":
+     ["page", "popup"],
+   "claim_types_supported":
+     ["normal", "distributed"],
+   "claims_supported":
+     ["sub", "iss", "auth_time", "acr",
+      "name", "given_name", "family_name", "nickname",
+      "profile", "picture", "website",
+      "email", "email_verified", "locale", "zoneinfo",
+      "http://example.info/claims/groups"],
+   "claims_parameter_supported":
+     true,
+   "service_documentation":
+     "http://server.example.com/connect/service_documentation.html",
+   "ui_locales_supported":
+     ["en-US", "en-GB", "en-CA", "fr-FR", "fr-CA"]
+  }
+</pre></div>
+	
+
+<a name="ProviderConfigurationValidation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.4.3"></a><h3>4.3.&nbsp;
+OpenID Provider Configuration Validation</h3>
+
+<p>
+	  If any of the validation procedures defined in this specification fail, any operations requiring
+	  the information that failed to correctly validate MUST be aborted and
+	  the information that failed to validate MUST NOT be used.
+	
+</p>
+<p>
+	  The <tt>issuer</tt> value returned MUST be identical to
+	  the Issuer URL that was used as the prefix
+	  to <tt>/.well-known/openid-configuration</tt>
+	  to retrieve the configuration information.
+	  This MUST also be identical to the <tt>iss</tt> Claim value
+	  in ID Tokens issued from this Issuer.
+	
+</p>
+<a name="StringOps"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.5"></a><h3>5.&nbsp;
+String Operations</h3>
+
+<p>
+	Processing some OpenID Connect messages requires comparing
+	values in the messages to known values. For example, the
+	member names in the provider configuration response might be
+	compared to specific member names such as <tt>issuer</tt>.  Comparing Unicode <a class='info' href='#UNICODE'>[UNICODE]<span> (</span><span class='info'>The Unicode Consortium, &ldquo;The Unicode Standard,&rdquo; .</span><span>)</span></a> strings,
+	however, has significant security implications.
+      
+</p>
+<p>
+	Therefore, comparisons between JSON strings and other Unicode
+	strings MUST be performed as specified below:
+
+	</p>
+<ol class="text">
+<li>
+	    Remove any JSON applied escaping to produce an array of
+	    Unicode code points.
+	  
+</li>
+<li>
+	    Unicode Normalization <a class='info' href='#USA15'>[USA15]<span> (</span><span class='info'>Whistler, K., &ldquo;Unicode Normalization Forms,&rdquo; August&nbsp;2023.</span><span>)</span></a> MUST NOT
+	    be applied at any point to either the JSON string or to
+	    the string it is to be compared against.
+	  
+</li>
+<li>
+	    Comparisons between the two strings MUST be performed as a
+	    Unicode code point to code point equality comparison.
+	  
+</li>
+</ol><p>
+      
+</p>
+<a name="ImplementationConsiderations"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6"></a><h3>6.&nbsp;
+Implementation Considerations</h3>
+
+<p>
+	This specification defines features used by both Relying Parties and
+	OpenID Providers that choose to implement Discovery.
+	All of these Relying Parties and OpenID Providers
+	MUST implement the features that are listed
+	in this specification as being "REQUIRED" or are described with a "MUST".
+	No other implementation considerations for implementations of
+	Discovery are defined by this specification.
+      
+</p>
+<a name="CompatibilityNotes"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.6.1"></a><h3>6.1.&nbsp;
+Compatibility Notes</h3>
+
+<p>
+	  NOTE: Potential compatibility issues that were previously described in
+	  the original version of this specification have since been addressed.
+	
+</p>
+<a name="Security"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7"></a><h3>7.&nbsp;
+Security Considerations</h3>
+
+<a name="TLSRequirements"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.1"></a><h3>7.1.&nbsp;
+TLS Requirements</h3>
+
+<p>
+	  Implementations MUST support TLS.
+	  Which version(s) ought to be implemented will vary over
+	  time and depend on the widespread deployment and known
+	  security vulnerabilities at the time of implementation.
+	  Implementations SHOULD follow the guidance in
+	  BCP 195 <a class='info' href='#RFC8996'>[RFC8996]<span> (</span><span class='info'>Moriarty, K. and S. Farrell, &ldquo;Deprecating TLS 1.0 and TLS 1.1,&rdquo; March&nbsp;2021.</span><span>)</span></a> <a class='info' href='#RFC9325'>[RFC9325]<span> (</span><span class='info'>Sheffer, Y., Saint-Andre, P., and T. Fossati, &ldquo;Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS),&rdquo; November&nbsp;2022.</span><span>)</span></a>,
+	  which provides recommendations and requirements
+	  for improving the security of deployed services that use TLS.
+	
+</p>
+<p>
+	  To protect against information disclosure and tampering,
+	  confidentiality protection MUST be applied using TLS
+	  with a ciphersuite that provides confidentiality and
+	  integrity protection.
+	
+</p>
+<p>
+	  Whenever TLS is used, a TLS server certificate check
+	  MUST be performed, per <a class='info' href='#RFC6125'>RFC 6125<span> (</span><span class='info'>Saint-Andre, P. and J. Hodges, &ldquo;Representation and Verification of Domain-Based Application Service Identity within Internet Public Key Infrastructure Using X.509 (PKIX) Certificates in the Context of Transport Layer Security (TLS),&rdquo; March&nbsp;2011.</span><span>)</span></a> [RFC6125].
+	
+</p>
+<a name="Impersonation"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.7.2"></a><h3>7.2.&nbsp;
+Impersonation Attacks</h3>
+
+<p>
+	  TLS certificate checking MUST be performed by the RP,
+	  as described in <a class='info' href='#TLSRequirements'>Section&nbsp;7.1<span> (</span><span class='info'>TLS Requirements</span><span>)</span></a>,
+	  when making an OpenID Provider Configuration Request.
+	  Checking that the server certificate is valid for the Issuer URL
+	  prevents man-in-middle and DNS-based attacks.
+	  These attacks could cause an RP to be tricked into using an attacker's
+	  keys and endpoints, which would enable impersonation of the legitimate Issuer.
+	  If an attacker can accomplish this, they can access the accounts
+	  of any existing users at the affected RP that can be logged into
+	  using the OP that they are impersonating.
+	
+</p>
+<p>
+	  An attacker may also attempt to impersonate an OpenID Provider by publishing
+	  a Discovery document that contains an <tt>issuer</tt> Claim
+	  using the Issuer URL of the OP being impersonated,
+	  but with its own endpoints and signing keys.
+	  This would enable it to issue ID Tokens as that OP, if accepted by the RP.
+	  To prevent this, RPs MUST ensure that the Issuer URL they are using
+	  for the Configuration Request exactly matches the value of
+	  the <tt>issuer</tt> Claim
+	  in the OP Metadata document received by the RP
+	  and that this also exactly matches the <tt>iss</tt> Claim
+	  value in ID Tokens that are supposed to be from that Issuer.
+	
+</p>
+<a name="IANA"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8"></a><h3>8.&nbsp;
+IANA Considerations</h3>
+
+<a name="WellKnownRegistry"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.1"></a><h3>8.1.&nbsp;
+Well-Known URI Registry</h3>
+
+<p>
+	  This specification registers the well-known URI defined in
+	  <a class='info' href='#ProviderConfig'>Section&nbsp;4<span> (</span><span class='info'>Obtaining OpenID Provider Configuration Information</span><span>)</span></a> in the IANA
+	  "Well-Known URIs" registry <a class='info' href='#IANA.well-known'>[IANA.well&#8209;known]<span> (</span><span class='info'>IANA, &ldquo;Well-Known URIs,&rdquo; .</span><span>)</span></a>
+	  established by <a class='info' href='#RFC5785'>RFC 5785<span> (</span><span class='info'>Nottingham, M. and E. Hammer-Lahav, &ldquo;Defining Well-Known Uniform Resource Identifiers (URIs),&rdquo; April&nbsp;2010.</span><span>)</span></a> [RFC5785].
+	
+</p>
+<a name="WellKnownContents"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.1.1"></a><h3>8.1.1.&nbsp;
+Registry Contents</h3>
+
+<p> 
+            </p>
+<ul class="text">
+<li>
+		URI suffix: <tt>openid-configuration</tt>
+	      
+</li>
+<li>
+		Change controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+	      
+</li>
+<li>
+		Specification document: <a class='info' href='#ProviderConfig'>Section&nbsp;4<span> (</span><span class='info'>Obtaining OpenID Provider Configuration Information</span><span>)</span></a> of this specification
+	      
+</li>
+<li>
+		Related information: (none)
+	      
+</li>
+</ul><p>
+	  
+</p>
+<a name="MetadataRegistry"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.2"></a><h3>8.2.&nbsp;
+OAuth Authorization Server Metadata Registry</h3>
+
+<p>
+	  This specification registers the following metadata names in the
+	  IANA "OAuth Authorization Server Metadata" registry <a class='info' href='#IANA.OAuth.Parameters'>[IANA.OAuth.Parameters]<span> (</span><span class='info'>IANA, &ldquo;OAuth Parameters,&rdquo; .</span><span>)</span></a>
+	  established by <a class='info' href='#RFC8414'>[RFC8414]<span> (</span><span class='info'>Jones, M., Sakimura, N., and J. Bradley, &ldquo;OAuth 2.0 Authorization Server Metadata,&rdquo; June&nbsp;2018.</span><span>)</span></a>.
+	
+</p>
+<a name="MetadataContents"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.8.2.1"></a><h3>8.2.1.&nbsp;
+Registry Contents</h3>
+
+<p>
+	    
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>userinfo_endpoint</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		URL of the OP's UserInfo Endpoint
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>acr_values_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		JSON array containing a list of the Authentication Context Class References
+		that this OP supports
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>subject_types_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		JSON array containing a list of the Subject Identifier types that
+		this OP supports
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>id_token_signing_alg_values_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		JSON array containing a list of the JWS "alg" values
+		supported by the OP for the ID Token
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>id_token_encryption_alg_values_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		JSON array containing a list of the JWE "alg" values
+		supported by the OP for the ID Token
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>id_token_encryption_enc_values_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		JSON array containing a list of the JWE "enc" values
+		supported by the OP for the ID Token
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>userinfo_signing_alg_values_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		JSON array containing a list of the JWS "alg" values
+		supported by the UserInfo Endpoint
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>userinfo_encryption_alg_values_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		JSON array containing a list of the JWE "alg" values
+		supported by the UserInfo Endpoint
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>userinfo_encryption_enc_values_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		JSON array containing a list of the JWE "enc" values
+		supported by the UserInfo Endpoint
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>request_object_signing_alg_values_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		JSON array containing a list of the JWS "alg" values
+		supported by the OP for Request Objects
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>request_object_encryption_alg_values_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		JSON array containing a list of the JWE "alg" values
+		supported by the OP for Request Objects
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>request_object_encryption_enc_values_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		JSON array containing a list of the JWE "enc" values
+		supported by the OP for Request Objects
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>display_values_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		JSON array containing a list of the "display"
+		parameter values that the OpenID Provider supports
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>claim_types_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		JSON array containing a list of the Claim Types
+		that the OpenID Provider supports
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>claims_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		JSON array containing a list of the Claim Names of the Claims
+		that the OpenID Provider MAY be able to supply values for
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>claims_locales_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		Languages and scripts supported for values in Claims being returned,
+		represented as a JSON array of BCP 47 language tag values
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>claims_parameter_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		Boolean value specifying whether the OP supports use of the
+		"claims" parameter
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>request_parameter_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		Boolean value specifying whether the OP supports use of the
+		"request" parameter
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>request_uri_parameter_supported</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		Boolean value specifying whether the OP supports use of the
+		"request_uri" parameter
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<p>
+            </p>
+<ul class="text">
+<li>
+                Metadata Name: <tt>require_request_uri_registration</tt>
+              
+</li>
+<li>
+                Metadata Description:
+		Boolean value specifying whether the OP requires any
+		"request_uri" values used to be pre-registered
+              
+</li>
+<li>
+                Change Controller: OpenID Foundation Artifact Binding Working Group - openid-specs-ab@lists.openid.net
+              
+</li>
+<li>
+                Specification Document(s): <a class='info' href='#ProviderMetadata'>Section&nbsp;3<span> (</span><span class='info'>OpenID Provider Metadata</span><span>)</span></a> of this specification
+              
+</li>
+</ul><p>
+	  
+</p>
+<a name="rfc.references"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.9"></a><h3>9.&nbsp;
+References</h3>
+
+<a name="rfc.references1"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<h3>9.1.&nbsp;Normative References</h3>
+<table width="99%" border="0">
+<tr><td class="author-text" valign="top"><a name="CORS">[CORS]</a></td>
+<td class="author-text">Opera Software ASA, &ldquo;<a href="http://www.w3.org/TR/access-control/">Cross-Origin Resource Sharing</a>,&rdquo; July&nbsp;2010.</td></tr>
+<tr><td class="author-text" valign="top"><a name="IANA.well-known">[IANA.well-known]</a></td>
+<td class="author-text">IANA, &ldquo;<a href="https://www.iana.org/assignments/well-known-uris">Well-Known URIs</a>.&rdquo;</td></tr>
+<tr><td class="author-text" valign="top"><a name="JWA">[JWA]</a></td>
+<td class="author-text">Jones, M., &ldquo;<a href="https://www.rfc-editor.org/info/rfc7518">JSON Web Algorithms (JWA)</a>,&rdquo; RFC&nbsp;7518, DOI&nbsp;10.17487/RFC7518, May&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="JWE">[JWE]</a></td>
+<td class="author-text">Jones, M. and J. Hildebrand, &ldquo;<a href="https://www.rfc-editor.org/info/rfc7516">JSON Web Encryption (JWE)</a>,&rdquo; RFC&nbsp;7516, DOI&nbsp;10.17487/RFC7516, May&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="JWK">[JWK]</a></td>
+<td class="author-text">Jones, M., &ldquo;<a href="https://www.rfc-editor.org/info/rfc7517">JSON Web Key (JWK)</a>,&rdquo; RFC&nbsp;7517, DOI&nbsp;10.17487/RFC7517, May&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="JWS">[JWS]</a></td>
+<td class="author-text">Jones, M., Bradley, J., and N. Sakimura, &ldquo;<a href="https://www.rfc-editor.org/info/rfc7515">JSON Web Signature (JWS)</a>,&rdquo; RFC&nbsp;7515, DOI&nbsp;10.17487/RFC7515, May&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="JWT">[JWT]</a></td>
+<td class="author-text">Jones, M., Bradley, J., and N. Sakimura, &ldquo;<a href="https://www.rfc-editor.org/info/rfc7519">JSON Web Token (JWT)</a>,&rdquo; RFC&nbsp;7519, DOI&nbsp;10.17487/RFC7519, May&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OAuth.Responses">[OAuth.Responses]</a></td>
+<td class="author-text">de Medeiros, B., Ed., Scurtescu, M., Tarjan, P., and M. Jones, &ldquo;<a href="https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html">OAuth 2.0 Multiple Response Type Encoding Practices</a>,&rdquo; February&nbsp;2014.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.Core">[OpenID.Core]</a></td>
+<td class="author-text">Sakimura, N., Bradley, J., Jones, M., de Medeiros, B., and C. Mortimore, &ldquo;<a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect Core 1.0</a>,&rdquo; December&nbsp;2023.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.Registration">[OpenID.Registration]</a></td>
+<td class="author-text">Sakimura, N., Bradley, J., and M. Jones, &ldquo;<a href="https://openid.net/specs/openid-connect-registration-1_0.html">OpenID Connect Dynamic Client Registration 1.0</a>,&rdquo; December&nbsp;2023.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC2119">[RFC2119]</a></td>
+<td class="author-text">Bradner, S., &ldquo;<a href="https://www.rfc-editor.org/info/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>,&rdquo; BCP&nbsp;14, RFC&nbsp;2119, DOI&nbsp;10.17487/RFC2119, March&nbsp;1997.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC3986">[RFC3986]</a></td>
+<td class="author-text">Berners-Lee, T., Fielding, R., and L. Masinter, &ldquo;<a href="https://www.rfc-editor.org/info/rfc3986">Uniform Resource Identifier (URI): Generic Syntax</a>,&rdquo; STD&nbsp;66, RFC&nbsp;3986, DOI&nbsp;10.17487/RFC3986, January&nbsp;2005.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC5322">[RFC5322]</a></td>
+<td class="author-text">Resnick, P., Ed., &ldquo;<a href="https://www.rfc-editor.org/info/rfc5322">Internet Message Format</a>,&rdquo; RFC&nbsp;5322, DOI&nbsp;10.17487/RFC5322, October&nbsp;2008.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC5646">[RFC5646]</a></td>
+<td class="author-text">Phillips, A., Ed. and M. Davis, Ed., &ldquo;<a href="https://www.rfc-editor.org/info/rfc5646">Tags for Identifying Languages</a>,&rdquo; BCP&nbsp;47, RFC&nbsp;5646, DOI&nbsp;10.17487/RFC5646, September&nbsp;2009.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC5785">[RFC5785]</a></td>
+<td class="author-text">Nottingham, M. and E. Hammer-Lahav, &ldquo;<a href="https://www.rfc-editor.org/info/rfc5785">Defining Well-Known Uniform Resource Identifiers (URIs)</a>,&rdquo; RFC&nbsp;5785, DOI&nbsp;10.17487/RFC5785, April&nbsp;2010.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC6125">[RFC6125]</a></td>
+<td class="author-text">Saint-Andre, P. and J. Hodges, &ldquo;<a href="https://www.rfc-editor.org/info/rfc6125">Representation and Verification of Domain-Based Application Service Identity within Internet Public Key Infrastructure Using X.509 (PKIX) Certificates in the Context of Transport Layer Security (TLS)</a>,&rdquo; RFC&nbsp;6125, DOI&nbsp;10.17487/RFC6125, March&nbsp;2011.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC6749">[RFC6749]</a></td>
+<td class="author-text">Hardt, D., Ed., &ldquo;<a href="https://www.rfc-editor.org/info/rfc6749">The OAuth 2.0 Authorization Framework</a>,&rdquo; RFC&nbsp;6749, DOI&nbsp;10.17487/RFC6749, October&nbsp;2012.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC7033">[RFC7033]</a></td>
+<td class="author-text">Jones, P., Salgueiro, G., Jones, M., and J. Smarr, &ldquo;<a href="https://www.rfc-editor.org/info/rfc7033">WebFinger</a>,&rdquo; RFC&nbsp;7033, DOI&nbsp;10.17487/RFC7033, September&nbsp;2013.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC7565">[RFC7565]</a></td>
+<td class="author-text">Saint-Andre, P., &ldquo;<a href="https://www.rfc-editor.org/info/rfc7565">The 'acct' URI Scheme</a>,&rdquo; RFC&nbsp;7565, DOI&nbsp;10.17487/RFC7565, May&nbsp;2015.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC8259">[RFC8259]</a></td>
+<td class="author-text">Bray, T., Ed., &ldquo;<a href="https://www.rfc-editor.org/info/rfc8259">The JavaScript Object Notation (JSON) Data Interchange Format</a>,&rdquo; STD&nbsp;90, RFC&nbsp;8259, DOI&nbsp;10.17487/RFC8259, December&nbsp;2017.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC8996">[RFC8996]</a></td>
+<td class="author-text">Moriarty, K. and S. Farrell, &ldquo;<a href="https://www.rfc-editor.org/info/rfc8996">Deprecating TLS 1.0 and TLS 1.1</a>,&rdquo; BCP&nbsp;195, RFC&nbsp;8996, DOI&nbsp;10.17487/RFC8996, March&nbsp;2021.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC9325">[RFC9325]</a></td>
+<td class="author-text">Sheffer, Y., Saint-Andre, P., and T. Fossati, &ldquo;<a href="https://www.rfc-editor.org/info/rfc9325">Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS)</a>,&rdquo; BCP&nbsp;195, RFC&nbsp;9325, DOI&nbsp;10.17487/RFC9325, November&nbsp;2022.</td></tr>
+<tr><td class="author-text" valign="top"><a name="UNICODE">[UNICODE]</a></td>
+<td class="author-text">The Unicode Consortium, &ldquo;<a href="http://www.unicode.org/versions/latest/">The Unicode Standard</a>.&rdquo;</td></tr>
+<tr><td class="author-text" valign="top"><a name="USA15">[USA15]</a></td>
+<td class="author-text">Whistler, K., &ldquo;<a href="https://www.unicode.org/reports/tr15/">Unicode Normalization Forms</a>,&rdquo; Unicode Standard Annex&nbsp;15, August&nbsp;2023.</td></tr>
+</table>
+
+<a name="rfc.references2"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<h3>9.2.&nbsp;Informative References</h3>
+<table width="99%" border="0">
+<tr><td class="author-text" valign="top"><a name="IANA.OAuth.Parameters">[IANA.OAuth.Parameters]</a></td>
+<td class="author-text">IANA, &ldquo;<a href="https://www.iana.org/assignments/oauth-parameters">OAuth Parameters</a>.&rdquo;</td></tr>
+<tr><td class="author-text" valign="top"><a name="OWASP.CSRF">[OWASP.CSRF]</a></td>
+<td class="author-text">OWASP, &ldquo;<a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html">Cross-Site Request Forgery Prevention Cheat Sheet</a>.&rdquo;</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.Discovery.Errata1">[OpenID.Discovery.Errata1]</a></td>
+<td class="author-text">Sakimura, N., Bradley, J., Jones, M., and E. Jay, &ldquo;<a href="https://openid.net/specs/openid-connect-discovery-1_0-errata1.html">OpenID Connect Discovery 1.0 incorporating errata set 1</a>,&rdquo; November&nbsp;2014.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.Discovery.Final">[OpenID.Discovery.Final]</a></td>
+<td class="author-text">Sakimura, N., Bradley, J., Jones, M., and E. Jay, &ldquo;<a href="https://openid.net/specs/openid-connect-discovery-1_0-final.html">OpenID Connect Discovery 1.0 (final)</a>,&rdquo; February&nbsp;2014.</td></tr>
+<tr><td class="author-text" valign="top"><a name="OpenID.Session">[OpenID.Session]</a></td>
+<td class="author-text">de Medeiros, B., Agarwal, N., Sakimura, N., Bradley, J., and M. Jones, &ldquo;<a href="https://openid.net/specs/openid-connect-session-1_0.html">OpenID Connect Session Management 1.0</a>,&rdquo; September&nbsp;2022.</td></tr>
+<tr><td class="author-text" valign="top"><a name="RFC8414">[RFC8414]</a></td>
+<td class="author-text">Jones, M., Sakimura, N., and J. Bradley, &ldquo;<a href="https://www.rfc-editor.org/info/rfc8414">OAuth 2.0 Authorization Server Metadata</a>,&rdquo; RFC&nbsp;8414, DOI&nbsp;10.17487/RFC8414, June&nbsp;2018.</td></tr>
+<tr><td class="author-text" valign="top"><a name="XRI_Syntax_2.0">[XRI_Syntax_2.0]</a></td>
+<td class="author-text">Reed, D. and D. McAlpin, &ldquo;<a href="https://www.oasis-open.org/committees/download.php/15377/xri-syntax-V2.0-cs.pdf">Extensible Resource Identifier (XRI) Syntax V2.0</a>,&rdquo; November&nbsp;2005.</td></tr>
+</table>
+
+<a name="Acknowledgements"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.A"></a><h3>Appendix A.&nbsp;
+Acknowledgements</h3>
+
+<p>
+	The OpenID Community would like to thank the following people for
+	their contributions to this specification:
+      
+</p>
+<p>
+	</p>
+<blockquote class="text">
+<p>Andrew Arnott (andarno@microsoft.com), Microsoft
+</p>
+<p>Dirk Balfanz (balfanz@google.com), Google
+</p>
+<p>Casper Biering (cb@peercraft.com), Peercraft
+</p>
+<p>John Bradley (ve7jtb@ve7jtb.com), Yubico (was at Ping Identity)
+</p>
+<p>Johnny Bufu (johnny.bufu@gmail.com), independent (was at Janrain)
+</p>
+<p>Brian Campbell (bcampbell@pingidentity.com), Ping Identity
+</p>
+<p>Blaine Cook (romeda@gmail.com), independent
+</p>
+<p>Breno de Medeiros (breno@google.com), Google
+</p>
+<p>Pamela Dingle (Pamela.Dingle@microsoft.com), Microsoft (was at Ping Identity)
+</p>
+<p>Vladimir Dzhuvinov (vladimir@connect2id.com), Connect2id (was at Nimbus Directory Services)
+</p>
+<p>George Fletcher (gffletch@aol.com), Capital One (was at AOL)
+</p>
+<p>Dick Hardt (dick.hardt@gmail.com), independent
+</p>
+<p>Roland Hedberg (roland@catalogix.se), independent (was at University of Ume&aring;)
+</p>
+<p>Edmund Jay (ejay@mgi1.com), Illumila
+</p>
+<p>Michael B. Jones (michael_b_jones@hotmail.com), Self-Issued Consulting (was at Microsoft)
+</p>
+<p>Torsten Lodderstedt (torsten@lodderstedt.net), independent (was at Deutsche Telekom)
+</p>
+<p>Nov Matake (nov@matake.jp), independent
+</p>
+<p>Chuck Mortimore (charliemortimore@gmail.com), Disney (was at Salesforce)
+</p>
+<p>Anthony Nadalin (nadalin@prodigy.net), independent (was at Microsoft)
+</p>
+<p>Axel Nennker (axel.nennker@telekom.de), Deutsche Telekom
+</p>
+<p>John Panzer (jpanzer@google.com), Google
+</p>
+<p>Justin Richer (justin@bspk.io), Bespoke Engineering (was at MITRE)
+</p>
+<p>Nat Sakimura (nat@nat.consulting), NAT.Consulting (was at NRI)
+</p>
+<p>Owen Shepherd (owen.shepherd@e43.eu), independent
+</p>
+<p>Andreas &Aring;kre Solberg (Andreas.Solberg@sikt.no), Sikt (was at UNINET)
+</p>
+<p>Kick Willemse (k.willemse@evidos.nl), Evidos B.V.
+</p>
+</blockquote><p>
+      
+</p>
+<a name="Notices"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<a name="rfc.section.B"></a><h3>Appendix B.&nbsp;
+Notices</h3>
+
+<p>Copyright (c) 2023 The OpenID Foundation.
+</p>
+<p>
+	The OpenID Foundation (OIDF) grants to any Contributor, developer,
+	implementer, or other interested party a non-exclusive, royalty free,
+	worldwide copyright license to reproduce, prepare derivative works from,
+	distribute, perform and display, this Implementers Draft or
+	Final Specification solely for the purposes of (i) developing
+	specifications, and (ii) implementing Implementers Drafts and
+	Final Specifications based on such documents, provided that attribution
+	be made to the OIDF as the source of the material, but that such attribution
+	does not indicate an endorsement by the OIDF.
+      
+</p>
+<p>
+	The technology described in this specification was
+	made available from contributions from various sources,
+	including members of the OpenID Foundation and others.
+	Although the OpenID Foundation has taken steps to help ensure
+	that the technology is available for distribution, it takes
+	no position regarding the validity or scope of any intellectual
+	property or other rights that might be claimed to pertain to
+	the implementation or use of the technology described in
+	this specification or the extent to which any license under
+	such rights might or might not be available; neither does it
+	represent that it has made any independent effort to identify
+	any such rights.  The OpenID Foundation and the contributors
+	to this specification make no (and hereby expressly disclaim any)
+	warranties (express, implied, or otherwise), including implied
+	warranties of merchantability, non-infringement, fitness for
+	a particular purpose, or title, related to this specification,
+	and the entire risk as to implementing this specification is
+	assumed by the implementer.  The OpenID Intellectual
+	Property Rights policy requires contributors to offer
+	a patent promise not to assert certain patent claims against
+	other contributors and against implementers.  The OpenID Foundation invites
+	any interested party to bring to its attention any copyrights,
+	patents, patent applications, or other proprietary rights
+	that may cover technology that may be required to practice
+	this specification.
+      
+</p>
+<a name="rfc.authors"></a><br /><hr />
+<table summary="layout" cellpadding="0" cellspacing="2" class="TOCbug" align="right"><tr><td class="TOCbug"><a href="#toc">&nbsp;TOC&nbsp;</a></td></tr></table>
+<h3>Authors' Addresses</h3>
+<table width="99%" border="0" cellpadding="0" cellspacing="0">
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Nat Sakimura</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">NAT.Consulting</td></tr>
+<tr><td class="author" align="right">Email:&nbsp;</td>
+<td class="author-text"><a href="mailto:nat@nat.consulting">nat@nat.consulting</a></td></tr>
+<tr><td class="author" align="right">URI:&nbsp;</td>
+<td class="author-text"><a href="https://nat.sakimura.org/">https://nat.sakimura.org/</a></td></tr>
+<tr cellpadding="3"><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">John Bradley</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Yubico</td></tr>
+<tr><td class="author" align="right">Email:&nbsp;</td>
+<td class="author-text"><a href="mailto:ve7jtb@ve7jtb.com">ve7jtb@ve7jtb.com</a></td></tr>
+<tr><td class="author" align="right">URI:&nbsp;</td>
+<td class="author-text"><a href="http://www.thread-safe.com/">http://www.thread-safe.com/</a></td></tr>
+<tr cellpadding="3"><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Michael B. Jones</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Self-Issued Consulting</td></tr>
+<tr><td class="author" align="right">Email:&nbsp;</td>
+<td class="author-text"><a href="mailto:michael_b_jones@hotmail.com">michael_b_jones@hotmail.com</a></td></tr>
+<tr><td class="author" align="right">URI:&nbsp;</td>
+<td class="author-text"><a href="https://self-issued.info/">https://self-issued.info/</a></td></tr>
+<tr cellpadding="3"><td>&nbsp;</td><td>&nbsp;</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Edmund Jay</td></tr>
+<tr><td class="author-text">&nbsp;</td>
+<td class="author-text">Illumila</td></tr>
+<tr><td class="author" align="right">Email:&nbsp;</td>
+<td class="author-text"><a href="mailto:ejay@mgi1.com">ejay@mgi1.com</a></td></tr>
+</table>
+</body></html>

--- a/rfc/rfc.md
+++ b/rfc/rfc.md
@@ -1,0 +1,190 @@
+# RFC Compliance Review Plan
+
+## Overview
+
+Seven phases tackling one spec at a time, in dependency order. Each phase: read spec sections, review code paths, fix bugs, add unit + e2e tests.
+
+| Phase | Spec | Est. Time | Status |
+|---|---|---|---|
+| 1 | RFC 6749 — OAuth 2.0 Core | 2–3h | pending |
+| 2 | RFC 6750 — Bearer Token Usage | 1.5h | pending |
+| 3 | RFC 7636 — PKCE | 1.5h | pending |
+| 4 | RFC 7009 — Token Revocation | 1.5h | pending |
+| 5 | RFC 7662 — Token Introspection | 1.5h | pending |
+| 6 | OIDC Core 1.0 | 3h | pending |
+| 7 | OIDC Discovery 1.0 | 1h | pending |
+
+**Recommended order:** 1 → 4 → 5 → 2 → 3 → 6 → 7
+
+---
+
+## Bug Inventory
+
+| Severity | Location | Issue | Spec Reference |
+|---|---|---|---|
+| High | `pkg/token/revoke.go:55` | Returns `401` for expired/invalid tokens instead of `200` | RFC 7009 §2.2 |
+| High | `pkg/introspect/handler.go:52` | Returns `401 invalid_token` for inactive tokens instead of `200 {"active":false}` | RFC 7662 §2.2 |
+| High | `pkg/introspect/handler.go:31` | Accepts only `application/json`; spec requires `application/x-www-form-urlencoded` | RFC 7662 §2.1 |
+| Medium | `pkg/authorize/handler.go:229` | `error_description` not URL-encoded in redirect URL | RFC 6749 §4.1.2.1 |
+| Medium | `pkg/token/handler.go` + `pkg/token/revoke.go` | No client authentication on revoke and introspect endpoints | RFC 7009 §2.1, RFC 7662 §2.1 |
+| Medium | `pkg/wellknown/handler.go` | Missing `introspection_endpoint`, `revocation_endpoint`, `code_challenge_methods_supported` | RFC 7662 §4, RFC 7009 §4, RFC 7636 §6.2 |
+| Medium | `pkg/token/generate.go:26-44` | Access token always embeds profile/email claims regardless of scope | OIDC Core §5.4 |
+| Medium | all protected endpoints | Missing `WWW-Authenticate` header on 401 responses | RFC 6750 §3 |
+| Low | `pkg/token/authorization_code.go:84` | `code_verifier` length/charset not validated (43–128 chars, unreserved only) | RFC 7636 §4.1 |
+| Low | `pkg/wellknown/handler.go:33` | Advertises `token`, `id_token` response types that are not implemented | OIDC Discovery §3 |
+| Low | `pkg/token/generate.go:37` | `acr: "password"` in access token is non-standard | OIDC Core §2 |
+| Low | `pkg/token/handler.go` | `scope` absent from token response for `refresh_token` grant | RFC 6749 §5.1 |
+
+---
+
+## Phase 1 — RFC 6749: OAuth 2.0 Core
+
+**File:** `rfc/rfc6749.txt`
+
+| Section | What to check | Code path |
+|---|---|---|
+| §3.1 | `response_type` validation, required params | `pkg/authorize/handler.go`, `pkg/authorize/model.go` |
+| §4.1.2 | Auth response: `code`, `state`; `state` MUST echo client's value | `pkg/login/handler.go` redirect construction |
+| §4.1.2.1 | `error_description` MUST be URL-encoded in redirect | `pkg/authorize/handler.go` `redirectWithError` |
+| §4.1.3 | Token request: `grant_type`, `code`, `redirect_uri`, client auth | `pkg/token/handler.go`, `pkg/token/authorization_code.go` |
+| §4.1.4 | Token response: `scope` must be omitted if identical to requested | `pkg/token/model.go` `TokenResponse` |
+| §4.3 | ROPC: `invalid_grant` vs `invalid_client` error codes | `pkg/token/handler.go` password block |
+| §4.6 | Refresh: `scope` MUST NOT exceed original; `scope` MUST appear in response | `pkg/token/refresh_token.go` |
+| §5.2 | Error response: `error`, `error_description`, HTTP 400 (401 only for `invalid_client`) | `pkg/utils/responses.go` |
+| §10.6 | Auth code replay: revoke all tokens for user/client | `pkg/token/revoke.go` |
+
+**Tests to add:**
+- Unit: `error_description` with spaces/special chars is URL-encoded in redirect
+- Unit: `scope` present in token response for `refresh_token` grant
+- Unit: `refresh_token` grant rejects scope expansion
+- E2e: `TestAuthorizationCodeFlow_ScopeDownscope`
+
+---
+
+## Phase 2 — RFC 6750: Bearer Token Usage
+
+**File:** `rfc/rfc6750.txt`
+
+| Section | What to check | Code path |
+|---|---|---|
+| §2.1 | `Bearer ` prefix parsing (capital B, single space) | `pkg/utils/extract_bearer_token.go` |
+| §2.2 | Form-encoded `access_token`: only `application/x-www-form-urlencoded`, POST only, not alongside header | `pkg/userinfo/handler.go` |
+| §3.1 | `WWW-Authenticate` header MUST be set on 401 responses | all protected endpoints |
+| §3.1 | `WWW-Authenticate: Bearer realm="...", error="...", error_description="..."` format | all protected endpoints |
+
+**Tests to add:**
+- E2e: `TestUserInfo_WWWAuthenticateHeader` — assert header on 401
+- E2e: `TestUserInfo_FormBodyToken` — POST with `access_token` in form body
+- E2e: `TestUserInfo_DualCredentials_Rejected` — header + body token simultaneously
+- Unit: `ExtractBearerToken` with case variations
+
+---
+
+## Phase 3 — RFC 7636: PKCE
+
+**File:** `rfc/rfc7636.txt`
+
+| Section | What to check | Code path |
+|---|---|---|
+| §4.1 | `code_verifier`: 43–128 chars, unreserved chars only | `pkg/token/authorization_code.go` `verifyCodeChallenge` |
+| §4.2 | `code_challenge`: `BASE64URL(SHA256(ASCII(verifier)))`, no padding | `pkg/token/authorization_code.go` |
+| §4.2 | `code_challenge_method` absent → default to S256 | `pkg/token/authorization_code.go` line 86 |
+| §4.3 | If challenge was sent, verifier MUST be sent on exchange | `pkg/token/authorization_code.go` line 54 |
+| §6.1 | `code_challenge_methods_supported` in discovery | `pkg/wellknown/handler.go` — absent |
+
+**Tests to add:**
+- Unit: verifier shorter than 43 chars — rejected
+- Unit: verifier with invalid chars (`+`, `/`) — rejected
+- Unit: verifier at exactly 43 and 128 chars (boundary)
+- E2e: `TestPKCE_PlainMethod_E2E`
+- Unit: wellknown asserts `code_challenge_methods_supported` once added
+
+---
+
+## Phase 4 — RFC 7009: Token Revocation
+
+**File:** `rfc/rfc7009.txt`
+
+| Section | What to check | Code path |
+|---|---|---|
+| §2.1 | `token` required, `token_type_hint` optional | `pkg/token/revoke.go` |
+| §2.1 | Client auth required for confidential clients | `pkg/token/revoke.go` — missing |
+| §2.2 | MUST return `200` for all requests incl. invalid/expired/unknown tokens | `pkg/token/revoke.go` — currently returns `401` (BUG) |
+| §2.2 | Refresh token revocation SHOULD also revoke associated access token | `pkg/token/revoke.go` |
+| §4 | `revocation_endpoint` in discovery | `pkg/wellknown/handler.go` — absent |
+
+**Tests to add:**
+- E2e: `TestRevoke_ExpiredToken_Returns200`
+- E2e: `TestRevoke_UnknownToken_Returns200`
+- E2e: `TestRevoke_RefreshToken_RevokesAccessToo`
+- Unit: `token_type_hint` present — accepted and ignored without error
+
+---
+
+## Phase 5 — RFC 7662: Token Introspection
+
+**File:** `rfc/rfc7662.txt`
+
+| Section | What to check | Code path |
+|---|---|---|
+| §2.1 | Request MUST be `application/x-www-form-urlencoded` | `pkg/introspect/handler.go` — JSON only (BUG) |
+| §2.1 | Client authentication required | `pkg/introspect/handler.go` — missing |
+| §2.2 | Active token: `active=true` + all registered claims (`scope`, `exp`, `iat`, `sub`, `client_id`, `username`, `aud`, `jti`) | `pkg/introspect/model.go` — missing `client_id`, `username`, `aud`, `nbf` |
+| §2.2 | Inactive token: MUST return `200 {"active":false}` only | `pkg/introspect/handler.go` — returns `401` (BUG) |
+| §4 | `introspection_endpoint` in discovery | `pkg/wellknown/handler.go` — absent |
+
+**Tests to add:**
+- E2e: `TestIntrospect_ExpiredToken_ActiveFalse`
+- E2e: `TestIntrospect_RevokedToken_ActiveFalse`
+- E2e: `TestIntrospect_UnknownToken_ActiveFalse`
+- E2e: `TestIntrospect_FormEncoded` (after fix)
+- E2e: `TestIntrospect_ActiveToken_AllFields` — assert all required fields present
+- Note: existing tests `TestRevokedToken_IntrospectRejects` and `TestExpiredAccessToken_IntrospectRejects` assert `401` — these must be updated to expect `200 {"active":false}`
+
+---
+
+## Phase 6 — OIDC Core 1.0
+
+**File:** `rfc/openid-connect-core-1_0.html`
+
+| Section | What to check | Code path |
+|---|---|---|
+| §3.1.2.1 | `scope` MUST include `openid` for OIDC requests | `pkg/authorize/model.go` |
+| §3.1.3.3 | ID token required claims: `iss`, `sub`, `aud`, `exp`, `iat` | `pkg/token/generate.go` `GenerateIDToken` |
+| §3.1.3.3 | `nonce` MUST be present in ID token if sent in auth request | `pkg/token/generate.go` |
+| §3.1.3.3 | `acr: "password"` non-standard; ID token uses `"1"` — inconsistency | `pkg/token/generate.go` lines 37, 95 |
+| §5.1 | UserInfo standard claims scope-filtered | `pkg/userinfo/handler.go` |
+| §5.3 | UserInfo `sub` MUST match ID token `sub` | `pkg/userinfo/handler.go` |
+| §5.4 | Claims in access token must respect scope | `pkg/token/generate.go` — always includes profile claims (BUG) |
+| §11 | `offline_access` requires `prompt=consent` | `pkg/token/handler.go` — not enforced |
+
+**Tests to add:**
+- E2e: `TestIDToken_Claims_Verification` — parse and validate all required claims
+- E2e: `TestIDToken_Nonce_Preserved` — nonce in decoded token matches sent value
+- E2e: `TestUserInfo_Sub_MatchesIDToken`
+- E2e: `TestUserInfo_ScopeFiltering` — `openid` only; no `email`/`profile` claims
+- Unit: `GenerateIDToken` — all required claims, correct absence of optional ones
+- Unit: access token does not include profile claims when `profile` scope absent
+
+---
+
+## Phase 7 — OIDC Discovery 1.0
+
+**File:** `rfc/openid-connect-discovery-1_0.html`
+
+| Section | What to check | Code path |
+|---|---|---|
+| §3 | Required: `issuer`, `authorization_endpoint`, `token_endpoint`, `jwks_uri`, `response_types_supported`, `subject_types_supported`, `id_token_signing_alg_values_supported` | `pkg/wellknown/handler.go` — all present |
+| §3 | `introspection_endpoint` — absent | `pkg/model/well_known_config.go` |
+| §3 | `revocation_endpoint` — absent | `pkg/model/well_known_config.go` |
+| §3 | `code_challenge_methods_supported` — absent | `pkg/model/well_known_config.go` |
+| §3 | `response_types_supported` lists `token`, `id_token` — implicit flow not implemented | `pkg/wellknown/handler.go` |
+| §3 | `issuer` MUST exactly match `iss` in tokens | `pkg/wellknown/handler.go` vs `pkg/token/generate.go` |
+| §3 | JWKS keys: `kty`, `use`, `alg`, `kid`, `n`, `e` all present | `pkg/wellknown/handler.go` `HandleJWKS` |
+
+**Tests to add:**
+- E2e: `TestWellKnown_RequiredFields` — all required fields present with correct types
+- E2e: `TestWellKnown_IssuerMatchesTokenIss` — compare `issuer` in discovery to `iss` in token
+- E2e: `TestJWKS_Structure` — assert key fields present
+- E2e: `TestJWKS_ValidatesIDToken` — use JWKS to verify ID token signature
+- Unit: assert `introspection_endpoint`, `revocation_endpoint`, `code_challenge_methods_supported` present once added

--- a/rfc/rfc6749.txt
+++ b/rfc/rfc6749.txt
@@ -1,0 +1,4259 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                     D. Hardt, Ed.
+Request for Comments: 6749                                     Microsoft
+Obsoletes: 5849                                             October 2012
+Category: Standards Track
+ISSN: 2070-1721
+
+
+                 The OAuth 2.0 Authorization Framework
+
+Abstract
+
+   The OAuth 2.0 authorization framework enables a third-party
+   application to obtain limited access to an HTTP service, either on
+   behalf of a resource owner by orchestrating an approval interaction
+   between the resource owner and the HTTP service, or by allowing the
+   third-party application to obtain access on its own behalf.  This
+   specification replaces and obsoletes the OAuth 1.0 protocol described
+   in RFC 5849.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6749.
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+Hardt                        Standards Track                    [Page 1]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+Table of Contents
+
+   1. Introduction ....................................................4
+      1.1. Roles ......................................................6
+      1.2. Protocol Flow ..............................................7
+      1.3. Authorization Grant ........................................8
+           1.3.1. Authorization Code ..................................8
+           1.3.2. Implicit ............................................8
+           1.3.3. Resource Owner Password Credentials .................9
+           1.3.4. Client Credentials ..................................9
+      1.4. Access Token ..............................................10
+      1.5. Refresh Token .............................................10
+      1.6. TLS Version ...............................................12
+      1.7. HTTP Redirections .........................................12
+      1.8. Interoperability ..........................................12
+      1.9. Notational Conventions ....................................13
+   2. Client Registration ............................................13
+      2.1. Client Types ..............................................14
+      2.2. Client Identifier .........................................15
+      2.3. Client Authentication .....................................16
+           2.3.1. Client Password ....................................16
+           2.3.2. Other Authentication Methods .......................17
+      2.4. Unregistered Clients ......................................17
+   3. Protocol Endpoints .............................................18
+      3.1. Authorization Endpoint ....................................18
+           3.1.1. Response Type ......................................19
+           3.1.2. Redirection Endpoint ...............................19
+      3.2. Token Endpoint ............................................21
+           3.2.1. Client Authentication ..............................22
+      3.3. Access Token Scope ........................................23
+   4. Obtaining Authorization ........................................23
+      4.1. Authorization Code Grant ..................................24
+           4.1.1. Authorization Request ..............................25
+           4.1.2. Authorization Response .............................26
+           4.1.3. Access Token Request ...............................29
+           4.1.4. Access Token Response ..............................30
+      4.2. Implicit Grant ............................................31
+           4.2.1. Authorization Request ..............................33
+           4.2.2. Access Token Response ..............................35
+      4.3. Resource Owner Password Credentials Grant .................37
+           4.3.1. Authorization Request and Response .................39
+           4.3.2. Access Token Request ...............................39
+           4.3.3. Access Token Response ..............................40
+      4.4. Client Credentials Grant ..................................40
+           4.4.1. Authorization Request and Response .................41
+           4.4.2. Access Token Request ...............................41
+           4.4.3. Access Token Response ..............................42
+      4.5. Extension Grants ..........................................42
+
+
+
+Hardt                        Standards Track                    [Page 2]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   5. Issuing an Access Token ........................................43
+      5.1. Successful Response .......................................43
+      5.2. Error Response ............................................45
+   6. Refreshing an Access Token .....................................47
+   7. Accessing Protected Resources ..................................48
+      7.1. Access Token Types ........................................49
+      7.2. Error Response ............................................49
+   8. Extensibility ..................................................50
+      8.1. Defining Access Token Types ...............................50
+      8.2. Defining New Endpoint Parameters ..........................50
+      8.3. Defining New Authorization Grant Types ....................51
+      8.4. Defining New Authorization Endpoint Response Types ........51
+      8.5. Defining Additional Error Codes ...........................51
+   9. Native Applications ............................................52
+   10. Security Considerations .......................................53
+      10.1. Client Authentication ....................................53
+      10.2. Client Impersonation .....................................54
+      10.3. Access Tokens ............................................55
+      10.4. Refresh Tokens ...........................................55
+      10.5. Authorization Codes ......................................56
+      10.6. Authorization Code Redirection URI Manipulation ..........56
+      10.7. Resource Owner Password Credentials ......................57
+      10.8. Request Confidentiality ..................................58
+      10.9. Ensuring Endpoint Authenticity ...........................58
+      10.10. Credentials-Guessing Attacks ............................58
+      10.11. Phishing Attacks ........................................58
+      10.12. Cross-Site Request Forgery ..............................59
+      10.13. Clickjacking ............................................60
+      10.14. Code Injection and Input Validation .....................60
+      10.15. Open Redirectors ........................................60
+      10.16. Misuse of Access Token to Impersonate Resource
+             Owner in Implicit Flow ..................................61
+   11. IANA Considerations ...........................................62
+      11.1. OAuth Access Token Types Registry ........................62
+           11.1.1. Registration Template .............................62
+      11.2. OAuth Parameters Registry ................................63
+           11.2.1. Registration Template .............................63
+           11.2.2. Initial Registry Contents .........................64
+      11.3. OAuth Authorization Endpoint Response Types Registry .....66
+           11.3.1. Registration Template .............................66
+           11.3.2. Initial Registry Contents .........................67
+      11.4. OAuth Extensions Error Registry ..........................67
+           11.4.1. Registration Template .............................68
+   12. References ....................................................68
+      12.1. Normative References .....................................68
+      12.2. Informative References ...................................70
+
+
+
+
+
+Hardt                        Standards Track                    [Page 3]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   Appendix A. Augmented Backus-Naur Form (ABNF) Syntax ..............71
+     A.1.  "client_id" Syntax ........................................71
+     A.2.  "client_secret" Syntax ....................................71
+     A.3.  "response_type" Syntax ....................................71
+     A.4.  "scope" Syntax ............................................72
+     A.5.  "state" Syntax ............................................72
+     A.6.  "redirect_uri" Syntax .....................................72
+     A.7.  "error" Syntax ............................................72
+     A.8.  "error_description" Syntax ................................72
+     A.9.  "error_uri" Syntax ........................................72
+     A.10. "grant_type" Syntax .......................................73
+     A.11. "code" Syntax .............................................73
+     A.12. "access_token" Syntax .....................................73
+     A.13. "token_type" Syntax .......................................73
+     A.14. "expires_in" Syntax .......................................73
+     A.15. "username" Syntax .........................................73
+     A.16. "password" Syntax .........................................73
+     A.17. "refresh_token" Syntax ....................................74
+     A.18. Endpoint Parameter Syntax .................................74
+   Appendix B. Use of application/x-www-form-urlencoded Media Type ...74
+   Appendix C. Acknowledgements ......................................75
+
+1.  Introduction
+
+   In the traditional client-server authentication model, the client
+   requests an access-restricted resource (protected resource) on the
+   server by authenticating with the server using the resource owner's
+   credentials.  In order to provide third-party applications access to
+   restricted resources, the resource owner shares its credentials with
+   the third party.  This creates several problems and limitations:
+
+   o  Third-party applications are required to store the resource
+      owner's credentials for future use, typically a password in
+      clear-text.
+
+   o  Servers are required to support password authentication, despite
+      the security weaknesses inherent in passwords.
+
+   o  Third-party applications gain overly broad access to the resource
+      owner's protected resources, leaving resource owners without any
+      ability to restrict duration or access to a limited subset of
+      resources.
+
+   o  Resource owners cannot revoke access to an individual third party
+      without revoking access to all third parties, and must do so by
+      changing the third party's password.
+
+
+
+
+
+Hardt                        Standards Track                    [Page 4]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   o  Compromise of any third-party application results in compromise of
+      the end-user's password and all of the data protected by that
+      password.
+
+   OAuth addresses these issues by introducing an authorization layer
+   and separating the role of the client from that of the resource
+   owner.  In OAuth, the client requests access to resources controlled
+   by the resource owner and hosted by the resource server, and is
+   issued a different set of credentials than those of the resource
+   owner.
+
+   Instead of using the resource owner's credentials to access protected
+   resources, the client obtains an access token -- a string denoting a
+   specific scope, lifetime, and other access attributes.  Access tokens
+   are issued to third-party clients by an authorization server with the
+   approval of the resource owner.  The client uses the access token to
+   access the protected resources hosted by the resource server.
+
+   For example, an end-user (resource owner) can grant a printing
+   service (client) access to her protected photos stored at a photo-
+   sharing service (resource server), without sharing her username and
+   password with the printing service.  Instead, she authenticates
+   directly with a server trusted by the photo-sharing service
+   (authorization server), which issues the printing service delegation-
+   specific credentials (access token).
+
+   This specification is designed for use with HTTP ([RFC2616]).  The
+   use of OAuth over any protocol other than HTTP is out of scope.
+
+   The OAuth 1.0 protocol ([RFC5849]), published as an informational
+   document, was the result of a small ad hoc community effort.  This
+   Standards Track specification builds on the OAuth 1.0 deployment
+   experience, as well as additional use cases and extensibility
+   requirements gathered from the wider IETF community.  The OAuth 2.0
+   protocol is not backward compatible with OAuth 1.0.  The two versions
+   may co-exist on the network, and implementations may choose to
+   support both.  However, it is the intention of this specification
+   that new implementations support OAuth 2.0 as specified in this
+   document and that OAuth 1.0 is used only to support existing
+   deployments.  The OAuth 2.0 protocol shares very few implementation
+   details with the OAuth 1.0 protocol.  Implementers familiar with
+   OAuth 1.0 should approach this document without any assumptions as to
+   its structure and details.
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                    [Page 5]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+1.1.  Roles
+
+   OAuth defines four roles:
+
+   resource owner
+      An entity capable of granting access to a protected resource.
+      When the resource owner is a person, it is referred to as an
+      end-user.
+
+   resource server
+      The server hosting the protected resources, capable of accepting
+      and responding to protected resource requests using access tokens.
+
+   client
+      An application making protected resource requests on behalf of the
+      resource owner and with its authorization.  The term "client" does
+      not imply any particular implementation characteristics (e.g.,
+      whether the application executes on a server, a desktop, or other
+      devices).
+
+   authorization server
+      The server issuing access tokens to the client after successfully
+      authenticating the resource owner and obtaining authorization.
+
+   The interaction between the authorization server and resource server
+   is beyond the scope of this specification.  The authorization server
+   may be the same server as the resource server or a separate entity.
+   A single authorization server may issue access tokens accepted by
+   multiple resource servers.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                    [Page 6]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+1.2.  Protocol Flow
+
+     +--------+                               +---------------+
+     |        |--(A)- Authorization Request ->|   Resource    |
+     |        |                               |     Owner     |
+     |        |<-(B)-- Authorization Grant ---|               |
+     |        |                               +---------------+
+     |        |
+     |        |                               +---------------+
+     |        |--(C)-- Authorization Grant -->| Authorization |
+     | Client |                               |     Server    |
+     |        |<-(D)----- Access Token -------|               |
+     |        |                               +---------------+
+     |        |
+     |        |                               +---------------+
+     |        |--(E)----- Access Token ------>|    Resource   |
+     |        |                               |     Server    |
+     |        |<-(F)--- Protected Resource ---|               |
+     +--------+                               +---------------+
+
+                     Figure 1: Abstract Protocol Flow
+
+   The abstract OAuth 2.0 flow illustrated in Figure 1 describes the
+   interaction between the four roles and includes the following steps:
+
+   (A)  The client requests authorization from the resource owner.  The
+        authorization request can be made directly to the resource owner
+        (as shown), or preferably indirectly via the authorization
+        server as an intermediary.
+
+   (B)  The client receives an authorization grant, which is a
+        credential representing the resource owner's authorization,
+        expressed using one of four grant types defined in this
+        specification or using an extension grant type.  The
+        authorization grant type depends on the method used by the
+        client to request authorization and the types supported by the
+        authorization server.
+
+   (C)  The client requests an access token by authenticating with the
+        authorization server and presenting the authorization grant.
+
+   (D)  The authorization server authenticates the client and validates
+        the authorization grant, and if valid, issues an access token.
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                    [Page 7]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   (E)  The client requests the protected resource from the resource
+        server and authenticates by presenting the access token.
+
+   (F)  The resource server validates the access token, and if valid,
+        serves the request.
+
+   The preferred method for the client to obtain an authorization grant
+   from the resource owner (depicted in steps (A) and (B)) is to use the
+   authorization server as an intermediary, which is illustrated in
+   Figure 3 in Section 4.1.
+
+1.3.  Authorization Grant
+
+   An authorization grant is a credential representing the resource
+   owner's authorization (to access its protected resources) used by the
+   client to obtain an access token.  This specification defines four
+   grant types -- authorization code, implicit, resource owner password
+   credentials, and client credentials -- as well as an extensibility
+   mechanism for defining additional types.
+
+1.3.1.  Authorization Code
+
+   The authorization code is obtained by using an authorization server
+   as an intermediary between the client and resource owner.  Instead of
+   requesting authorization directly from the resource owner, the client
+   directs the resource owner to an authorization server (via its
+   user-agent as defined in [RFC2616]), which in turn directs the
+   resource owner back to the client with the authorization code.
+
+   Before directing the resource owner back to the client with the
+   authorization code, the authorization server authenticates the
+   resource owner and obtains authorization.  Because the resource owner
+   only authenticates with the authorization server, the resource
+   owner's credentials are never shared with the client.
+
+   The authorization code provides a few important security benefits,
+   such as the ability to authenticate the client, as well as the
+   transmission of the access token directly to the client without
+   passing it through the resource owner's user-agent and potentially
+   exposing it to others, including the resource owner.
+
+1.3.2.  Implicit
+
+   The implicit grant is a simplified authorization code flow optimized
+   for clients implemented in a browser using a scripting language such
+   as JavaScript.  In the implicit flow, instead of issuing the client
+   an authorization code, the client is issued an access token directly
+
+
+
+
+Hardt                        Standards Track                    [Page 8]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   (as the result of the resource owner authorization).  The grant type
+   is implicit, as no intermediate credentials (such as an authorization
+   code) are issued (and later used to obtain an access token).
+
+   When issuing an access token during the implicit grant flow, the
+   authorization server does not authenticate the client.  In some
+   cases, the client identity can be verified via the redirection URI
+   used to deliver the access token to the client.  The access token may
+   be exposed to the resource owner or other applications with access to
+   the resource owner's user-agent.
+
+   Implicit grants improve the responsiveness and efficiency of some
+   clients (such as a client implemented as an in-browser application),
+   since it reduces the number of round trips required to obtain an
+   access token.  However, this convenience should be weighed against
+   the security implications of using implicit grants, such as those
+   described in Sections 10.3 and 10.16, especially when the
+   authorization code grant type is available.
+
+1.3.3.  Resource Owner Password Credentials
+
+   The resource owner password credentials (i.e., username and password)
+   can be used directly as an authorization grant to obtain an access
+   token.  The credentials should only be used when there is a high
+   degree of trust between the resource owner and the client (e.g., the
+   client is part of the device operating system or a highly privileged
+   application), and when other authorization grant types are not
+   available (such as an authorization code).
+
+   Even though this grant type requires direct client access to the
+   resource owner credentials, the resource owner credentials are used
+   for a single request and are exchanged for an access token.  This
+   grant type can eliminate the need for the client to store the
+   resource owner credentials for future use, by exchanging the
+   credentials with a long-lived access token or refresh token.
+
+1.3.4.  Client Credentials
+
+   The client credentials (or other forms of client authentication) can
+   be used as an authorization grant when the authorization scope is
+   limited to the protected resources under the control of the client,
+   or to protected resources previously arranged with the authorization
+   server.  Client credentials are used as an authorization grant
+   typically when the client is acting on its own behalf (the client is
+   also the resource owner) or is requesting access to protected
+   resources based on an authorization previously arranged with the
+   authorization server.
+
+
+
+
+Hardt                        Standards Track                    [Page 9]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+1.4.  Access Token
+
+   Access tokens are credentials used to access protected resources.  An
+   access token is a string representing an authorization issued to the
+   client.  The string is usually opaque to the client.  Tokens
+   represent specific scopes and durations of access, granted by the
+   resource owner, and enforced by the resource server and authorization
+   server.
+
+   The token may denote an identifier used to retrieve the authorization
+   information or may self-contain the authorization information in a
+   verifiable manner (i.e., a token string consisting of some data and a
+   signature).  Additional authentication credentials, which are beyond
+   the scope of this specification, may be required in order for the
+   client to use a token.
+
+   The access token provides an abstraction layer, replacing different
+   authorization constructs (e.g., username and password) with a single
+   token understood by the resource server.  This abstraction enables
+   issuing access tokens more restrictive than the authorization grant
+   used to obtain them, as well as removing the resource server's need
+   to understand a wide range of authentication methods.
+
+   Access tokens can have different formats, structures, and methods of
+   utilization (e.g., cryptographic properties) based on the resource
+   server security requirements.  Access token attributes and the
+   methods used to access protected resources are beyond the scope of
+   this specification and are defined by companion specifications such
+   as [RFC6750].
+
+1.5.  Refresh Token
+
+   Refresh tokens are credentials used to obtain access tokens.  Refresh
+   tokens are issued to the client by the authorization server and are
+   used to obtain a new access token when the current access token
+   becomes invalid or expires, or to obtain additional access tokens
+   with identical or narrower scope (access tokens may have a shorter
+   lifetime and fewer permissions than authorized by the resource
+   owner).  Issuing a refresh token is optional at the discretion of the
+   authorization server.  If the authorization server issues a refresh
+   token, it is included when issuing an access token (i.e., step (D) in
+   Figure 1).
+
+   A refresh token is a string representing the authorization granted to
+   the client by the resource owner.  The string is usually opaque to
+   the client.  The token denotes an identifier used to retrieve the
+
+
+
+
+
+Hardt                        Standards Track                   [Page 10]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   authorization information.  Unlike access tokens, refresh tokens are
+   intended for use only with authorization servers and are never sent
+   to resource servers.
+
+  +--------+                                           +---------------+
+  |        |--(A)------- Authorization Grant --------->|               |
+  |        |                                           |               |
+  |        |<-(B)----------- Access Token -------------|               |
+  |        |               & Refresh Token             |               |
+  |        |                                           |               |
+  |        |                            +----------+   |               |
+  |        |--(C)---- Access Token ---->|          |   |               |
+  |        |                            |          |   |               |
+  |        |<-(D)- Protected Resource --| Resource |   | Authorization |
+  | Client |                            |  Server  |   |     Server    |
+  |        |--(E)---- Access Token ---->|          |   |               |
+  |        |                            |          |   |               |
+  |        |<-(F)- Invalid Token Error -|          |   |               |
+  |        |                            +----------+   |               |
+  |        |                                           |               |
+  |        |--(G)----------- Refresh Token ----------->|               |
+  |        |                                           |               |
+  |        |<-(H)----------- Access Token -------------|               |
+  +--------+           & Optional Refresh Token        +---------------+
+
+               Figure 2: Refreshing an Expired Access Token
+
+   The flow illustrated in Figure 2 includes the following steps:
+
+   (A)  The client requests an access token by authenticating with the
+        authorization server and presenting an authorization grant.
+
+   (B)  The authorization server authenticates the client and validates
+        the authorization grant, and if valid, issues an access token
+        and a refresh token.
+
+   (C)  The client makes a protected resource request to the resource
+        server by presenting the access token.
+
+   (D)  The resource server validates the access token, and if valid,
+        serves the request.
+
+   (E)  Steps (C) and (D) repeat until the access token expires.  If the
+        client knows the access token expired, it skips to step (G);
+        otherwise, it makes another protected resource request.
+
+   (F)  Since the access token is invalid, the resource server returns
+        an invalid token error.
+
+
+
+Hardt                        Standards Track                   [Page 11]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   (G)  The client requests a new access token by authenticating with
+        the authorization server and presenting the refresh token.  The
+        client authentication requirements are based on the client type
+        and on the authorization server policies.
+
+   (H)  The authorization server authenticates the client and validates
+        the refresh token, and if valid, issues a new access token (and,
+        optionally, a new refresh token).
+
+   Steps (C), (D), (E), and (F) are outside the scope of this
+   specification, as described in Section 7.
+
+1.6.  TLS Version
+
+   Whenever Transport Layer Security (TLS) is used by this
+   specification, the appropriate version (or versions) of TLS will vary
+   over time, based on the widespread deployment and known security
+   vulnerabilities.  At the time of this writing, TLS version 1.2
+   [RFC5246] is the most recent version, but has a very limited
+   deployment base and might not be readily available for
+   implementation.  TLS version 1.0 [RFC2246] is the most widely
+   deployed version and will provide the broadest interoperability.
+
+   Implementations MAY also support additional transport-layer security
+   mechanisms that meet their security requirements.
+
+1.7.  HTTP Redirections
+
+   This specification makes extensive use of HTTP redirections, in which
+   the client or the authorization server directs the resource owner's
+   user-agent to another destination.  While the examples in this
+   specification show the use of the HTTP 302 status code, any other
+   method available via the user-agent to accomplish this redirection is
+   allowed and is considered to be an implementation detail.
+
+1.8.  Interoperability
+
+   OAuth 2.0 provides a rich authorization framework with well-defined
+   security properties.  However, as a rich and highly extensible
+   framework with many optional components, on its own, this
+   specification is likely to produce a wide range of non-interoperable
+   implementations.
+
+   In addition, this specification leaves a few required components
+   partially or fully undefined (e.g., client registration,
+   authorization server capabilities, endpoint discovery).  Without
+
+
+
+
+
+Hardt                        Standards Track                   [Page 12]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   these components, clients must be manually and specifically
+   configured against a specific authorization server and resource
+   server in order to interoperate.
+
+   This framework was designed with the clear expectation that future
+   work will define prescriptive profiles and extensions necessary to
+   achieve full web-scale interoperability.
+
+1.9.  Notational Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   specification are to be interpreted as described in [RFC2119].
+
+   This specification uses the Augmented Backus-Naur Form (ABNF)
+   notation of [RFC5234].  Additionally, the rule URI-reference is
+   included from "Uniform Resource Identifier (URI): Generic Syntax"
+   [RFC3986].
+
+   Certain security-related terms are to be understood in the sense
+   defined in [RFC4949].  These terms include, but are not limited to,
+   "attack", "authentication", "authorization", "certificate",
+   "confidentiality", "credential", "encryption", "identity", "sign",
+   "signature", "trust", "validate", and "verify".
+
+   Unless otherwise noted, all the protocol parameter names and values
+   are case sensitive.
+
+2.  Client Registration
+
+   Before initiating the protocol, the client registers with the
+   authorization server.  The means through which the client registers
+   with the authorization server are beyond the scope of this
+   specification but typically involve end-user interaction with an HTML
+   registration form.
+
+   Client registration does not require a direct interaction between the
+   client and the authorization server.  When supported by the
+   authorization server, registration can rely on other means for
+   establishing trust and obtaining the required client properties
+   (e.g., redirection URI, client type).  For example, registration can
+   be accomplished using a self-issued or third-party-issued assertion,
+   or by the authorization server performing client discovery using a
+   trusted channel.
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 13]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   When registering a client, the client developer SHALL:
+
+   o  specify the client type as described in Section 2.1,
+
+   o  provide its client redirection URIs as described in Section 3.1.2,
+      and
+
+   o  include any other information required by the authorization server
+      (e.g., application name, website, description, logo image, the
+      acceptance of legal terms).
+
+2.1.  Client Types
+
+   OAuth defines two client types, based on their ability to
+   authenticate securely with the authorization server (i.e., ability to
+   maintain the confidentiality of their client credentials):
+
+   confidential
+      Clients capable of maintaining the confidentiality of their
+      credentials (e.g., client implemented on a secure server with
+      restricted access to the client credentials), or capable of secure
+      client authentication using other means.
+
+   public
+      Clients incapable of maintaining the confidentiality of their
+      credentials (e.g., clients executing on the device used by the
+      resource owner, such as an installed native application or a web
+      browser-based application), and incapable of secure client
+      authentication via any other means.
+
+   The client type designation is based on the authorization server's
+   definition of secure authentication and its acceptable exposure
+   levels of client credentials.  The authorization server SHOULD NOT
+   make assumptions about the client type.
+
+   A client may be implemented as a distributed set of components, each
+   with a different client type and security context (e.g., a
+   distributed client with both a confidential server-based component
+   and a public browser-based component).  If the authorization server
+   does not provide support for such clients or does not provide
+   guidance with regard to their registration, the client SHOULD
+   register each component as a separate client.
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 14]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   This specification has been designed around the following client
+   profiles:
+
+   web application
+      A web application is a confidential client running on a web
+      server.  Resource owners access the client via an HTML user
+      interface rendered in a user-agent on the device used by the
+      resource owner.  The client credentials as well as any access
+      token issued to the client are stored on the web server and are
+      not exposed to or accessible by the resource owner.
+
+   user-agent-based application
+      A user-agent-based application is a public client in which the
+      client code is downloaded from a web server and executes within a
+      user-agent (e.g., web browser) on the device used by the resource
+      owner.  Protocol data and credentials are easily accessible (and
+      often visible) to the resource owner.  Since such applications
+      reside within the user-agent, they can make seamless use of the
+      user-agent capabilities when requesting authorization.
+
+   native application
+      A native application is a public client installed and executed on
+      the device used by the resource owner.  Protocol data and
+      credentials are accessible to the resource owner.  It is assumed
+      that any client authentication credentials included in the
+      application can be extracted.  On the other hand, dynamically
+      issued credentials such as access tokens or refresh tokens can
+      receive an acceptable level of protection.  At a minimum, these
+      credentials are protected from hostile servers with which the
+      application may interact.  On some platforms, these credentials
+      might be protected from other applications residing on the same
+      device.
+
+2.2.  Client Identifier
+
+   The authorization server issues the registered client a client
+   identifier -- a unique string representing the registration
+   information provided by the client.  The client identifier is not a
+   secret; it is exposed to the resource owner and MUST NOT be used
+   alone for client authentication.  The client identifier is unique to
+   the authorization server.
+
+   The client identifier string size is left undefined by this
+   specification.  The client should avoid making assumptions about the
+   identifier size.  The authorization server SHOULD document the size
+   of any identifier it issues.
+
+
+
+
+
+Hardt                        Standards Track                   [Page 15]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+2.3.  Client Authentication
+
+   If the client type is confidential, the client and authorization
+   server establish a client authentication method suitable for the
+   security requirements of the authorization server.  The authorization
+   server MAY accept any form of client authentication meeting its
+   security requirements.
+
+   Confidential clients are typically issued (or establish) a set of
+   client credentials used for authenticating with the authorization
+   server (e.g., password, public/private key pair).
+
+   The authorization server MAY establish a client authentication method
+   with public clients.  However, the authorization server MUST NOT rely
+   on public client authentication for the purpose of identifying the
+   client.
+
+   The client MUST NOT use more than one authentication method in each
+   request.
+
+2.3.1.  Client Password
+
+   Clients in possession of a client password MAY use the HTTP Basic
+   authentication scheme as defined in [RFC2617] to authenticate with
+   the authorization server.  The client identifier is encoded using the
+   "application/x-www-form-urlencoded" encoding algorithm per
+   Appendix B, and the encoded value is used as the username; the client
+   password is encoded using the same algorithm and used as the
+   password.  The authorization server MUST support the HTTP Basic
+   authentication scheme for authenticating clients that were issued a
+   client password.
+
+   For example (with extra line breaks for display purposes only):
+
+     Authorization: Basic czZCaGRSa3F0Mzo3RmpmcDBaQnIxS3REUmJuZlZkbUl3
+
+   Alternatively, the authorization server MAY support including the
+   client credentials in the request-body using the following
+   parameters:
+
+   client_id
+         REQUIRED.  The client identifier issued to the client during
+         the registration process described by Section 2.2.
+
+   client_secret
+         REQUIRED.  The client secret.  The client MAY omit the
+         parameter if the client secret is an empty string.
+
+
+
+
+Hardt                        Standards Track                   [Page 16]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   Including the client credentials in the request-body using the two
+   parameters is NOT RECOMMENDED and SHOULD be limited to clients unable
+   to directly utilize the HTTP Basic authentication scheme (or other
+   password-based HTTP authentication schemes).  The parameters can only
+   be transmitted in the request-body and MUST NOT be included in the
+   request URI.
+
+   For example, a request to refresh an access token (Section 6) using
+   the body parameters (with extra line breaks for display purposes
+   only):
+
+     POST /token HTTP/1.1
+     Host: server.example.com
+     Content-Type: application/x-www-form-urlencoded
+
+     grant_type=refresh_token&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA
+     &client_id=s6BhdRkqt3&client_secret=7Fjfp0ZBr1KtDRbnfVdmIw
+
+   The authorization server MUST require the use of TLS as described in
+   Section 1.6 when sending requests using password authentication.
+
+   Since this client authentication method involves a password, the
+   authorization server MUST protect any endpoint utilizing it against
+   brute force attacks.
+
+2.3.2.  Other Authentication Methods
+
+   The authorization server MAY support any suitable HTTP authentication
+   scheme matching its security requirements.  When using other
+   authentication methods, the authorization server MUST define a
+   mapping between the client identifier (registration record) and
+   authentication scheme.
+
+2.4.  Unregistered Clients
+
+   This specification does not exclude the use of unregistered clients.
+   However, the use of such clients is beyond the scope of this
+   specification and requires additional security analysis and review of
+   its interoperability impact.
+
+
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 17]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+3.  Protocol Endpoints
+
+   The authorization process utilizes two authorization server endpoints
+   (HTTP resources):
+
+   o  Authorization endpoint - used by the client to obtain
+      authorization from the resource owner via user-agent redirection.
+
+   o  Token endpoint - used by the client to exchange an authorization
+      grant for an access token, typically with client authentication.
+
+   As well as one client endpoint:
+
+   o  Redirection endpoint - used by the authorization server to return
+      responses containing authorization credentials to the client via
+      the resource owner user-agent.
+
+   Not every authorization grant type utilizes both endpoints.
+   Extension grant types MAY define additional endpoints as needed.
+
+3.1.  Authorization Endpoint
+
+   The authorization endpoint is used to interact with the resource
+   owner and obtain an authorization grant.  The authorization server
+   MUST first verify the identity of the resource owner.  The way in
+   which the authorization server authenticates the resource owner
+   (e.g., username and password login, session cookies) is beyond the
+   scope of this specification.
+
+   The means through which the client obtains the location of the
+   authorization endpoint are beyond the scope of this specification,
+   but the location is typically provided in the service documentation.
+
+   The endpoint URI MAY include an "application/x-www-form-urlencoded"
+   formatted (per Appendix B) query component ([RFC3986] Section 3.4),
+   which MUST be retained when adding additional query parameters.  The
+   endpoint URI MUST NOT include a fragment component.
+
+   Since requests to the authorization endpoint result in user
+   authentication and the transmission of clear-text credentials (in the
+   HTTP response), the authorization server MUST require the use of TLS
+   as described in Section 1.6 when sending requests to the
+   authorization endpoint.
+
+   The authorization server MUST support the use of the HTTP "GET"
+   method [RFC2616] for the authorization endpoint and MAY support the
+   use of the "POST" method as well.
+
+
+
+
+Hardt                        Standards Track                   [Page 18]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   Parameters sent without a value MUST be treated as if they were
+   omitted from the request.  The authorization server MUST ignore
+   unrecognized request parameters.  Request and response parameters
+   MUST NOT be included more than once.
+
+3.1.1.  Response Type
+
+   The authorization endpoint is used by the authorization code grant
+   type and implicit grant type flows.  The client informs the
+   authorization server of the desired grant type using the following
+   parameter:
+
+   response_type
+         REQUIRED.  The value MUST be one of "code" for requesting an
+         authorization code as described by Section 4.1.1, "token" for
+         requesting an access token (implicit grant) as described by
+         Section 4.2.1, or a registered extension value as described by
+         Section 8.4.
+
+   Extension response types MAY contain a space-delimited (%x20) list of
+   values, where the order of values does not matter (e.g., response
+   type "a b" is the same as "b a").  The meaning of such composite
+   response types is defined by their respective specifications.
+
+   If an authorization request is missing the "response_type" parameter,
+   or if the response type is not understood, the authorization server
+   MUST return an error response as described in Section 4.1.2.1.
+
+3.1.2.  Redirection Endpoint
+
+   After completing its interaction with the resource owner, the
+   authorization server directs the resource owner's user-agent back to
+   the client.  The authorization server redirects the user-agent to the
+   client's redirection endpoint previously established with the
+   authorization server during the client registration process or when
+   making the authorization request.
+
+   The redirection endpoint URI MUST be an absolute URI as defined by
+   [RFC3986] Section 4.3.  The endpoint URI MAY include an
+   "application/x-www-form-urlencoded" formatted (per Appendix B) query
+   component ([RFC3986] Section 3.4), which MUST be retained when adding
+   additional query parameters.  The endpoint URI MUST NOT include a
+   fragment component.
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 19]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+3.1.2.1.  Endpoint Request Confidentiality
+
+   The redirection endpoint SHOULD require the use of TLS as described
+   in Section 1.6 when the requested response type is "code" or "token",
+   or when the redirection request will result in the transmission of
+   sensitive credentials over an open network.  This specification does
+   not mandate the use of TLS because at the time of this writing,
+   requiring clients to deploy TLS is a significant hurdle for many
+   client developers.  If TLS is not available, the authorization server
+   SHOULD warn the resource owner about the insecure endpoint prior to
+   redirection (e.g., display a message during the authorization
+   request).
+
+   Lack of transport-layer security can have a severe impact on the
+   security of the client and the protected resources it is authorized
+   to access.  The use of transport-layer security is particularly
+   critical when the authorization process is used as a form of
+   delegated end-user authentication by the client (e.g., third-party
+   sign-in service).
+
+3.1.2.2.  Registration Requirements
+
+   The authorization server MUST require the following clients to
+   register their redirection endpoint:
+
+   o  Public clients.
+
+   o  Confidential clients utilizing the implicit grant type.
+
+   The authorization server SHOULD require all clients to register their
+   redirection endpoint prior to utilizing the authorization endpoint.
+
+   The authorization server SHOULD require the client to provide the
+   complete redirection URI (the client MAY use the "state" request
+   parameter to achieve per-request customization).  If requiring the
+   registration of the complete redirection URI is not possible, the
+   authorization server SHOULD require the registration of the URI
+   scheme, authority, and path (allowing the client to dynamically vary
+   only the query component of the redirection URI when requesting
+   authorization).
+
+   The authorization server MAY allow the client to register multiple
+   redirection endpoints.
+
+   Lack of a redirection URI registration requirement can enable an
+   attacker to use the authorization endpoint as an open redirector as
+   described in Section 10.15.
+
+
+
+
+Hardt                        Standards Track                   [Page 20]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+3.1.2.3.  Dynamic Configuration
+
+   If multiple redirection URIs have been registered, if only part of
+   the redirection URI has been registered, or if no redirection URI has
+   been registered, the client MUST include a redirection URI with the
+   authorization request using the "redirect_uri" request parameter.
+
+   When a redirection URI is included in an authorization request, the
+   authorization server MUST compare and match the value received
+   against at least one of the registered redirection URIs (or URI
+   components) as defined in [RFC3986] Section 6, if any redirection
+   URIs were registered.  If the client registration included the full
+   redirection URI, the authorization server MUST compare the two URIs
+   using simple string comparison as defined in [RFC3986] Section 6.2.1.
+
+3.1.2.4.  Invalid Endpoint
+
+   If an authorization request fails validation due to a missing,
+   invalid, or mismatching redirection URI, the authorization server
+   SHOULD inform the resource owner of the error and MUST NOT
+   automatically redirect the user-agent to the invalid redirection URI.
+
+3.1.2.5.  Endpoint Content
+
+   The redirection request to the client's endpoint typically results in
+   an HTML document response, processed by the user-agent.  If the HTML
+   response is served directly as the result of the redirection request,
+   any script included in the HTML document will execute with full
+   access to the redirection URI and the credentials it contains.
+
+   The client SHOULD NOT include any third-party scripts (e.g., third-
+   party analytics, social plug-ins, ad networks) in the redirection
+   endpoint response.  Instead, it SHOULD extract the credentials from
+   the URI and redirect the user-agent again to another endpoint without
+   exposing the credentials (in the URI or elsewhere).  If third-party
+   scripts are included, the client MUST ensure that its own scripts
+   (used to extract and remove the credentials from the URI) will
+   execute first.
+
+3.2.  Token Endpoint
+
+   The token endpoint is used by the client to obtain an access token by
+   presenting its authorization grant or refresh token.  The token
+   endpoint is used with every authorization grant except for the
+   implicit grant type (since an access token is issued directly).
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 21]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   The means through which the client obtains the location of the token
+   endpoint are beyond the scope of this specification, but the location
+   is typically provided in the service documentation.
+
+   The endpoint URI MAY include an "application/x-www-form-urlencoded"
+   formatted (per Appendix B) query component ([RFC3986] Section 3.4),
+   which MUST be retained when adding additional query parameters.  The
+   endpoint URI MUST NOT include a fragment component.
+
+   Since requests to the token endpoint result in the transmission of
+   clear-text credentials (in the HTTP request and response), the
+   authorization server MUST require the use of TLS as described in
+   Section 1.6 when sending requests to the token endpoint.
+
+   The client MUST use the HTTP "POST" method when making access token
+   requests.
+
+   Parameters sent without a value MUST be treated as if they were
+   omitted from the request.  The authorization server MUST ignore
+   unrecognized request parameters.  Request and response parameters
+   MUST NOT be included more than once.
+
+3.2.1.  Client Authentication
+
+   Confidential clients or other clients issued client credentials MUST
+   authenticate with the authorization server as described in
+   Section 2.3 when making requests to the token endpoint.  Client
+   authentication is used for:
+
+   o  Enforcing the binding of refresh tokens and authorization codes to
+      the client they were issued to.  Client authentication is critical
+      when an authorization code is transmitted to the redirection
+      endpoint over an insecure channel or when the redirection URI has
+      not been registered in full.
+
+   o  Recovering from a compromised client by disabling the client or
+      changing its credentials, thus preventing an attacker from abusing
+      stolen refresh tokens.  Changing a single set of client
+      credentials is significantly faster than revoking an entire set of
+      refresh tokens.
+
+   o  Implementing authentication management best practices, which
+      require periodic credential rotation.  Rotation of an entire set
+      of refresh tokens can be challenging, while rotation of a single
+      set of client credentials is significantly easier.
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 22]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   A client MAY use the "client_id" request parameter to identify itself
+   when sending requests to the token endpoint.  In the
+   "authorization_code" "grant_type" request to the token endpoint, an
+   unauthenticated client MUST send its "client_id" to prevent itself
+   from inadvertently accepting a code intended for a client with a
+   different "client_id".  This protects the client from substitution of
+   the authentication code.  (It provides no additional security for the
+   protected resource.)
+
+3.3.  Access Token Scope
+
+   The authorization and token endpoints allow the client to specify the
+   scope of the access request using the "scope" request parameter.  In
+   turn, the authorization server uses the "scope" response parameter to
+   inform the client of the scope of the access token issued.
+
+   The value of the scope parameter is expressed as a list of space-
+   delimited, case-sensitive strings.  The strings are defined by the
+   authorization server.  If the value contains multiple space-delimited
+   strings, their order does not matter, and each string adds an
+   additional access range to the requested scope.
+
+     scope       = scope-token *( SP scope-token )
+     scope-token = 1*( %x21 / %x23-5B / %x5D-7E )
+
+   The authorization server MAY fully or partially ignore the scope
+   requested by the client, based on the authorization server policy or
+   the resource owner's instructions.  If the issued access token scope
+   is different from the one requested by the client, the authorization
+   server MUST include the "scope" response parameter to inform the
+   client of the actual scope granted.
+
+   If the client omits the scope parameter when requesting
+   authorization, the authorization server MUST either process the
+   request using a pre-defined default value or fail the request
+   indicating an invalid scope.  The authorization server SHOULD
+   document its scope requirements and default value (if defined).
+
+4.  Obtaining Authorization
+
+   To request an access token, the client obtains authorization from the
+   resource owner.  The authorization is expressed in the form of an
+   authorization grant, which the client uses to request the access
+   token.  OAuth defines four grant types: authorization code, implicit,
+   resource owner password credentials, and client credentials.  It also
+   provides an extension mechanism for defining additional grant types.
+
+
+
+
+
+Hardt                        Standards Track                   [Page 23]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+4.1.  Authorization Code Grant
+
+   The authorization code grant type is used to obtain both access
+   tokens and refresh tokens and is optimized for confidential clients.
+   Since this is a redirection-based flow, the client must be capable of
+   interacting with the resource owner's user-agent (typically a web
+   browser) and capable of receiving incoming requests (via redirection)
+   from the authorization server.
+
+     +----------+
+     | Resource |
+     |   Owner  |
+     |          |
+     +----------+
+          ^
+          |
+         (B)
+     +----|-----+          Client Identifier      +---------------+
+     |         -+----(A)-- & Redirection URI ---->|               |
+     |  User-   |                                 | Authorization |
+     |  Agent  -+----(B)-- User authenticates --->|     Server    |
+     |          |                                 |               |
+     |         -+----(C)-- Authorization Code ---<|               |
+     +-|----|---+                                 +---------------+
+       |    |                                         ^      v
+      (A)  (C)                                        |      |
+       |    |                                         |      |
+       ^    v                                         |      |
+     +---------+                                      |      |
+     |         |>---(D)-- Authorization Code ---------'      |
+     |  Client |          & Redirection URI                  |
+     |         |                                             |
+     |         |<---(E)----- Access Token -------------------'
+     +---------+       (w/ Optional Refresh Token)
+
+   Note: The lines illustrating steps (A), (B), and (C) are broken into
+   two parts as they pass through the user-agent.
+
+                     Figure 3: Authorization Code Flow
+
+
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 24]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   The flow illustrated in Figure 3 includes the following steps:
+
+   (A)  The client initiates the flow by directing the resource owner's
+        user-agent to the authorization endpoint.  The client includes
+        its client identifier, requested scope, local state, and a
+        redirection URI to which the authorization server will send the
+        user-agent back once access is granted (or denied).
+
+   (B)  The authorization server authenticates the resource owner (via
+        the user-agent) and establishes whether the resource owner
+        grants or denies the client's access request.
+
+   (C)  Assuming the resource owner grants access, the authorization
+        server redirects the user-agent back to the client using the
+        redirection URI provided earlier (in the request or during
+        client registration).  The redirection URI includes an
+        authorization code and any local state provided by the client
+        earlier.
+
+   (D)  The client requests an access token from the authorization
+        server's token endpoint by including the authorization code
+        received in the previous step.  When making the request, the
+        client authenticates with the authorization server.  The client
+        includes the redirection URI used to obtain the authorization
+        code for verification.
+
+   (E)  The authorization server authenticates the client, validates the
+        authorization code, and ensures that the redirection URI
+        received matches the URI used to redirect the client in
+        step (C).  If valid, the authorization server responds back with
+        an access token and, optionally, a refresh token.
+
+4.1.1.  Authorization Request
+
+   The client constructs the request URI by adding the following
+   parameters to the query component of the authorization endpoint URI
+   using the "application/x-www-form-urlencoded" format, per Appendix B:
+
+   response_type
+         REQUIRED.  Value MUST be set to "code".
+
+   client_id
+         REQUIRED.  The client identifier as described in Section 2.2.
+
+   redirect_uri
+         OPTIONAL.  As described in Section 3.1.2.
+
+
+
+
+
+Hardt                        Standards Track                   [Page 25]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   scope
+         OPTIONAL.  The scope of the access request as described by
+         Section 3.3.
+
+   state
+         RECOMMENDED.  An opaque value used by the client to maintain
+         state between the request and callback.  The authorization
+         server includes this value when redirecting the user-agent back
+         to the client.  The parameter SHOULD be used for preventing
+         cross-site request forgery as described in Section 10.12.
+
+   The client directs the resource owner to the constructed URI using an
+   HTTP redirection response, or by other means available to it via the
+   user-agent.
+
+   For example, the client directs the user-agent to make the following
+   HTTP request using TLS (with extra line breaks for display purposes
+   only):
+
+    GET /authorize?response_type=code&client_id=s6BhdRkqt3&state=xyz
+        &redirect_uri=https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb HTTP/1.1
+    Host: server.example.com
+
+   The authorization server validates the request to ensure that all
+   required parameters are present and valid.  If the request is valid,
+   the authorization server authenticates the resource owner and obtains
+   an authorization decision (by asking the resource owner or by
+   establishing approval via other means).
+
+   When a decision is established, the authorization server directs the
+   user-agent to the provided client redirection URI using an HTTP
+   redirection response, or by other means available to it via the
+   user-agent.
+
+4.1.2.  Authorization Response
+
+   If the resource owner grants the access request, the authorization
+   server issues an authorization code and delivers it to the client by
+   adding the following parameters to the query component of the
+   redirection URI using the "application/x-www-form-urlencoded" format,
+   per Appendix B:
+
+   code
+         REQUIRED.  The authorization code generated by the
+         authorization server.  The authorization code MUST expire
+         shortly after it is issued to mitigate the risk of leaks.  A
+         maximum authorization code lifetime of 10 minutes is
+         RECOMMENDED.  The client MUST NOT use the authorization code
+
+
+
+Hardt                        Standards Track                   [Page 26]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+         more than once.  If an authorization code is used more than
+         once, the authorization server MUST deny the request and SHOULD
+         revoke (when possible) all tokens previously issued based on
+         that authorization code.  The authorization code is bound to
+         the client identifier and redirection URI.
+
+   state
+         REQUIRED if the "state" parameter was present in the client
+         authorization request.  The exact value received from the
+         client.
+
+   For example, the authorization server redirects the user-agent by
+   sending the following HTTP response:
+
+     HTTP/1.1 302 Found
+     Location: https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA
+               &state=xyz
+
+   The client MUST ignore unrecognized response parameters.  The
+   authorization code string size is left undefined by this
+   specification.  The client should avoid making assumptions about code
+   value sizes.  The authorization server SHOULD document the size of
+   any value it issues.
+
+4.1.2.1.  Error Response
+
+   If the request fails due to a missing, invalid, or mismatching
+   redirection URI, or if the client identifier is missing or invalid,
+   the authorization server SHOULD inform the resource owner of the
+   error and MUST NOT automatically redirect the user-agent to the
+   invalid redirection URI.
+
+   If the resource owner denies the access request or if the request
+   fails for reasons other than a missing or invalid redirection URI,
+   the authorization server informs the client by adding the following
+   parameters to the query component of the redirection URI using the
+   "application/x-www-form-urlencoded" format, per Appendix B:
+
+   error
+         REQUIRED.  A single ASCII [USASCII] error code from the
+         following:
+
+         invalid_request
+               The request is missing a required parameter, includes an
+               invalid parameter value, includes a parameter more than
+               once, or is otherwise malformed.
+
+
+
+
+
+Hardt                        Standards Track                   [Page 27]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+         unauthorized_client
+               The client is not authorized to request an authorization
+               code using this method.
+
+         access_denied
+               The resource owner or authorization server denied the
+               request.
+
+         unsupported_response_type
+               The authorization server does not support obtaining an
+               authorization code using this method.
+
+         invalid_scope
+               The requested scope is invalid, unknown, or malformed.
+
+         server_error
+               The authorization server encountered an unexpected
+               condition that prevented it from fulfilling the request.
+               (This error code is needed because a 500 Internal Server
+               Error HTTP status code cannot be returned to the client
+               via an HTTP redirect.)
+
+         temporarily_unavailable
+               The authorization server is currently unable to handle
+               the request due to a temporary overloading or maintenance
+               of the server.  (This error code is needed because a 503
+               Service Unavailable HTTP status code cannot be returned
+               to the client via an HTTP redirect.)
+
+         Values for the "error" parameter MUST NOT include characters
+         outside the set %x20-21 / %x23-5B / %x5D-7E.
+
+   error_description
+         OPTIONAL.  Human-readable ASCII [USASCII] text providing
+         additional information, used to assist the client developer in
+         understanding the error that occurred.
+         Values for the "error_description" parameter MUST NOT include
+         characters outside the set %x20-21 / %x23-5B / %x5D-7E.
+
+   error_uri
+         OPTIONAL.  A URI identifying a human-readable web page with
+         information about the error, used to provide the client
+         developer with additional information about the error.
+         Values for the "error_uri" parameter MUST conform to the
+         URI-reference syntax and thus MUST NOT include characters
+         outside the set %x21 / %x23-5B / %x5D-7E.
+
+
+
+
+
+Hardt                        Standards Track                   [Page 28]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   state
+         REQUIRED if a "state" parameter was present in the client
+         authorization request.  The exact value received from the
+         client.
+
+   For example, the authorization server redirects the user-agent by
+   sending the following HTTP response:
+
+   HTTP/1.1 302 Found
+   Location: https://client.example.com/cb?error=access_denied&state=xyz
+
+4.1.3.  Access Token Request
+
+   The client makes a request to the token endpoint by sending the
+   following parameters using the "application/x-www-form-urlencoded"
+   format per Appendix B with a character encoding of UTF-8 in the HTTP
+   request entity-body:
+
+   grant_type
+         REQUIRED.  Value MUST be set to "authorization_code".
+
+   code
+         REQUIRED.  The authorization code received from the
+         authorization server.
+
+   redirect_uri
+         REQUIRED, if the "redirect_uri" parameter was included in the
+         authorization request as described in Section 4.1.1, and their
+         values MUST be identical.
+
+   client_id
+         REQUIRED, if the client is not authenticating with the
+         authorization server as described in Section 3.2.1.
+
+   If the client type is confidential or the client was issued client
+   credentials (or assigned other authentication requirements), the
+   client MUST authenticate with the authorization server as described
+   in Section 3.2.1.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 29]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   For example, the client makes the following HTTP request using TLS
+   (with extra line breaks for display purposes only):
+
+     POST /token HTTP/1.1
+     Host: server.example.com
+     Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW
+     Content-Type: application/x-www-form-urlencoded
+
+     grant_type=authorization_code&code=SplxlOBeZQQYbYS6WxSbIA
+     &redirect_uri=https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb
+
+   The authorization server MUST:
+
+   o  require client authentication for confidential clients or for any
+      client that was issued client credentials (or with other
+      authentication requirements),
+
+   o  authenticate the client if client authentication is included,
+
+   o  ensure that the authorization code was issued to the authenticated
+      confidential client, or if the client is public, ensure that the
+      code was issued to "client_id" in the request,
+
+   o  verify that the authorization code is valid, and
+
+   o  ensure that the "redirect_uri" parameter is present if the
+      "redirect_uri" parameter was included in the initial authorization
+      request as described in Section 4.1.1, and if included ensure that
+      their values are identical.
+
+4.1.4.  Access Token Response
+
+   If the access token request is valid and authorized, the
+   authorization server issues an access token and optional refresh
+   token as described in Section 5.1.  If the request client
+   authentication failed or is invalid, the authorization server returns
+   an error response as described in Section 5.2.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 30]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   An example successful response:
+
+     HTTP/1.1 200 OK
+     Content-Type: application/json;charset=UTF-8
+     Cache-Control: no-store
+     Pragma: no-cache
+
+     {
+       "access_token":"2YotnFZFEjr1zCsicMWpAA",
+       "token_type":"example",
+       "expires_in":3600,
+       "refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA",
+       "example_parameter":"example_value"
+     }
+
+4.2.  Implicit Grant
+
+   The implicit grant type is used to obtain access tokens (it does not
+   support the issuance of refresh tokens) and is optimized for public
+   clients known to operate a particular redirection URI.  These clients
+   are typically implemented in a browser using a scripting language
+   such as JavaScript.
+
+   Since this is a redirection-based flow, the client must be capable of
+   interacting with the resource owner's user-agent (typically a web
+   browser) and capable of receiving incoming requests (via redirection)
+   from the authorization server.
+
+   Unlike the authorization code grant type, in which the client makes
+   separate requests for authorization and for an access token, the
+   client receives the access token as the result of the authorization
+   request.
+
+   The implicit grant type does not include client authentication, and
+   relies on the presence of the resource owner and the registration of
+   the redirection URI.  Because the access token is encoded into the
+   redirection URI, it may be exposed to the resource owner and other
+   applications residing on the same device.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 31]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+     +----------+
+     | Resource |
+     |  Owner   |
+     |          |
+     +----------+
+          ^
+          |
+         (B)
+     +----|-----+          Client Identifier     +---------------+
+     |         -+----(A)-- & Redirection URI --->|               |
+     |  User-   |                                | Authorization |
+     |  Agent  -|----(B)-- User authenticates -->|     Server    |
+     |          |                                |               |
+     |          |<---(C)--- Redirection URI ----<|               |
+     |          |          with Access Token     +---------------+
+     |          |            in Fragment
+     |          |                                +---------------+
+     |          |----(D)--- Redirection URI ---->|   Web-Hosted  |
+     |          |          without Fragment      |     Client    |
+     |          |                                |    Resource   |
+     |     (F)  |<---(E)------- Script ---------<|               |
+     |          |                                +---------------+
+     +-|--------+
+       |    |
+      (A)  (G) Access Token
+       |    |
+       ^    v
+     +---------+
+     |         |
+     |  Client |
+     |         |
+     +---------+
+
+   Note: The lines illustrating steps (A) and (B) are broken into two
+   parts as they pass through the user-agent.
+
+                       Figure 4: Implicit Grant Flow
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 32]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   The flow illustrated in Figure 4 includes the following steps:
+
+   (A)  The client initiates the flow by directing the resource owner's
+        user-agent to the authorization endpoint.  The client includes
+        its client identifier, requested scope, local state, and a
+        redirection URI to which the authorization server will send the
+        user-agent back once access is granted (or denied).
+
+   (B)  The authorization server authenticates the resource owner (via
+        the user-agent) and establishes whether the resource owner
+        grants or denies the client's access request.
+
+   (C)  Assuming the resource owner grants access, the authorization
+        server redirects the user-agent back to the client using the
+        redirection URI provided earlier.  The redirection URI includes
+        the access token in the URI fragment.
+
+   (D)  The user-agent follows the redirection instructions by making a
+        request to the web-hosted client resource (which does not
+        include the fragment per [RFC2616]).  The user-agent retains the
+        fragment information locally.
+
+   (E)  The web-hosted client resource returns a web page (typically an
+        HTML document with an embedded script) capable of accessing the
+        full redirection URI including the fragment retained by the
+        user-agent, and extracting the access token (and other
+        parameters) contained in the fragment.
+
+   (F)  The user-agent executes the script provided by the web-hosted
+        client resource locally, which extracts the access token.
+
+   (G)  The user-agent passes the access token to the client.
+
+   See Sections 1.3.2 and 9 for background on using the implicit grant.
+   See Sections 10.3 and 10.16 for important security considerations
+   when using the implicit grant.
+
+4.2.1.  Authorization Request
+
+   The client constructs the request URI by adding the following
+   parameters to the query component of the authorization endpoint URI
+   using the "application/x-www-form-urlencoded" format, per Appendix B:
+
+   response_type
+         REQUIRED.  Value MUST be set to "token".
+
+   client_id
+         REQUIRED.  The client identifier as described in Section 2.2.
+
+
+
+Hardt                        Standards Track                   [Page 33]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   redirect_uri
+         OPTIONAL.  As described in Section 3.1.2.
+
+   scope
+         OPTIONAL.  The scope of the access request as described by
+         Section 3.3.
+
+   state
+         RECOMMENDED.  An opaque value used by the client to maintain
+         state between the request and callback.  The authorization
+         server includes this value when redirecting the user-agent back
+         to the client.  The parameter SHOULD be used for preventing
+         cross-site request forgery as described in Section 10.12.
+
+   The client directs the resource owner to the constructed URI using an
+   HTTP redirection response, or by other means available to it via the
+   user-agent.
+
+   For example, the client directs the user-agent to make the following
+   HTTP request using TLS (with extra line breaks for display purposes
+   only):
+
+    GET /authorize?response_type=token&client_id=s6BhdRkqt3&state=xyz
+        &redirect_uri=https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb HTTP/1.1
+    Host: server.example.com
+
+   The authorization server validates the request to ensure that all
+   required parameters are present and valid.  The authorization server
+   MUST verify that the redirection URI to which it will redirect the
+   access token matches a redirection URI registered by the client as
+   described in Section 3.1.2.
+
+   If the request is valid, the authorization server authenticates the
+   resource owner and obtains an authorization decision (by asking the
+   resource owner or by establishing approval via other means).
+
+   When a decision is established, the authorization server directs the
+   user-agent to the provided client redirection URI using an HTTP
+   redirection response, or by other means available to it via the
+   user-agent.
+
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 34]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+4.2.2.  Access Token Response
+
+   If the resource owner grants the access request, the authorization
+   server issues an access token and delivers it to the client by adding
+   the following parameters to the fragment component of the redirection
+   URI using the "application/x-www-form-urlencoded" format, per
+   Appendix B:
+
+   access_token
+         REQUIRED.  The access token issued by the authorization server.
+
+   token_type
+         REQUIRED.  The type of the token issued as described in
+         Section 7.1.  Value is case insensitive.
+
+   expires_in
+         RECOMMENDED.  The lifetime in seconds of the access token.  For
+         example, the value "3600" denotes that the access token will
+         expire in one hour from the time the response was generated.
+         If omitted, the authorization server SHOULD provide the
+         expiration time via other means or document the default value.
+
+   scope
+         OPTIONAL, if identical to the scope requested by the client;
+         otherwise, REQUIRED.  The scope of the access token as
+         described by Section 3.3.
+
+   state
+         REQUIRED if the "state" parameter was present in the client
+         authorization request.  The exact value received from the
+         client.
+
+   The authorization server MUST NOT issue a refresh token.
+
+   For example, the authorization server redirects the user-agent by
+   sending the following HTTP response (with extra line breaks for
+   display purposes only):
+
+     HTTP/1.1 302 Found
+     Location: http://example.com/cb#access_token=2YotnFZFEjr1zCsicMWpAA
+               &state=xyz&token_type=example&expires_in=3600
+
+   Developers should note that some user-agents do not support the
+   inclusion of a fragment component in the HTTP "Location" response
+   header field.  Such clients will require using other methods for
+   redirecting the client than a 3xx redirection response -- for
+   example, returning an HTML page that includes a 'continue' button
+   with an action linked to the redirection URI.
+
+
+
+Hardt                        Standards Track                   [Page 35]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   The client MUST ignore unrecognized response parameters.  The access
+   token string size is left undefined by this specification.  The
+   client should avoid making assumptions about value sizes.  The
+   authorization server SHOULD document the size of any value it issues.
+
+4.2.2.1.  Error Response
+
+   If the request fails due to a missing, invalid, or mismatching
+   redirection URI, or if the client identifier is missing or invalid,
+   the authorization server SHOULD inform the resource owner of the
+   error and MUST NOT automatically redirect the user-agent to the
+   invalid redirection URI.
+
+   If the resource owner denies the access request or if the request
+   fails for reasons other than a missing or invalid redirection URI,
+   the authorization server informs the client by adding the following
+   parameters to the fragment component of the redirection URI using the
+   "application/x-www-form-urlencoded" format, per Appendix B:
+
+   error
+         REQUIRED.  A single ASCII [USASCII] error code from the
+         following:
+
+         invalid_request
+               The request is missing a required parameter, includes an
+               invalid parameter value, includes a parameter more than
+               once, or is otherwise malformed.
+
+         unauthorized_client
+               The client is not authorized to request an access token
+               using this method.
+
+         access_denied
+               The resource owner or authorization server denied the
+               request.
+
+         unsupported_response_type
+               The authorization server does not support obtaining an
+               access token using this method.
+
+         invalid_scope
+               The requested scope is invalid, unknown, or malformed.
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 36]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+         server_error
+               The authorization server encountered an unexpected
+               condition that prevented it from fulfilling the request.
+               (This error code is needed because a 500 Internal Server
+               Error HTTP status code cannot be returned to the client
+               via an HTTP redirect.)
+
+         temporarily_unavailable
+               The authorization server is currently unable to handle
+               the request due to a temporary overloading or maintenance
+               of the server.  (This error code is needed because a 503
+               Service Unavailable HTTP status code cannot be returned
+               to the client via an HTTP redirect.)
+
+         Values for the "error" parameter MUST NOT include characters
+         outside the set %x20-21 / %x23-5B / %x5D-7E.
+
+   error_description
+         OPTIONAL.  Human-readable ASCII [USASCII] text providing
+         additional information, used to assist the client developer in
+         understanding the error that occurred.
+         Values for the "error_description" parameter MUST NOT include
+         characters outside the set %x20-21 / %x23-5B / %x5D-7E.
+
+   error_uri
+         OPTIONAL.  A URI identifying a human-readable web page with
+         information about the error, used to provide the client
+         developer with additional information about the error.
+         Values for the "error_uri" parameter MUST conform to the
+         URI-reference syntax and thus MUST NOT include characters
+         outside the set %x21 / %x23-5B / %x5D-7E.
+
+   state
+         REQUIRED if a "state" parameter was present in the client
+         authorization request.  The exact value received from the
+         client.
+
+   For example, the authorization server redirects the user-agent by
+   sending the following HTTP response:
+
+   HTTP/1.1 302 Found
+   Location: https://client.example.com/cb#error=access_denied&state=xyz
+
+4.3.  Resource Owner Password Credentials Grant
+
+   The resource owner password credentials grant type is suitable in
+   cases where the resource owner has a trust relationship with the
+   client, such as the device operating system or a highly privileged
+
+
+
+Hardt                        Standards Track                   [Page 37]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   application.  The authorization server should take special care when
+   enabling this grant type and only allow it when other flows are not
+   viable.
+
+   This grant type is suitable for clients capable of obtaining the
+   resource owner's credentials (username and password, typically using
+   an interactive form).  It is also used to migrate existing clients
+   using direct authentication schemes such as HTTP Basic or Digest
+   authentication to OAuth by converting the stored credentials to an
+   access token.
+
+     +----------+
+     | Resource |
+     |  Owner   |
+     |          |
+     +----------+
+          v
+          |    Resource Owner
+         (A) Password Credentials
+          |
+          v
+     +---------+                                  +---------------+
+     |         |>--(B)---- Resource Owner ------->|               |
+     |         |         Password Credentials     | Authorization |
+     | Client  |                                  |     Server    |
+     |         |<--(C)---- Access Token ---------<|               |
+     |         |    (w/ Optional Refresh Token)   |               |
+     +---------+                                  +---------------+
+
+            Figure 5: Resource Owner Password Credentials Flow
+
+   The flow illustrated in Figure 5 includes the following steps:
+
+   (A)  The resource owner provides the client with its username and
+        password.
+
+   (B)  The client requests an access token from the authorization
+        server's token endpoint by including the credentials received
+        from the resource owner.  When making the request, the client
+        authenticates with the authorization server.
+
+   (C)  The authorization server authenticates the client and validates
+        the resource owner credentials, and if valid, issues an access
+        token.
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 38]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+4.3.1.  Authorization Request and Response
+
+   The method through which the client obtains the resource owner
+   credentials is beyond the scope of this specification.  The client
+   MUST discard the credentials once an access token has been obtained.
+
+4.3.2.  Access Token Request
+
+   The client makes a request to the token endpoint by adding the
+   following parameters using the "application/x-www-form-urlencoded"
+   format per Appendix B with a character encoding of UTF-8 in the HTTP
+   request entity-body:
+
+   grant_type
+         REQUIRED.  Value MUST be set to "password".
+
+   username
+         REQUIRED.  The resource owner username.
+
+   password
+         REQUIRED.  The resource owner password.
+
+   scope
+         OPTIONAL.  The scope of the access request as described by
+         Section 3.3.
+
+   If the client type is confidential or the client was issued client
+   credentials (or assigned other authentication requirements), the
+   client MUST authenticate with the authorization server as described
+   in Section 3.2.1.
+
+   For example, the client makes the following HTTP request using
+   transport-layer security (with extra line breaks for display purposes
+   only):
+
+     POST /token HTTP/1.1
+     Host: server.example.com
+     Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW
+     Content-Type: application/x-www-form-urlencoded
+
+     grant_type=password&username=johndoe&password=A3ddj3w
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 39]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   The authorization server MUST:
+
+   o  require client authentication for confidential clients or for any
+      client that was issued client credentials (or with other
+      authentication requirements),
+
+   o  authenticate the client if client authentication is included, and
+
+   o  validate the resource owner password credentials using its
+      existing password validation algorithm.
+
+   Since this access token request utilizes the resource owner's
+   password, the authorization server MUST protect the endpoint against
+   brute force attacks (e.g., using rate-limitation or generating
+   alerts).
+
+4.3.3.  Access Token Response
+
+   If the access token request is valid and authorized, the
+   authorization server issues an access token and optional refresh
+   token as described in Section 5.1.  If the request failed client
+   authentication or is invalid, the authorization server returns an
+   error response as described in Section 5.2.
+
+   An example successful response:
+
+     HTTP/1.1 200 OK
+     Content-Type: application/json;charset=UTF-8
+     Cache-Control: no-store
+     Pragma: no-cache
+
+     {
+       "access_token":"2YotnFZFEjr1zCsicMWpAA",
+       "token_type":"example",
+       "expires_in":3600,
+       "refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA",
+       "example_parameter":"example_value"
+     }
+
+4.4.  Client Credentials Grant
+
+   The client can request an access token using only its client
+   credentials (or other supported means of authentication) when the
+   client is requesting access to the protected resources under its
+   control, or those of another resource owner that have been previously
+   arranged with the authorization server (the method of which is beyond
+   the scope of this specification).
+
+
+
+
+Hardt                        Standards Track                   [Page 40]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   The client credentials grant type MUST only be used by confidential
+   clients.
+
+     +---------+                                  +---------------+
+     |         |                                  |               |
+     |         |>--(A)- Client Authentication --->| Authorization |
+     | Client  |                                  |     Server    |
+     |         |<--(B)---- Access Token ---------<|               |
+     |         |                                  |               |
+     +---------+                                  +---------------+
+
+                     Figure 6: Client Credentials Flow
+
+   The flow illustrated in Figure 6 includes the following steps:
+
+   (A)  The client authenticates with the authorization server and
+        requests an access token from the token endpoint.
+
+   (B)  The authorization server authenticates the client, and if valid,
+        issues an access token.
+
+4.4.1.  Authorization Request and Response
+
+   Since the client authentication is used as the authorization grant,
+   no additional authorization request is needed.
+
+4.4.2.  Access Token Request
+
+   The client makes a request to the token endpoint by adding the
+   following parameters using the "application/x-www-form-urlencoded"
+   format per Appendix B with a character encoding of UTF-8 in the HTTP
+   request entity-body:
+
+   grant_type
+         REQUIRED.  Value MUST be set to "client_credentials".
+
+   scope
+         OPTIONAL.  The scope of the access request as described by
+         Section 3.3.
+
+   The client MUST authenticate with the authorization server as
+   described in Section 3.2.1.
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 41]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   For example, the client makes the following HTTP request using
+   transport-layer security (with extra line breaks for display purposes
+   only):
+
+     POST /token HTTP/1.1
+     Host: server.example.com
+     Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW
+     Content-Type: application/x-www-form-urlencoded
+
+     grant_type=client_credentials
+
+   The authorization server MUST authenticate the client.
+
+4.4.3.  Access Token Response
+
+   If the access token request is valid and authorized, the
+   authorization server issues an access token as described in
+   Section 5.1.  A refresh token SHOULD NOT be included.  If the request
+   failed client authentication or is invalid, the authorization server
+   returns an error response as described in Section 5.2.
+
+   An example successful response:
+
+     HTTP/1.1 200 OK
+     Content-Type: application/json;charset=UTF-8
+     Cache-Control: no-store
+     Pragma: no-cache
+
+     {
+       "access_token":"2YotnFZFEjr1zCsicMWpAA",
+       "token_type":"example",
+       "expires_in":3600,
+       "example_parameter":"example_value"
+     }
+
+4.5.  Extension Grants
+
+   The client uses an extension grant type by specifying the grant type
+   using an absolute URI (defined by the authorization server) as the
+   value of the "grant_type" parameter of the token endpoint, and by
+   adding any additional parameters necessary.
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 42]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   For example, to request an access token using a Security Assertion
+   Markup Language (SAML) 2.0 assertion grant type as defined by
+   [OAuth-SAML2], the client could make the following HTTP request using
+   TLS (with extra line breaks for display purposes only):
+
+     POST /token HTTP/1.1
+     Host: server.example.com
+     Content-Type: application/x-www-form-urlencoded
+
+     grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Asaml2-
+     bearer&assertion=PEFzc2VydGlvbiBJc3N1ZUluc3RhbnQ9IjIwMTEtMDU
+     [...omitted for brevity...]aG5TdGF0ZW1lbnQ-PC9Bc3NlcnRpb24-
+
+   If the access token request is valid and authorized, the
+   authorization server issues an access token and optional refresh
+   token as described in Section 5.1.  If the request failed client
+   authentication or is invalid, the authorization server returns an
+   error response as described in Section 5.2.
+
+5.  Issuing an Access Token
+
+   If the access token request is valid and authorized, the
+   authorization server issues an access token and optional refresh
+   token as described in Section 5.1.  If the request failed client
+   authentication or is invalid, the authorization server returns an
+   error response as described in Section 5.2.
+
+5.1.  Successful Response
+
+   The authorization server issues an access token and optional refresh
+   token, and constructs the response by adding the following parameters
+   to the entity-body of the HTTP response with a 200 (OK) status code:
+
+   access_token
+         REQUIRED.  The access token issued by the authorization server.
+
+   token_type
+         REQUIRED.  The type of the token issued as described in
+         Section 7.1.  Value is case insensitive.
+
+   expires_in
+         RECOMMENDED.  The lifetime in seconds of the access token.  For
+         example, the value "3600" denotes that the access token will
+         expire in one hour from the time the response was generated.
+         If omitted, the authorization server SHOULD provide the
+         expiration time via other means or document the default value.
+
+
+
+
+
+Hardt                        Standards Track                   [Page 43]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   refresh_token
+         OPTIONAL.  The refresh token, which can be used to obtain new
+         access tokens using the same authorization grant as described
+         in Section 6.
+
+   scope
+         OPTIONAL, if identical to the scope requested by the client;
+         otherwise, REQUIRED.  The scope of the access token as
+         described by Section 3.3.
+
+   The parameters are included in the entity-body of the HTTP response
+   using the "application/json" media type as defined by [RFC4627].  The
+   parameters are serialized into a JavaScript Object Notation (JSON)
+   structure by adding each parameter at the highest structure level.
+   Parameter names and string values are included as JSON strings.
+   Numerical values are included as JSON numbers.  The order of
+   parameters does not matter and can vary.
+
+   The authorization server MUST include the HTTP "Cache-Control"
+   response header field [RFC2616] with a value of "no-store" in any
+   response containing tokens, credentials, or other sensitive
+   information, as well as the "Pragma" response header field [RFC2616]
+   with a value of "no-cache".
+
+   For example:
+
+     HTTP/1.1 200 OK
+     Content-Type: application/json;charset=UTF-8
+     Cache-Control: no-store
+     Pragma: no-cache
+
+     {
+       "access_token":"2YotnFZFEjr1zCsicMWpAA",
+       "token_type":"example",
+       "expires_in":3600,
+       "refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA",
+       "example_parameter":"example_value"
+     }
+
+   The client MUST ignore unrecognized value names in the response.  The
+   sizes of tokens and other values received from the authorization
+   server are left undefined.  The client should avoid making
+   assumptions about value sizes.  The authorization server SHOULD
+   document the size of any value it issues.
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 44]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+5.2.  Error Response
+
+   The authorization server responds with an HTTP 400 (Bad Request)
+   status code (unless specified otherwise) and includes the following
+   parameters with the response:
+
+   error
+         REQUIRED.  A single ASCII [USASCII] error code from the
+         following:
+
+         invalid_request
+               The request is missing a required parameter, includes an
+               unsupported parameter value (other than grant type),
+               repeats a parameter, includes multiple credentials,
+               utilizes more than one mechanism for authenticating the
+               client, or is otherwise malformed.
+
+         invalid_client
+               Client authentication failed (e.g., unknown client, no
+               client authentication included, or unsupported
+               authentication method).  The authorization server MAY
+               return an HTTP 401 (Unauthorized) status code to indicate
+               which HTTP authentication schemes are supported.  If the
+               client attempted to authenticate via the "Authorization"
+               request header field, the authorization server MUST
+               respond with an HTTP 401 (Unauthorized) status code and
+               include the "WWW-Authenticate" response header field
+               matching the authentication scheme used by the client.
+
+         invalid_grant
+               The provided authorization grant (e.g., authorization
+               code, resource owner credentials) or refresh token is
+               invalid, expired, revoked, does not match the redirection
+               URI used in the authorization request, or was issued to
+               another client.
+
+         unauthorized_client
+               The authenticated client is not authorized to use this
+               authorization grant type.
+
+         unsupported_grant_type
+               The authorization grant type is not supported by the
+               authorization server.
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 45]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+         invalid_scope
+               The requested scope is invalid, unknown, malformed, or
+               exceeds the scope granted by the resource owner.
+
+         Values for the "error" parameter MUST NOT include characters
+         outside the set %x20-21 / %x23-5B / %x5D-7E.
+
+   error_description
+         OPTIONAL.  Human-readable ASCII [USASCII] text providing
+         additional information, used to assist the client developer in
+         understanding the error that occurred.
+         Values for the "error_description" parameter MUST NOT include
+         characters outside the set %x20-21 / %x23-5B / %x5D-7E.
+
+   error_uri
+         OPTIONAL.  A URI identifying a human-readable web page with
+         information about the error, used to provide the client
+         developer with additional information about the error.
+         Values for the "error_uri" parameter MUST conform to the
+         URI-reference syntax and thus MUST NOT include characters
+         outside the set %x21 / %x23-5B / %x5D-7E.
+
+   The parameters are included in the entity-body of the HTTP response
+   using the "application/json" media type as defined by [RFC4627].  The
+   parameters are serialized into a JSON structure by adding each
+   parameter at the highest structure level.  Parameter names and string
+   values are included as JSON strings.  Numerical values are included
+   as JSON numbers.  The order of parameters does not matter and can
+   vary.
+
+   For example:
+
+     HTTP/1.1 400 Bad Request
+     Content-Type: application/json;charset=UTF-8
+     Cache-Control: no-store
+     Pragma: no-cache
+
+     {
+       "error":"invalid_request"
+     }
+
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 46]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+6.  Refreshing an Access Token
+
+   If the authorization server issued a refresh token to the client, the
+   client makes a refresh request to the token endpoint by adding the
+   following parameters using the "application/x-www-form-urlencoded"
+   format per Appendix B with a character encoding of UTF-8 in the HTTP
+   request entity-body:
+
+   grant_type
+         REQUIRED.  Value MUST be set to "refresh_token".
+
+   refresh_token
+         REQUIRED.  The refresh token issued to the client.
+
+   scope
+         OPTIONAL.  The scope of the access request as described by
+         Section 3.3.  The requested scope MUST NOT include any scope
+         not originally granted by the resource owner, and if omitted is
+         treated as equal to the scope originally granted by the
+         resource owner.
+
+   Because refresh tokens are typically long-lasting credentials used to
+   request additional access tokens, the refresh token is bound to the
+   client to which it was issued.  If the client type is confidential or
+   the client was issued client credentials (or assigned other
+   authentication requirements), the client MUST authenticate with the
+   authorization server as described in Section 3.2.1.
+
+   For example, the client makes the following HTTP request using
+   transport-layer security (with extra line breaks for display purposes
+   only):
+
+     POST /token HTTP/1.1
+     Host: server.example.com
+     Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW
+     Content-Type: application/x-www-form-urlencoded
+
+     grant_type=refresh_token&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 47]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   The authorization server MUST:
+
+   o  require client authentication for confidential clients or for any
+      client that was issued client credentials (or with other
+      authentication requirements),
+
+   o  authenticate the client if client authentication is included and
+      ensure that the refresh token was issued to the authenticated
+      client, and
+
+   o  validate the refresh token.
+
+   If valid and authorized, the authorization server issues an access
+   token as described in Section 5.1.  If the request failed
+   verification or is invalid, the authorization server returns an error
+   response as described in Section 5.2.
+
+   The authorization server MAY issue a new refresh token, in which case
+   the client MUST discard the old refresh token and replace it with the
+   new refresh token.  The authorization server MAY revoke the old
+   refresh token after issuing a new refresh token to the client.  If a
+   new refresh token is issued, the refresh token scope MUST be
+   identical to that of the refresh token included by the client in the
+   request.
+
+7.  Accessing Protected Resources
+
+   The client accesses protected resources by presenting the access
+   token to the resource server.  The resource server MUST validate the
+   access token and ensure that it has not expired and that its scope
+   covers the requested resource.  The methods used by the resource
+   server to validate the access token (as well as any error responses)
+   are beyond the scope of this specification but generally involve an
+   interaction or coordination between the resource server and the
+   authorization server.
+
+   The method in which the client utilizes the access token to
+   authenticate with the resource server depends on the type of access
+   token issued by the authorization server.  Typically, it involves
+   using the HTTP "Authorization" request header field [RFC2617] with an
+   authentication scheme defined by the specification of the access
+   token type used, such as [RFC6750].
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 48]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+7.1.  Access Token Types
+
+   The access token type provides the client with the information
+   required to successfully utilize the access token to make a protected
+   resource request (along with type-specific attributes).  The client
+   MUST NOT use an access token if it does not understand the token
+   type.
+
+   For example, the "bearer" token type defined in [RFC6750] is utilized
+   by simply including the access token string in the request:
+
+     GET /resource/1 HTTP/1.1
+     Host: example.com
+     Authorization: Bearer mF_9.B5f-4.1JqM
+
+   while the "mac" token type defined in [OAuth-HTTP-MAC] is utilized by
+   issuing a Message Authentication Code (MAC) key together with the
+   access token that is used to sign certain components of the HTTP
+   requests:
+
+     GET /resource/1 HTTP/1.1
+     Host: example.com
+     Authorization: MAC id="h480djs93hd8",
+                        nonce="274312:dj83hs9s",
+                        mac="kDZvddkndxvhGRXZhvuDjEWhGeE="
+
+   The above examples are provided for illustration purposes only.
+   Developers are advised to consult the [RFC6750] and [OAuth-HTTP-MAC]
+   specifications before use.
+
+   Each access token type definition specifies the additional attributes
+   (if any) sent to the client together with the "access_token" response
+   parameter.  It also defines the HTTP authentication method used to
+   include the access token when making a protected resource request.
+
+7.2.  Error Response
+
+   If a resource access request fails, the resource server SHOULD inform
+   the client of the error.  While the specifics of such error responses
+   are beyond the scope of this specification, this document establishes
+   a common registry in Section 11.4 for error values to be shared among
+   OAuth token authentication schemes.
+
+   New authentication schemes designed primarily for OAuth token
+   authentication SHOULD define a mechanism for providing an error
+   status code to the client, in which the error values allowed are
+   registered in the error registry established by this specification.
+
+
+
+
+Hardt                        Standards Track                   [Page 49]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   Such schemes MAY limit the set of valid error codes to a subset of
+   the registered values.  If the error code is returned using a named
+   parameter, the parameter name SHOULD be "error".
+
+   Other schemes capable of being used for OAuth token authentication,
+   but not primarily designed for that purpose, MAY bind their error
+   values to the registry in the same manner.
+
+   New authentication schemes MAY choose to also specify the use of the
+   "error_description" and "error_uri" parameters to return error
+   information in a manner parallel to their usage in this
+   specification.
+
+8.  Extensibility
+
+8.1.  Defining Access Token Types
+
+   Access token types can be defined in one of two ways: registered in
+   the Access Token Types registry (following the procedures in
+   Section 11.1), or by using a unique absolute URI as its name.
+
+   Types utilizing a URI name SHOULD be limited to vendor-specific
+   implementations that are not commonly applicable, and are specific to
+   the implementation details of the resource server where they are
+   used.
+
+   All other types MUST be registered.  Type names MUST conform to the
+   type-name ABNF.  If the type definition includes a new HTTP
+   authentication scheme, the type name SHOULD be identical to the HTTP
+   authentication scheme name (as defined by [RFC2617]).  The token type
+   "example" is reserved for use in examples.
+
+     type-name  = 1*name-char
+     name-char  = "-" / "." / "_" / DIGIT / ALPHA
+
+8.2.  Defining New Endpoint Parameters
+
+   New request or response parameters for use with the authorization
+   endpoint or the token endpoint are defined and registered in the
+   OAuth Parameters registry following the procedure in Section 11.2.
+
+   Parameter names MUST conform to the param-name ABNF, and parameter
+   values syntax MUST be well-defined (e.g., using ABNF, or a reference
+   to the syntax of an existing parameter).
+
+     param-name  = 1*name-char
+     name-char   = "-" / "." / "_" / DIGIT / ALPHA
+
+
+
+
+Hardt                        Standards Track                   [Page 50]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   Unregistered vendor-specific parameter extensions that are not
+   commonly applicable and that are specific to the implementation
+   details of the authorization server where they are used SHOULD
+   utilize a vendor-specific prefix that is not likely to conflict with
+   other registered values (e.g., begin with 'companyname_').
+
+8.3.  Defining New Authorization Grant Types
+
+   New authorization grant types can be defined by assigning them a
+   unique absolute URI for use with the "grant_type" parameter.  If the
+   extension grant type requires additional token endpoint parameters,
+   they MUST be registered in the OAuth Parameters registry as described
+   by Section 11.2.
+
+8.4.  Defining New Authorization Endpoint Response Types
+
+   New response types for use with the authorization endpoint are
+   defined and registered in the Authorization Endpoint Response Types
+   registry following the procedure in Section 11.3.  Response type
+   names MUST conform to the response-type ABNF.
+
+     response-type  = response-name *( SP response-name )
+     response-name  = 1*response-char
+     response-char  = "_" / DIGIT / ALPHA
+
+   If a response type contains one or more space characters (%x20), it
+   is compared as a space-delimited list of values in which the order of
+   values does not matter.  Only one order of values can be registered,
+   which covers all other arrangements of the same set of values.
+
+   For example, the response type "token code" is left undefined by this
+   specification.  However, an extension can define and register the
+   "token code" response type.  Once registered, the same combination
+   cannot be registered as "code token", but both values can be used to
+   denote the same response type.
+
+8.5.  Defining Additional Error Codes
+
+   In cases where protocol extensions (i.e., access token types,
+   extension parameters, or extension grant types) require additional
+   error codes to be used with the authorization code grant error
+   response (Section 4.1.2.1), the implicit grant error response
+   (Section 4.2.2.1), the token error response (Section 5.2), or the
+   resource access error response (Section 7.2), such error codes MAY be
+   defined.
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 51]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   Extension error codes MUST be registered (following the procedures in
+   Section 11.4) if the extension they are used in conjunction with is a
+   registered access token type, a registered endpoint parameter, or an
+   extension grant type.  Error codes used with unregistered extensions
+   MAY be registered.
+
+   Error codes MUST conform to the error ABNF and SHOULD be prefixed by
+   an identifying name when possible.  For example, an error identifying
+   an invalid value set to the extension parameter "example" SHOULD be
+   named "example_invalid".
+
+     error      = 1*error-char
+     error-char = %x20-21 / %x23-5B / %x5D-7E
+
+9.  Native Applications
+
+   Native applications are clients installed and executed on the device
+   used by the resource owner (i.e., desktop application, native mobile
+   application).  Native applications require special consideration
+   related to security, platform capabilities, and overall end-user
+   experience.
+
+   The authorization endpoint requires interaction between the client
+   and the resource owner's user-agent.  Native applications can invoke
+   an external user-agent or embed a user-agent within the application.
+   For example:
+
+   o  External user-agent - the native application can capture the
+      response from the authorization server using a redirection URI
+      with a scheme registered with the operating system to invoke the
+      client as the handler, manual copy-and-paste of the credentials,
+      running a local web server, installing a user-agent extension, or
+      by providing a redirection URI identifying a server-hosted
+      resource under the client's control, which in turn makes the
+      response available to the native application.
+
+   o  Embedded user-agent - the native application obtains the response
+      by directly communicating with the embedded user-agent by
+      monitoring state changes emitted during the resource load, or
+      accessing the user-agent's cookies storage.
+
+   When choosing between an external or embedded user-agent, developers
+   should consider the following:
+
+   o  An external user-agent may improve completion rate, as the
+      resource owner may already have an active session with the
+      authorization server, removing the need to re-authenticate.  It
+      provides a familiar end-user experience and functionality.  The
+
+
+
+Hardt                        Standards Track                   [Page 52]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+      resource owner may also rely on user-agent features or extensions
+      to assist with authentication (e.g., password manager, 2-factor
+      device reader).
+
+   o  An embedded user-agent may offer improved usability, as it removes
+      the need to switch context and open new windows.
+
+   o  An embedded user-agent poses a security challenge because resource
+      owners are authenticating in an unidentified window without access
+      to the visual protections found in most external user-agents.  An
+      embedded user-agent educates end-users to trust unidentified
+      requests for authentication (making phishing attacks easier to
+      execute).
+
+   When choosing between the implicit grant type and the authorization
+   code grant type, the following should be considered:
+
+   o  Native applications that use the authorization code grant type
+      SHOULD do so without using client credentials, due to the native
+      application's inability to keep client credentials confidential.
+
+   o  When using the implicit grant type flow, a refresh token is not
+      returned, which requires repeating the authorization process once
+      the access token expires.
+
+10.  Security Considerations
+
+   As a flexible and extensible framework, OAuth's security
+   considerations depend on many factors.  The following sections
+   provide implementers with security guidelines focused on the three
+   client profiles described in Section 2.1: web application,
+   user-agent-based application, and native application.
+
+   A comprehensive OAuth security model and analysis, as well as
+   background for the protocol design, is provided by
+   [OAuth-THREATMODEL].
+
+10.1.  Client Authentication
+
+   The authorization server establishes client credentials with web
+   application clients for the purpose of client authentication.  The
+   authorization server is encouraged to consider stronger client
+   authentication means than a client password.  Web application clients
+   MUST ensure confidentiality of client passwords and other client
+   credentials.
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 53]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   The authorization server MUST NOT issue client passwords or other
+   client credentials to native application or user-agent-based
+   application clients for the purpose of client authentication.  The
+   authorization server MAY issue a client password or other credentials
+   for a specific installation of a native application client on a
+   specific device.
+
+   When client authentication is not possible, the authorization server
+   SHOULD employ other means to validate the client's identity -- for
+   example, by requiring the registration of the client redirection URI
+   or enlisting the resource owner to confirm identity.  A valid
+   redirection URI is not sufficient to verify the client's identity
+   when asking for resource owner authorization but can be used to
+   prevent delivering credentials to a counterfeit client after
+   obtaining resource owner authorization.
+
+   The authorization server must consider the security implications of
+   interacting with unauthenticated clients and take measures to limit
+   the potential exposure of other credentials (e.g., refresh tokens)
+   issued to such clients.
+
+10.2.  Client Impersonation
+
+   A malicious client can impersonate another client and obtain access
+   to protected resources if the impersonated client fails to, or is
+   unable to, keep its client credentials confidential.
+
+   The authorization server MUST authenticate the client whenever
+   possible.  If the authorization server cannot authenticate the client
+   due to the client's nature, the authorization server MUST require the
+   registration of any redirection URI used for receiving authorization
+   responses and SHOULD utilize other means to protect resource owners
+   from such potentially malicious clients.  For example, the
+   authorization server can engage the resource owner to assist in
+   identifying the client and its origin.
+
+   The authorization server SHOULD enforce explicit resource owner
+   authentication and provide the resource owner with information about
+   the client and the requested authorization scope and lifetime.  It is
+   up to the resource owner to review the information in the context of
+   the current client and to authorize or deny the request.
+
+   The authorization server SHOULD NOT process repeated authorization
+   requests automatically (without active resource owner interaction)
+   without authenticating the client or relying on other measures to
+   ensure that the repeated request comes from the original client and
+   not an impersonator.
+
+
+
+
+Hardt                        Standards Track                   [Page 54]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+10.3.  Access Tokens
+
+   Access token credentials (as well as any confidential access token
+   attributes) MUST be kept confidential in transit and storage, and
+   only shared among the authorization server, the resource servers the
+   access token is valid for, and the client to whom the access token is
+   issued.  Access token credentials MUST only be transmitted using TLS
+   as described in Section 1.6 with server authentication as defined by
+   [RFC2818].
+
+   When using the implicit grant type, the access token is transmitted
+   in the URI fragment, which can expose it to unauthorized parties.
+
+   The authorization server MUST ensure that access tokens cannot be
+   generated, modified, or guessed to produce valid access tokens by
+   unauthorized parties.
+
+   The client SHOULD request access tokens with the minimal scope
+   necessary.  The authorization server SHOULD take the client identity
+   into account when choosing how to honor the requested scope and MAY
+   issue an access token with less rights than requested.
+
+   This specification does not provide any methods for the resource
+   server to ensure that an access token presented to it by a given
+   client was issued to that client by the authorization server.
+
+10.4.  Refresh Tokens
+
+   Authorization servers MAY issue refresh tokens to web application
+   clients and native application clients.
+
+   Refresh tokens MUST be kept confidential in transit and storage, and
+   shared only among the authorization server and the client to whom the
+   refresh tokens were issued.  The authorization server MUST maintain
+   the binding between a refresh token and the client to whom it was
+   issued.  Refresh tokens MUST only be transmitted using TLS as
+   described in Section 1.6 with server authentication as defined by
+   [RFC2818].
+
+   The authorization server MUST verify the binding between the refresh
+   token and client identity whenever the client identity can be
+   authenticated.  When client authentication is not possible, the
+   authorization server SHOULD deploy other means to detect refresh
+   token abuse.
+
+   For example, the authorization server could employ refresh token
+   rotation in which a new refresh token is issued with every access
+   token refresh response.  The previous refresh token is invalidated
+
+
+
+Hardt                        Standards Track                   [Page 55]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   but retained by the authorization server.  If a refresh token is
+   compromised and subsequently used by both the attacker and the
+   legitimate client, one of them will present an invalidated refresh
+   token, which will inform the authorization server of the breach.
+
+   The authorization server MUST ensure that refresh tokens cannot be
+   generated, modified, or guessed to produce valid refresh tokens by
+   unauthorized parties.
+
+10.5.  Authorization Codes
+
+   The transmission of authorization codes SHOULD be made over a secure
+   channel, and the client SHOULD require the use of TLS with its
+   redirection URI if the URI identifies a network resource.  Since
+   authorization codes are transmitted via user-agent redirections, they
+   could potentially be disclosed through user-agent history and HTTP
+   referrer headers.
+
+   Authorization codes operate as plaintext bearer credentials, used to
+   verify that the resource owner who granted authorization at the
+   authorization server is the same resource owner returning to the
+   client to complete the process.  Therefore, if the client relies on
+   the authorization code for its own resource owner authentication, the
+   client redirection endpoint MUST require the use of TLS.
+
+   Authorization codes MUST be short lived and single-use.  If the
+   authorization server observes multiple attempts to exchange an
+   authorization code for an access token, the authorization server
+   SHOULD attempt to revoke all access tokens already granted based on
+   the compromised authorization code.
+
+   If the client can be authenticated, the authorization servers MUST
+   authenticate the client and ensure that the authorization code was
+   issued to the same client.
+
+10.6.  Authorization Code Redirection URI Manipulation
+
+   When requesting authorization using the authorization code grant
+   type, the client can specify a redirection URI via the "redirect_uri"
+   parameter.  If an attacker can manipulate the value of the
+   redirection URI, it can cause the authorization server to redirect
+   the resource owner user-agent to a URI under the control of the
+   attacker with the authorization code.
+
+   An attacker can create an account at a legitimate client and initiate
+   the authorization flow.  When the attacker's user-agent is sent to
+   the authorization server to grant access, the attacker grabs the
+   authorization URI provided by the legitimate client and replaces the
+
+
+
+Hardt                        Standards Track                   [Page 56]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   client's redirection URI with a URI under the control of the
+   attacker.  The attacker then tricks the victim into following the
+   manipulated link to authorize access to the legitimate client.
+
+   Once at the authorization server, the victim is prompted with a
+   normal, valid request on behalf of a legitimate and trusted client,
+   and authorizes the request.  The victim is then redirected to an
+   endpoint under the control of the attacker with the authorization
+   code.  The attacker completes the authorization flow by sending the
+   authorization code to the client using the original redirection URI
+   provided by the client.  The client exchanges the authorization code
+   with an access token and links it to the attacker's client account,
+   which can now gain access to the protected resources authorized by
+   the victim (via the client).
+
+   In order to prevent such an attack, the authorization server MUST
+   ensure that the redirection URI used to obtain the authorization code
+   is identical to the redirection URI provided when exchanging the
+   authorization code for an access token.  The authorization server
+   MUST require public clients and SHOULD require confidential clients
+   to register their redirection URIs.  If a redirection URI is provided
+   in the request, the authorization server MUST validate it against the
+   registered value.
+
+10.7.  Resource Owner Password Credentials
+
+   The resource owner password credentials grant type is often used for
+   legacy or migration reasons.  It reduces the overall risk of storing
+   usernames and passwords by the client but does not eliminate the need
+   to expose highly privileged credentials to the client.
+
+   This grant type carries a higher risk than other grant types because
+   it maintains the password anti-pattern this protocol seeks to avoid.
+   The client could abuse the password, or the password could
+   unintentionally be disclosed to an attacker (e.g., via log files or
+   other records kept by the client).
+
+   Additionally, because the resource owner does not have control over
+   the authorization process (the resource owner's involvement ends when
+   it hands over its credentials to the client), the client can obtain
+   access tokens with a broader scope than desired by the resource
+   owner.  The authorization server should consider the scope and
+   lifetime of access tokens issued via this grant type.
+
+   The authorization server and client SHOULD minimize use of this grant
+   type and utilize other grant types whenever possible.
+
+
+
+
+
+Hardt                        Standards Track                   [Page 57]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+10.8.  Request Confidentiality
+
+   Access tokens, refresh tokens, resource owner passwords, and client
+   credentials MUST NOT be transmitted in the clear.  Authorization
+   codes SHOULD NOT be transmitted in the clear.
+
+   The "state" and "scope" parameters SHOULD NOT include sensitive
+   client or resource owner information in plain text, as they can be
+   transmitted over insecure channels or stored insecurely.
+
+10.9.  Ensuring Endpoint Authenticity
+
+   In order to prevent man-in-the-middle attacks, the authorization
+   server MUST require the use of TLS with server authentication as
+   defined by [RFC2818] for any request sent to the authorization and
+   token endpoints.  The client MUST validate the authorization server's
+   TLS certificate as defined by [RFC6125] and in accordance with its
+   requirements for server identity authentication.
+
+10.10.  Credentials-Guessing Attacks
+
+   The authorization server MUST prevent attackers from guessing access
+   tokens, authorization codes, refresh tokens, resource owner
+   passwords, and client credentials.
+
+   The probability of an attacker guessing generated tokens (and other
+   credentials not intended for handling by end-users) MUST be less than
+   or equal to 2^(-128) and SHOULD be less than or equal to 2^(-160).
+
+   The authorization server MUST utilize other means to protect
+   credentials intended for end-user usage.
+
+10.11.  Phishing Attacks
+
+   Wide deployment of this and similar protocols may cause end-users to
+   become inured to the practice of being redirected to websites where
+   they are asked to enter their passwords.  If end-users are not
+   careful to verify the authenticity of these websites before entering
+   their credentials, it will be possible for attackers to exploit this
+   practice to steal resource owners' passwords.
+
+   Service providers should attempt to educate end-users about the risks
+   phishing attacks pose and should provide mechanisms that make it easy
+   for end-users to confirm the authenticity of their sites.  Client
+   developers should consider the security implications of how they
+   interact with the user-agent (e.g., external, embedded), and the
+   ability of the end-user to verify the authenticity of the
+   authorization server.
+
+
+
+Hardt                        Standards Track                   [Page 58]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   To reduce the risk of phishing attacks, the authorization servers
+   MUST require the use of TLS on every endpoint used for end-user
+   interaction.
+
+10.12.  Cross-Site Request Forgery
+
+   Cross-site request forgery (CSRF) is an exploit in which an attacker
+   causes the user-agent of a victim end-user to follow a malicious URI
+   (e.g., provided to the user-agent as a misleading link, image, or
+   redirection) to a trusting server (usually established via the
+   presence of a valid session cookie).
+
+   A CSRF attack against the client's redirection URI allows an attacker
+   to inject its own authorization code or access token, which can
+   result in the client using an access token associated with the
+   attacker's protected resources rather than the victim's (e.g., save
+   the victim's bank account information to a protected resource
+   controlled by the attacker).
+
+   The client MUST implement CSRF protection for its redirection URI.
+   This is typically accomplished by requiring any request sent to the
+   redirection URI endpoint to include a value that binds the request to
+   the user-agent's authenticated state (e.g., a hash of the session
+   cookie used to authenticate the user-agent).  The client SHOULD
+   utilize the "state" request parameter to deliver this value to the
+   authorization server when making an authorization request.
+
+   Once authorization has been obtained from the end-user, the
+   authorization server redirects the end-user's user-agent back to the
+   client with the required binding value contained in the "state"
+   parameter.  The binding value enables the client to verify the
+   validity of the request by matching the binding value to the
+   user-agent's authenticated state.  The binding value used for CSRF
+   protection MUST contain a non-guessable value (as described in
+   Section 10.10), and the user-agent's authenticated state (e.g.,
+   session cookie, HTML5 local storage) MUST be kept in a location
+   accessible only to the client and the user-agent (i.e., protected by
+   same-origin policy).
+
+   A CSRF attack against the authorization server's authorization
+   endpoint can result in an attacker obtaining end-user authorization
+   for a malicious client without involving or alerting the end-user.
+
+   The authorization server MUST implement CSRF protection for its
+   authorization endpoint and ensure that a malicious client cannot
+   obtain authorization without the awareness and explicit consent of
+   the resource owner.
+
+
+
+
+Hardt                        Standards Track                   [Page 59]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+10.13.  Clickjacking
+
+   In a clickjacking attack, an attacker registers a legitimate client
+   and then constructs a malicious site in which it loads the
+   authorization server's authorization endpoint web page in a
+   transparent iframe overlaid on top of a set of dummy buttons, which
+   are carefully constructed to be placed directly under important
+   buttons on the authorization page.  When an end-user clicks a
+   misleading visible button, the end-user is actually clicking an
+   invisible button on the authorization page (such as an "Authorize"
+   button).  This allows an attacker to trick a resource owner into
+   granting its client access without the end-user's knowledge.
+
+   To prevent this form of attack, native applications SHOULD use
+   external browsers instead of embedding browsers within the
+   application when requesting end-user authorization.  For most newer
+   browsers, avoidance of iframes can be enforced by the authorization
+   server using the (non-standard) "x-frame-options" header.  This
+   header can have two values, "deny" and "sameorigin", which will block
+   any framing, or framing by sites with a different origin,
+   respectively.  For older browsers, JavaScript frame-busting
+   techniques can be used but may not be effective in all browsers.
+
+10.14.  Code Injection and Input Validation
+
+   A code injection attack occurs when an input or otherwise external
+   variable is used by an application unsanitized and causes
+   modification to the application logic.  This may allow an attacker to
+   gain access to the application device or its data, cause denial of
+   service, or introduce a wide range of malicious side-effects.
+
+   The authorization server and client MUST sanitize (and validate when
+   possible) any value received -- in particular, the value of the
+   "state" and "redirect_uri" parameters.
+
+10.15.  Open Redirectors
+
+   The authorization server, authorization endpoint, and client
+   redirection endpoint can be improperly configured and operate as open
+   redirectors.  An open redirector is an endpoint using a parameter to
+   automatically redirect a user-agent to the location specified by the
+   parameter value without any validation.
+
+   Open redirectors can be used in phishing attacks, or by an attacker
+   to get end-users to visit malicious sites by using the URI authority
+   component of a familiar and trusted destination.  In addition, if the
+   authorization server allows the client to register only part of the
+   redirection URI, an attacker can use an open redirector operated by
+
+
+
+Hardt                        Standards Track                   [Page 60]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   the client to construct a redirection URI that will pass the
+   authorization server validation but will send the authorization code
+   or access token to an endpoint under the control of the attacker.
+
+10.16.  Misuse of Access Token to Impersonate Resource Owner in Implicit
+        Flow
+
+   For public clients using implicit flows, this specification does not
+   provide any method for the client to determine what client an access
+   token was issued to.
+
+   A resource owner may willingly delegate access to a resource by
+   granting an access token to an attacker's malicious client.  This may
+   be due to phishing or some other pretext.  An attacker may also steal
+   a token via some other mechanism.  An attacker may then attempt to
+   impersonate the resource owner by providing the access token to a
+   legitimate public client.
+
+   In the implicit flow (response_type=token), the attacker can easily
+   switch the token in the response from the authorization server,
+   replacing the real access token with the one previously issued to the
+   attacker.
+
+   Servers communicating with native applications that rely on being
+   passed an access token in the back channel to identify the user of
+   the client may be similarly compromised by an attacker creating a
+   compromised application that can inject arbitrary stolen access
+   tokens.
+
+   Any public client that makes the assumption that only the resource
+   owner can present it with a valid access token for the resource is
+   vulnerable to this type of attack.
+
+   This type of attack may expose information about the resource owner
+   at the legitimate client to the attacker (malicious client).  This
+   will also allow the attacker to perform operations at the legitimate
+   client with the same permissions as the resource owner who originally
+   granted the access token or authorization code.
+
+   Authenticating resource owners to clients is out of scope for this
+   specification.  Any specification that uses the authorization process
+   as a form of delegated end-user authentication to the client (e.g.,
+   third-party sign-in service) MUST NOT use the implicit flow without
+   additional security mechanisms that would enable the client to
+   determine if the access token was issued for its use (e.g., audience-
+   restricting the access token).
+
+
+
+
+
+Hardt                        Standards Track                   [Page 61]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+11.  IANA Considerations
+
+11.1.  OAuth Access Token Types Registry
+
+   This specification establishes the OAuth Access Token Types registry.
+
+   Access token types are registered with a Specification Required
+   ([RFC5226]) after a two-week review period on the
+   oauth-ext-review@ietf.org mailing list, on the advice of one or more
+   Designated Experts.  However, to allow for the allocation of values
+   prior to publication, the Designated Expert(s) may approve
+   registration once they are satisfied that such a specification will
+   be published.
+
+   Registration requests must be sent to the oauth-ext-review@ietf.org
+   mailing list for review and comment, with an appropriate subject
+   (e.g., "Request for access token type: example").
+
+   Within the review period, the Designated Expert(s) will either
+   approve or deny the registration request, communicating this decision
+   to the review list and IANA.  Denials should include an explanation
+   and, if applicable, suggestions as to how to make the request
+   successful.
+
+   IANA must only accept registry updates from the Designated Expert(s)
+   and should direct all requests for registration to the review mailing
+   list.
+
+11.1.1.  Registration Template
+
+   Type name:
+      The name requested (e.g., "example").
+
+   Additional Token Endpoint Response Parameters:
+      Additional response parameters returned together with the
+      "access_token" parameter.  New parameters MUST be separately
+      registered in the OAuth Parameters registry as described by
+      Section 11.2.
+
+   HTTP Authentication Scheme(s):
+      The HTTP authentication scheme name(s), if any, used to
+      authenticate protected resource requests using access tokens of
+      this type.
+
+   Change controller:
+      For Standards Track RFCs, state "IETF".  For others, give the name
+      of the responsible party.  Other details (e.g., postal address,
+      email address, home page URI) may also be included.
+
+
+
+Hardt                        Standards Track                   [Page 62]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   Specification document(s):
+      Reference to the document(s) that specify the parameter,
+      preferably including a URI that can be used to retrieve a copy of
+      the document(s).  An indication of the relevant sections may also
+      be included but is not required.
+
+11.2.  OAuth Parameters Registry
+
+   This specification establishes the OAuth Parameters registry.
+
+   Additional parameters for inclusion in the authorization endpoint
+   request, the authorization endpoint response, the token endpoint
+   request, or the token endpoint response are registered with a
+   Specification Required ([RFC5226]) after a two-week review period on
+   the oauth-ext-review@ietf.org mailing list, on the advice of one or
+   more Designated Experts.  However, to allow for the allocation of
+   values prior to publication, the Designated Expert(s) may approve
+   registration once they are satisfied that such a specification will
+   be published.
+
+   Registration requests must be sent to the oauth-ext-review@ietf.org
+   mailing list for review and comment, with an appropriate subject
+   (e.g., "Request for parameter: example").
+
+   Within the review period, the Designated Expert(s) will either
+   approve or deny the registration request, communicating this decision
+   to the review list and IANA.  Denials should include an explanation
+   and, if applicable, suggestions as to how to make the request
+   successful.
+
+   IANA must only accept registry updates from the Designated Expert(s)
+   and should direct all requests for registration to the review mailing
+   list.
+
+11.2.1.  Registration Template
+
+   Parameter name:
+      The name requested (e.g., "example").
+
+   Parameter usage location:
+      The location(s) where parameter can be used.  The possible
+      locations are authorization request, authorization response, token
+      request, or token response.
+
+   Change controller:
+      For Standards Track RFCs, state "IETF".  For others, give the name
+      of the responsible party.  Other details (e.g., postal address,
+      email address, home page URI) may also be included.
+
+
+
+Hardt                        Standards Track                   [Page 63]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   Specification document(s):
+      Reference to the document(s) that specify the parameter,
+      preferably including a URI that can be used to retrieve a copy of
+      the document(s).  An indication of the relevant sections may also
+      be included but is not required.
+
+11.2.2.  Initial Registry Contents
+
+   The OAuth Parameters registry's initial contents are:
+
+   o  Parameter name: client_id
+   o  Parameter usage location: authorization request, token request
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+   o  Parameter name: client_secret
+   o  Parameter usage location: token request
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+   o  Parameter name: response_type
+   o  Parameter usage location: authorization request
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+   o  Parameter name: redirect_uri
+   o  Parameter usage location: authorization request, token request
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+   o  Parameter name: scope
+   o  Parameter usage location: authorization request, authorization
+      response, token request, token response
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+   o  Parameter name: state
+   o  Parameter usage location: authorization request, authorization
+      response
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+   o  Parameter name: code
+   o  Parameter usage location: authorization response, token request
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+
+
+
+
+Hardt                        Standards Track                   [Page 64]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   o  Parameter name: error_description
+   o  Parameter usage location: authorization response, token response
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+   o  Parameter name: error_uri
+   o  Parameter usage location: authorization response, token response
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+   o  Parameter name: grant_type
+   o  Parameter usage location: token request
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+   o  Parameter name: access_token
+   o  Parameter usage location: authorization response, token response
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+   o  Parameter name: token_type
+   o  Parameter usage location: authorization response, token response
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+   o  Parameter name: expires_in
+   o  Parameter usage location: authorization response, token response
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+   o  Parameter name: username
+   o  Parameter usage location: token request
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+   o  Parameter name: password
+   o  Parameter usage location: token request
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+   o  Parameter name: refresh_token
+   o  Parameter usage location: token request, token response
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 65]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+11.3.  OAuth Authorization Endpoint Response Types Registry
+
+   This specification establishes the OAuth Authorization Endpoint
+   Response Types registry.
+
+   Additional response types for use with the authorization endpoint are
+   registered with a Specification Required ([RFC5226]) after a two-week
+   review period on the oauth-ext-review@ietf.org mailing list, on the
+   advice of one or more Designated Experts.  However, to allow for the
+   allocation of values prior to publication, the Designated Expert(s)
+   may approve registration once they are satisfied that such a
+   specification will be published.
+
+   Registration requests must be sent to the oauth-ext-review@ietf.org
+   mailing list for review and comment, with an appropriate subject
+   (e.g., "Request for response type: example").
+
+   Within the review period, the Designated Expert(s) will either
+   approve or deny the registration request, communicating this decision
+   to the review list and IANA.  Denials should include an explanation
+   and, if applicable, suggestions as to how to make the request
+   successful.
+
+   IANA must only accept registry updates from the Designated Expert(s)
+   and should direct all requests for registration to the review mailing
+   list.
+
+11.3.1.  Registration Template
+
+   Response type name:
+      The name requested (e.g., "example").
+
+   Change controller:
+      For Standards Track RFCs, state "IETF".  For others, give the name
+      of the responsible party.  Other details (e.g., postal address,
+      email address, home page URI) may also be included.
+
+   Specification document(s):
+      Reference to the document(s) that specify the type, preferably
+      including a URI that can be used to retrieve a copy of the
+      document(s).  An indication of the relevant sections may also be
+      included but is not required.
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 66]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+11.3.2.  Initial Registry Contents
+
+   The OAuth Authorization Endpoint Response Types registry's initial
+   contents are:
+
+   o  Response type name: code
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+   o  Response type name: token
+   o  Change controller: IETF
+   o  Specification document(s): RFC 6749
+
+11.4.  OAuth Extensions Error Registry
+
+   This specification establishes the OAuth Extensions Error registry.
+
+   Additional error codes used together with other protocol extensions
+   (i.e., extension grant types, access token types, or extension
+   parameters) are registered with a Specification Required ([RFC5226])
+   after a two-week review period on the oauth-ext-review@ietf.org
+   mailing list, on the advice of one or more Designated Experts.
+   However, to allow for the allocation of values prior to publication,
+   the Designated Expert(s) may approve registration once they are
+   satisfied that such a specification will be published.
+
+   Registration requests must be sent to the oauth-ext-review@ietf.org
+   mailing list for review and comment, with an appropriate subject
+   (e.g., "Request for error code: example").
+
+   Within the review period, the Designated Expert(s) will either
+   approve or deny the registration request, communicating this decision
+   to the review list and IANA.  Denials should include an explanation
+   and, if applicable, suggestions as to how to make the request
+   successful.
+
+   IANA must only accept registry updates from the Designated Expert(s)
+   and should direct all requests for registration to the review mailing
+   list.
+
+
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 67]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+11.4.1.  Registration Template
+
+   Error name:
+      The name requested (e.g., "example").  Values for the error name
+      MUST NOT include characters outside the set %x20-21 / %x23-5B /
+      %x5D-7E.
+
+   Error usage location:
+      The location(s) where the error can be used.  The possible
+      locations are authorization code grant error response
+      (Section 4.1.2.1), implicit grant error response
+      (Section 4.2.2.1), token error response (Section 5.2), or resource
+      access error response (Section 7.2).
+
+   Related protocol extension:
+      The name of the extension grant type, access token type, or
+      extension parameter that the error code is used in conjunction
+      with.
+
+   Change controller:
+      For Standards Track RFCs, state "IETF".  For others, give the name
+      of the responsible party.  Other details (e.g., postal address,
+      email address, home page URI) may also be included.
+
+   Specification document(s):
+      Reference to the document(s) that specify the error code,
+      preferably including a URI that can be used to retrieve a copy of
+      the document(s).  An indication of the relevant sections may also
+      be included but is not required.
+
+12.  References
+
+12.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2246]  Dierks, T. and C. Allen, "The TLS Protocol Version 1.0",
+              RFC 2246, January 1999.
+
+   [RFC2616]  Fielding, R., Gettys, J., Mogul, J., Frystyk, H.,
+              Masinter, L., Leach, P., and T. Berners-Lee, "Hypertext
+              Transfer Protocol -- HTTP/1.1", RFC 2616, June 1999.
+
+   [RFC2617]  Franks, J., Hallam-Baker, P., Hostetler, J., Lawrence, S.,
+              Leach, P., Luotonen, A., and L. Stewart, "HTTP
+              Authentication: Basic and Digest Access Authentication",
+              RFC 2617, June 1999.
+
+
+
+Hardt                        Standards Track                   [Page 68]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   [RFC2818]  Rescorla, E., "HTTP Over TLS", RFC 2818, May 2000.
+
+   [RFC3629]  Yergeau, F., "UTF-8, a transformation format of
+              ISO 10646", STD 63, RFC 3629, November 2003.
+
+   [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+              Resource Identifier (URI): Generic Syntax", STD 66,
+              RFC 3986, January 2005.
+
+   [RFC4627]  Crockford, D., "The application/json Media Type for
+              JavaScript Object Notation (JSON)", RFC 4627, July 2006.
+
+   [RFC4949]  Shirey, R., "Internet Security Glossary, Version 2",
+              RFC 4949, August 2007.
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              May 2008.
+
+   [RFC5234]  Crocker, D. and P. Overell, "Augmented BNF for Syntax
+              Specifications: ABNF", STD 68, RFC 5234, January 2008.
+
+   [RFC5246]  Dierks, T. and E. Rescorla, "The Transport Layer Security
+              (TLS) Protocol Version 1.2", RFC 5246, August 2008.
+
+   [RFC6125]  Saint-Andre, P. and J. Hodges, "Representation and
+              Verification of Domain-Based Application Service Identity
+              within Internet Public Key Infrastructure Using X.509
+              (PKIX) Certificates in the Context of Transport Layer
+              Security (TLS)", RFC 6125, March 2011.
+
+   [USASCII]  American National Standards Institute, "Coded Character
+              Set -- 7-bit American Standard Code for Information
+              Interchange", ANSI X3.4, 1986.
+
+   [W3C.REC-html401-19991224]
+              Raggett, D., Le Hors, A., and I. Jacobs, "HTML 4.01
+              Specification", World Wide Web Consortium
+              Recommendation REC-html401-19991224, December 1999,
+              <http://www.w3.org/TR/1999/REC-html401-19991224>.
+
+   [W3C.REC-xml-20081126]
+              Bray, T., Paoli, J., Sperberg-McQueen, C., Maler, E.,
+              and F. Yergeau, "Extensible Markup Language (XML) 1.0
+              (Fifth Edition)", World Wide Web Consortium
+               Recommendation REC-xml-20081126, November 2008,
+              <http://www.w3.org/TR/2008/REC-xml-20081126>.
+
+
+
+
+Hardt                        Standards Track                   [Page 69]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+12.2.  Informative References
+
+   [OAuth-HTTP-MAC]
+              Hammer-Lahav, E., Ed., "HTTP Authentication: MAC Access
+              Authentication", Work in Progress, February 2012.
+
+   [OAuth-SAML2]
+              Campbell, B. and C. Mortimore, "SAML 2.0 Bearer Assertion
+              Profiles for OAuth 2.0", Work in Progress, September 2012.
+
+   [OAuth-THREATMODEL]
+              Lodderstedt, T., Ed., McGloin, M., and P. Hunt, "OAuth 2.0
+              Threat Model and Security Considerations", Work
+              in Progress, October 2012.
+
+   [OAuth-WRAP]
+              Hardt, D., Ed., Tom, A., Eaton, B., and Y. Goland, "OAuth
+              Web Resource Authorization Profiles", Work in Progress,
+              January 2010.
+
+   [RFC5849]  Hammer-Lahav, E., "The OAuth 1.0 Protocol", RFC 5849,
+              April 2010.
+
+   [RFC6750]  Jones, M. and D. Hardt, "The OAuth 2.0 Authorization
+              Framework: Bearer Token Usage", RFC 6750, October 2012.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 70]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+Appendix A.  Augmented Backus-Naur Form (ABNF) Syntax
+
+   This section provides Augmented Backus-Naur Form (ABNF) syntax
+   descriptions for the elements defined in this specification using the
+   notation of [RFC5234].  The ABNF below is defined in terms of Unicode
+   code points [W3C.REC-xml-20081126]; these characters are typically
+   encoded in UTF-8.  Elements are presented in the order first defined.
+
+   Some of the definitions that follow use the "URI-reference"
+   definition from [RFC3986].
+
+   Some of the definitions that follow use these common definitions:
+
+     VSCHAR     = %x20-7E
+     NQCHAR     = %x21 / %x23-5B / %x5D-7E
+     NQSCHAR    = %x20-21 / %x23-5B / %x5D-7E
+     UNICODECHARNOCRLF = %x09 /%x20-7E / %x80-D7FF /
+                         %xE000-FFFD / %x10000-10FFFF
+
+   (The UNICODECHARNOCRLF definition is based upon the Char definition
+   in Section 2.2 of [W3C.REC-xml-20081126], but omitting the Carriage
+   Return and Linefeed characters.)
+
+A.1.  "client_id" Syntax
+
+   The "client_id" element is defined in Section 2.3.1:
+
+     client-id     = *VSCHAR
+
+A.2.  "client_secret" Syntax
+
+   The "client_secret" element is defined in Section 2.3.1:
+
+     client-secret = *VSCHAR
+
+A.3.  "response_type" Syntax
+
+   The "response_type" element is defined in Sections 3.1.1 and 8.4:
+
+     response-type = response-name *( SP response-name )
+     response-name = 1*response-char
+     response-char = "_" / DIGIT / ALPHA
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 71]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+A.4.  "scope" Syntax
+
+   The "scope" element is defined in Section 3.3:
+
+     scope       = scope-token *( SP scope-token )
+     scope-token = 1*NQCHAR
+
+A.5.  "state" Syntax
+
+   The "state" element is defined in Sections 4.1.1, 4.1.2, 4.1.2.1,
+   4.2.1, 4.2.2, and 4.2.2.1:
+
+     state      = 1*VSCHAR
+
+A.6.  "redirect_uri" Syntax
+
+   The "redirect_uri" element is defined in Sections 4.1.1, 4.1.3,
+   and 4.2.1:
+
+     redirect-uri      = URI-reference
+
+A.7.  "error" Syntax
+
+   The "error" element is defined in Sections 4.1.2.1, 4.2.2.1, 5.2,
+   7.2, and 8.5:
+
+     error             = 1*NQSCHAR
+
+A.8.  "error_description" Syntax
+
+   The "error_description" element is defined in Sections 4.1.2.1,
+   4.2.2.1, 5.2, and 7.2:
+
+     error-description = 1*NQSCHAR
+
+A.9.  "error_uri" Syntax
+
+   The "error_uri" element is defined in Sections 4.1.2.1, 4.2.2.1, 5.2,
+   and 7.2:
+
+     error-uri         = URI-reference
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 72]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+A.10.  "grant_type" Syntax
+
+   The "grant_type" element is defined in Sections 4.1.3, 4.3.2, 4.4.2,
+   4.5, and 6:
+
+     grant-type = grant-name / URI-reference
+     grant-name = 1*name-char
+     name-char  = "-" / "." / "_" / DIGIT / ALPHA
+
+A.11.  "code" Syntax
+
+   The "code" element is defined in Section 4.1.3:
+
+     code       = 1*VSCHAR
+
+A.12.  "access_token" Syntax
+
+   The "access_token" element is defined in Sections 4.2.2 and 5.1:
+
+     access-token = 1*VSCHAR
+
+A.13.  "token_type" Syntax
+
+   The "token_type" element is defined in Sections 4.2.2, 5.1, and 8.1:
+
+     token-type = type-name / URI-reference
+     type-name  = 1*name-char
+     name-char  = "-" / "." / "_" / DIGIT / ALPHA
+
+A.14.  "expires_in" Syntax
+
+   The "expires_in" element is defined in Sections 4.2.2 and 5.1:
+
+     expires-in = 1*DIGIT
+
+A.15.  "username" Syntax
+
+   The "username" element is defined in Section 4.3.2:
+
+     username = *UNICODECHARNOCRLF
+
+A.16.  "password" Syntax
+
+   The "password" element is defined in Section 4.3.2:
+
+     password = *UNICODECHARNOCRLF
+
+
+
+
+
+Hardt                        Standards Track                   [Page 73]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+A.17.  "refresh_token" Syntax
+
+   The "refresh_token" element is defined in Sections 5.1 and 6:
+
+     refresh-token = 1*VSCHAR
+
+A.18.  Endpoint Parameter Syntax
+
+   The syntax for new endpoint parameters is defined in Section 8.2:
+
+     param-name = 1*name-char
+     name-char  = "-" / "." / "_" / DIGIT / ALPHA
+
+Appendix B.  Use of application/x-www-form-urlencoded Media Type
+
+   At the time of publication of this specification, the
+   "application/x-www-form-urlencoded" media type was defined in
+   Section 17.13.4 of [W3C.REC-html401-19991224] but not registered in
+   the IANA MIME Media Types registry
+   (<http://www.iana.org/assignments/media-types>).  Furthermore, that
+   definition is incomplete, as it does not consider non-US-ASCII
+   characters.
+
+   To address this shortcoming when generating payloads using this media
+   type, names and values MUST be encoded using the UTF-8 character
+   encoding scheme [RFC3629] first; the resulting octet sequence then
+   needs to be further encoded using the escaping rules defined in
+   [W3C.REC-html401-19991224].
+
+   When parsing data from a payload using this media type, the names and
+   values resulting from reversing the name/value encoding consequently
+   need to be treated as octet sequences, to be decoded using the UTF-8
+   character encoding scheme.
+
+   For example, the value consisting of the six Unicode code points
+   (1) U+0020 (SPACE), (2) U+0025 (PERCENT SIGN),
+   (3) U+0026 (AMPERSAND), (4) U+002B (PLUS SIGN),
+   (5) U+00A3 (POUND SIGN), and (6) U+20AC (EURO SIGN) would be encoded
+   into the octet sequence below (using hexadecimal notation):
+
+     20 25 26 2B C2 A3 E2 82 AC
+
+   and then represented in the payload as:
+
+     +%25%26%2B%C2%A3%E2%82%AC
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 74]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+Appendix C.  Acknowledgements
+
+   The initial OAuth 2.0 protocol specification was edited by David
+   Recordon, based on two previous publications: the OAuth 1.0 community
+   specification [RFC5849], and OAuth WRAP (OAuth Web Resource
+   Authorization Profiles) [OAuth-WRAP].  Eran Hammer then edited many
+   of the intermediate drafts that evolved into this RFC.  The Security
+   Considerations section was drafted by Torsten Lodderstedt, Mark
+   McGloin, Phil Hunt, Anthony Nadalin, and John Bradley.  The section
+   on use of the "application/x-www-form-urlencoded" media type was
+   drafted by Julian Reschke.  The ABNF section was drafted by Michael
+   B. Jones.
+
+   The OAuth 1.0 community specification was edited by Eran Hammer and
+   authored by Mark Atwood, Dirk Balfanz, Darren Bounds, Richard M.
+   Conlan, Blaine Cook, Leah Culver, Breno de Medeiros, Brian Eaton,
+   Kellan Elliott-McCrea, Larry Halff, Eran Hammer, Ben Laurie, Chris
+   Messina, John Panzer, Sam Quigley, David Recordon, Eran Sandler,
+   Jonathan Sergent, Todd Sieling, Brian Slesinsky, and Andy Smith.
+
+   The OAuth WRAP specification was edited by Dick Hardt and authored by
+   Brian Eaton, Yaron Y. Goland, Dick Hardt, and Allen Tom.
+
+   This specification is the work of the OAuth Working Group, which
+   includes dozens of active and dedicated participants.  In particular,
+   the following individuals contributed ideas, feedback, and wording
+   that shaped and formed the final specification:
+
+   Michael Adams, Amanda Anganes, Andrew Arnott, Dirk Balfanz, Aiden
+   Bell, John Bradley, Marcos Caceres, Brian Campbell, Scott Cantor,
+   Blaine Cook, Roger Crew, Leah Culver, Bill de hOra, Andre DeMarre,
+   Brian Eaton, Wesley Eddy, Wolter Eldering, Brian Ellin, Igor
+   Faynberg, George Fletcher, Tim Freeman, Luca Frosini, Evan Gilbert,
+   Yaron Y. Goland, Brent Goldman, Kristoffer Gronowski, Eran Hammer,
+   Dick Hardt, Justin Hart, Craig Heath, Phil Hunt, Michael B. Jones,
+   Terry Jones, John Kemp, Mark Kent, Raffi Krikorian, Chasen Le Hara,
+   Rasmus Lerdorf, Torsten Lodderstedt, Hui-Lan Lu, Casey Lucas, Paul
+   Madsen, Alastair Mair, Eve Maler, James Manger, Mark McGloin,
+   Laurence Miao, William Mills, Chuck Mortimore, Anthony Nadalin,
+   Julian Reschke, Justin Richer, Peter Saint-Andre, Nat Sakimura, Rob
+   Sayre, Marius Scurtescu, Naitik Shah, Luke Shepard, Vlad Skvortsov,
+   Justin Smith, Haibin Song, Niv Steingarten, Christian Stuebner,
+   Jeremy Suriel, Paul Tarjan, Christopher Thomas, Henry S. Thompson,
+   Allen Tom, Franklin Tse, Nick Walker, Shane Weeden, and Skylar
+   Woodward.
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 75]
+
+RFC 6749                        OAuth 2.0                   October 2012
+
+
+   This document was produced under the chairmanship of Blaine Cook,
+   Peter Saint-Andre, Hannes Tschofenig, Barry Leiba, and Derek Atkins.
+   The area directors included Lisa Dusseault, Peter Saint-Andre, and
+   Stephen Farrell.
+
+Author's Address
+
+   Dick Hardt (editor)
+   Microsoft
+
+   EMail: dick.hardt@gmail.com
+   URI:   http://dickhardt.org/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hardt                        Standards Track                   [Page 76]
+

--- a/rfc/rfc6750.txt
+++ b/rfc/rfc6750.txt
@@ -1,0 +1,1011 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          M. Jones
+Request for Comments: 6750                                     Microsoft
+Category: Standards Track                                       D. Hardt
+ISSN: 2070-1721                                              Independent
+                                                            October 2012
+
+
+       The OAuth 2.0 Authorization Framework: Bearer Token Usage
+
+Abstract
+
+   This specification describes how to use bearer tokens in HTTP
+   requests to access OAuth 2.0 protected resources.  Any party in
+   possession of a bearer token (a "bearer") can use it to get access to
+   the associated resources (without demonstrating possession of a
+   cryptographic key).  To prevent misuse, bearer tokens need to be
+   protected from disclosure in storage and in transport.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6750.
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+Jones & Hardt                Standards Track                    [Page 1]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+Table of Contents
+
+   1. Introduction ....................................................2
+      1.1. Notational Conventions .....................................3
+      1.2. Terminology ................................................3
+      1.3. Overview ...................................................3
+   2. Authenticated Requests ..........................................4
+      2.1. Authorization Request Header Field .........................5
+      2.2. Form-Encoded Body Parameter ................................5
+      2.3. URI Query Parameter ........................................6
+   3. The WWW-Authenticate Response Header Field ......................7
+      3.1. Error Codes ................................................9
+   4. Example Access Token Response ..................................10
+   5. Security Considerations ........................................10
+      5.1. Security Threats ..........................................10
+      5.2. Threat Mitigation .........................................11
+      5.3. Summary of Recommendations ................................13
+   6. IANA Considerations ............................................14
+      6.1. OAuth Access Token Type Registration ......................14
+           6.1.1. The "Bearer" OAuth Access Token Type ...............14
+      6.2. OAuth Extensions Error Registration .......................14
+           6.2.1. The "invalid_request" Error Value ..................14
+           6.2.2. The "invalid_token" Error Value ....................15
+           6.2.3. The "insufficient_scope" Error Value ...............15
+   7. References .....................................................15
+      7.1. Normative References ......................................15
+      7.2. Informative References ....................................17
+   Appendix A. Acknowledgements ......................................18
+
+1.  Introduction
+
+   OAuth enables clients to access protected resources by obtaining an
+   access token, which is defined in "The OAuth 2.0 Authorization
+   Framework" [RFC6749] as "a string representing an access
+   authorization issued to the client", rather than using the resource
+   owner's credentials directly.
+
+   Tokens are issued to clients by an authorization server with the
+   approval of the resource owner.  The client uses the access token to
+   access the protected resources hosted by the resource server.  This
+   specification describes how to make protected resource requests when
+   the OAuth access token is a bearer token.
+
+   This specification defines the use of bearer tokens over HTTP/1.1
+   [RFC2616] using Transport Layer Security (TLS) [RFC5246] to access
+   protected resources.  TLS is mandatory to implement and use with this
+   specification; other specifications may extend this specification for
+   use with other protocols.  While designed for use with access tokens
+
+
+
+Jones & Hardt                Standards Track                    [Page 2]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+   resulting from OAuth 2.0 authorization [RFC6749] flows to access
+   OAuth protected resources, this specification actually defines a
+   general HTTP authorization method that can be used with bearer tokens
+   from any source to access any resources protected by those bearer
+   tokens.  The Bearer authentication scheme is intended primarily for
+   server authentication using the WWW-Authenticate and Authorization
+   HTTP headers but does not preclude its use for proxy authentication.
+
+1.1.  Notational Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in "Key words for use in
+   RFCs to Indicate Requirement Levels" [RFC2119].
+
+   This document uses the Augmented Backus-Naur Form (ABNF) notation of
+   [RFC5234].  Additionally, the following rules are included from
+   HTTP/1.1 [RFC2617]: auth-param and auth-scheme; and from "Uniform
+   Resource Identifier (URI): Generic Syntax" [RFC3986]: URI-reference.
+
+   Unless otherwise noted, all the protocol parameter names and values
+   are case sensitive.
+
+1.2.  Terminology
+
+   Bearer Token
+      A security token with the property that any party in possession of
+      the token (a "bearer") can use the token in any way that any other
+      party in possession of it can.  Using a bearer token does not
+      require a bearer to prove possession of cryptographic key material
+      (proof-of-possession).
+
+   All other terms are as defined in "The OAuth 2.0 Authorization
+   Framework" [RFC6749].
+
+1.3.  Overview
+
+   OAuth provides a method for clients to access a protected resource on
+   behalf of a resource owner.  In the general case, before a client can
+   access a protected resource, it must first obtain an authorization
+   grant from the resource owner and then exchange the authorization
+   grant for an access token.  The access token represents the grant's
+   scope, duration, and other attributes granted by the authorization
+   grant.  The client accesses the protected resource by presenting the
+   access token to the resource server.  In some cases, a client can
+   directly present its own credentials to an authorization server to
+   obtain an access token without having to first obtain an
+   authorization grant from a resource owner.
+
+
+
+Jones & Hardt                Standards Track                    [Page 3]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+   The access token provides an abstraction, replacing different
+   authorization constructs (e.g., username and password, assertion) for
+   a single token understood by the resource server.  This abstraction
+   enables issuing access tokens valid for a short time period, as well
+   as removing the resource server's need to understand a wide range of
+   authentication schemes.
+
+     +--------+                               +---------------+
+     |        |--(A)- Authorization Request ->|   Resource    |
+     |        |                               |     Owner     |
+     |        |<-(B)-- Authorization Grant ---|               |
+     |        |                               +---------------+
+     |        |
+     |        |                               +---------------+
+     |        |--(C)-- Authorization Grant -->| Authorization |
+     | Client |                               |     Server    |
+     |        |<-(D)----- Access Token -------|               |
+     |        |                               +---------------+
+     |        |
+     |        |                               +---------------+
+     |        |--(E)----- Access Token ------>|    Resource   |
+     |        |                               |     Server    |
+     |        |<-(F)--- Protected Resource ---|               |
+     +--------+                               +---------------+
+
+                     Figure 1: Abstract Protocol Flow
+
+   The abstract OAuth 2.0 flow illustrated in Figure 1 describes the
+   interaction between the client, resource owner, authorization server,
+   and resource server (described in [RFC6749]).  The following two
+   steps are specified within this document:
+
+   (E)  The client requests the protected resource from the resource
+        server and authenticates by presenting the access token.
+
+   (F)  The resource server validates the access token, and if valid,
+        serves the request.
+
+   This document also imposes semantic requirements upon the access
+   token returned in step (D).
+
+2.  Authenticated Requests
+
+   This section defines three methods of sending bearer access tokens in
+   resource requests to resource servers.  Clients MUST NOT use more
+   than one method to transmit the token in each request.
+
+
+
+
+
+Jones & Hardt                Standards Track                    [Page 4]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+2.1.  Authorization Request Header Field
+
+   When sending the access token in the "Authorization" request header
+   field defined by HTTP/1.1 [RFC2617], the client uses the "Bearer"
+   authentication scheme to transmit the access token.
+
+   For example:
+
+     GET /resource HTTP/1.1
+     Host: server.example.com
+     Authorization: Bearer mF_9.B5f-4.1JqM
+
+   The syntax of the "Authorization" header field for this scheme
+   follows the usage of the Basic scheme defined in Section 2 of
+   [RFC2617].  Note that, as with Basic, it does not conform to the
+   generic syntax defined in Section 1.2 of [RFC2617] but is compatible
+   with the general authentication framework being developed for
+   HTTP 1.1 [HTTP-AUTH], although it does not follow the preferred
+   practice outlined therein in order to reflect existing deployments.
+   The syntax for Bearer credentials is as follows:
+
+     b64token    = 1*( ALPHA / DIGIT /
+                       "-" / "." / "_" / "~" / "+" / "/" ) *"="
+     credentials = "Bearer" 1*SP b64token
+
+   Clients SHOULD make authenticated requests with a bearer token using
+   the "Authorization" request header field with the "Bearer" HTTP
+   authorization scheme.  Resource servers MUST support this method.
+
+2.2.  Form-Encoded Body Parameter
+
+   When sending the access token in the HTTP request entity-body, the
+   client adds the access token to the request-body using the
+   "access_token" parameter.  The client MUST NOT use this method unless
+   all of the following conditions are met:
+
+   o  The HTTP request entity-header includes the "Content-Type" header
+      field set to "application/x-www-form-urlencoded".
+
+   o  The entity-body follows the encoding requirements of the
+      "application/x-www-form-urlencoded" content-type as defined by
+      HTML 4.01 [W3C.REC-html401-19991224].
+
+   o  The HTTP request entity-body is single-part.
+
+
+
+
+
+
+
+Jones & Hardt                Standards Track                    [Page 5]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+   o  The content to be encoded in the entity-body MUST consist entirely
+      of ASCII [USASCII] characters.
+
+   o  The HTTP request method is one for which the request-body has
+      defined semantics.  In particular, this means that the "GET"
+      method MUST NOT be used.
+
+   The entity-body MAY include other request-specific parameters, in
+   which case the "access_token" parameter MUST be properly separated
+   from the request-specific parameters using "&" character(s) (ASCII
+   code 38).
+
+   For example, the client makes the following HTTP request using
+   transport-layer security:
+
+     POST /resource HTTP/1.1
+     Host: server.example.com
+     Content-Type: application/x-www-form-urlencoded
+
+     access_token=mF_9.B5f-4.1JqM
+
+   The "application/x-www-form-urlencoded" method SHOULD NOT be used
+   except in application contexts where participating browsers do not
+   have access to the "Authorization" request header field.  Resource
+   servers MAY support this method.
+
+2.3.  URI Query Parameter
+
+   When sending the access token in the HTTP request URI, the client
+   adds the access token to the request URI query component as defined
+   by "Uniform Resource Identifier (URI): Generic Syntax" [RFC3986],
+   using the "access_token" parameter.
+
+   For example, the client makes the following HTTP request using
+   transport-layer security:
+
+     GET /resource?access_token=mF_9.B5f-4.1JqM HTTP/1.1
+     Host: server.example.com
+
+   The HTTP request URI query can include other request-specific
+   parameters, in which case the "access_token" parameter MUST be
+   properly separated from the request-specific parameters using "&"
+   character(s) (ASCII code 38).
+
+
+
+
+
+
+
+
+Jones & Hardt                Standards Track                    [Page 6]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+   For example:
+
+    https://server.example.com/resource?access_token=mF_9.B5f-4.1JqM&p=q
+
+   Clients using the URI Query Parameter method SHOULD also send a
+   Cache-Control header containing the "no-store" option.  Server
+   success (2XX status) responses to these requests SHOULD contain a
+   Cache-Control header with the "private" option.
+
+   Because of the security weaknesses associated with the URI method
+   (see Section 5), including the high likelihood that the URL
+   containing the access token will be logged, it SHOULD NOT be used
+   unless it is impossible to transport the access token in the
+   "Authorization" request header field or the HTTP request entity-body.
+   Resource servers MAY support this method.
+
+   This method is included to document current use; its use is not
+   recommended, due to its security deficiencies (see Section 5) and
+   also because it uses a reserved query parameter name, which is
+   counter to URI namespace best practices, per "Architecture of the
+   World Wide Web, Volume One" [W3C.REC-webarch-20041215].
+
+3.  The WWW-Authenticate Response Header Field
+
+   If the protected resource request does not include authentication
+   credentials or does not contain an access token that enables access
+   to the protected resource, the resource server MUST include the HTTP
+   "WWW-Authenticate" response header field; it MAY include it in
+   response to other conditions as well.  The "WWW-Authenticate" header
+   field uses the framework defined by HTTP/1.1 [RFC2617].
+
+   All challenges defined by this specification MUST use the auth-scheme
+   value "Bearer".  This scheme MUST be followed by one or more
+   auth-param values.  The auth-param attributes used or defined by this
+   specification are as follows.  Other auth-param attributes MAY be
+   used as well.
+
+   A "realm" attribute MAY be included to indicate the scope of
+   protection in the manner described in HTTP/1.1 [RFC2617].  The
+   "realm" attribute MUST NOT appear more than once.
+
+   The "scope" attribute is defined in Section 3.3 of [RFC6749].  The
+   "scope" attribute is a space-delimited list of case-sensitive scope
+   values indicating the required scope of the access token for
+   accessing the requested resource. "scope" values are implementation
+   defined; there is no centralized registry for them; allowed values
+   are defined by the authorization server.  The order of "scope" values
+   is not significant.  In some cases, the "scope" value will be used
+
+
+
+Jones & Hardt                Standards Track                    [Page 7]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+   when requesting a new access token with sufficient scope of access to
+   utilize the protected resource.  Use of the "scope" attribute is
+   OPTIONAL.  The "scope" attribute MUST NOT appear more than once.  The
+   "scope" value is intended for programmatic use and is not meant to be
+   displayed to end-users.
+
+   Two example scope values follow; these are taken from the OpenID
+   Connect [OpenID.Messages] and the Open Authentication Technology
+   Committee (OATC) Online Multimedia Authorization Protocol [OMAP]
+   OAuth 2.0 use cases, respectively:
+
+     scope="openid profile email"
+     scope="urn:example:channel=HBO&urn:example:rating=G,PG-13"
+
+   If the protected resource request included an access token and failed
+   authentication, the resource server SHOULD include the "error"
+   attribute to provide the client with the reason why the access
+   request was declined.  The parameter value is described in
+   Section 3.1.  In addition, the resource server MAY include the
+   "error_description" attribute to provide developers a human-readable
+   explanation that is not meant to be displayed to end-users.  It also
+   MAY include the "error_uri" attribute with an absolute URI
+   identifying a human-readable web page explaining the error.  The
+   "error", "error_description", and "error_uri" attributes MUST NOT
+   appear more than once.
+
+   Values for the "scope" attribute (specified in Appendix A.4 of
+   [RFC6749]) MUST NOT include characters outside the set %x21 / %x23-5B
+   / %x5D-7E for representing scope values and %x20 for delimiters
+   between scope values.  Values for the "error" and "error_description"
+   attributes (specified in Appendixes A.7 and A.8 of [RFC6749]) MUST
+   NOT include characters outside the set %x20-21 / %x23-5B / %x5D-7E.
+   Values for the "error_uri" attribute (specified in Appendix A.9 of
+   [RFC6749]) MUST conform to the URI-reference syntax and thus MUST NOT
+   include characters outside the set %x21 / %x23-5B / %x5D-7E.
+
+   For example, in response to a protected resource request without
+   authentication:
+
+     HTTP/1.1 401 Unauthorized
+     WWW-Authenticate: Bearer realm="example"
+
+
+
+
+
+
+
+
+
+
+Jones & Hardt                Standards Track                    [Page 8]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+   And in response to a protected resource request with an
+   authentication attempt using an expired access token:
+
+     HTTP/1.1 401 Unauthorized
+     WWW-Authenticate: Bearer realm="example",
+                       error="invalid_token",
+                       error_description="The access token expired"
+
+3.1.  Error Codes
+
+   When a request fails, the resource server responds using the
+   appropriate HTTP status code (typically, 400, 401, 403, or 405) and
+   includes one of the following error codes in the response:
+
+   invalid_request
+         The request is missing a required parameter, includes an
+         unsupported parameter or parameter value, repeats the same
+         parameter, uses more than one method for including an access
+         token, or is otherwise malformed.  The resource server SHOULD
+         respond with the HTTP 400 (Bad Request) status code.
+
+   invalid_token
+         The access token provided is expired, revoked, malformed, or
+         invalid for other reasons.  The resource SHOULD respond with
+         the HTTP 401 (Unauthorized) status code.  The client MAY
+         request a new access token and retry the protected resource
+         request.
+
+   insufficient_scope
+         The request requires higher privileges than provided by the
+         access token.  The resource server SHOULD respond with the HTTP
+         403 (Forbidden) status code and MAY include the "scope"
+         attribute with the scope necessary to access the protected
+         resource.
+
+   If the request lacks any authentication information (e.g., the client
+   was unaware that authentication is necessary or attempted using an
+   unsupported authentication method), the resource server SHOULD NOT
+   include an error code or other error information.
+
+   For example:
+
+     HTTP/1.1 401 Unauthorized
+     WWW-Authenticate: Bearer realm="example"
+
+
+
+
+
+
+
+Jones & Hardt                Standards Track                    [Page 9]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+4.  Example Access Token Response
+
+   Typically, a bearer token is returned to the client as part of an
+   OAuth 2.0 [RFC6749] access token response.  An example of such a
+   response is:
+
+     HTTP/1.1 200 OK
+     Content-Type: application/json;charset=UTF-8
+     Cache-Control: no-store
+     Pragma: no-cache
+
+     {
+       "access_token":"mF_9.B5f-4.1JqM",
+       "token_type":"Bearer",
+       "expires_in":3600,
+       "refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA"
+     }
+
+5.  Security Considerations
+
+   This section describes the relevant security threats regarding token
+   handling when using bearer tokens and describes how to mitigate these
+   threats.
+
+5.1.  Security Threats
+
+   The following list presents several common threats against protocols
+   utilizing some form of tokens.  This list of threats is based on NIST
+   Special Publication 800-63 [NIST800-63].  Since this document builds
+   on the OAuth 2.0 Authorization specification [RFC6749], we exclude a
+   discussion of threats that are described there or in related
+   documents.
+
+   Token manufacture/modification:  An attacker may generate a bogus
+      token or modify the token contents (such as the authentication or
+      attribute statements) of an existing token, causing the resource
+      server to grant inappropriate access to the client.  For example,
+      an attacker may modify the token to extend the validity period; a
+      malicious client may modify the assertion to gain access to
+      information that they should not be able to view.
+
+   Token disclosure:  Tokens may contain authentication and attribute
+      statements that include sensitive information.
+
+
+
+
+
+
+
+
+Jones & Hardt                Standards Track                   [Page 10]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+   Token redirect:  An attacker uses a token generated for consumption
+      by one resource server to gain access to a different resource
+      server that mistakenly believes the token to be for it.
+
+   Token replay:  An attacker attempts to use a token that has already
+      been used with that resource server in the past.
+
+5.2.  Threat Mitigation
+
+   A large range of threats can be mitigated by protecting the contents
+   of the token by using a digital signature or a Message Authentication
+   Code (MAC).  Alternatively, a bearer token can contain a reference to
+   authorization information, rather than encoding the information
+   directly.  Such references MUST be infeasible for an attacker to
+   guess; using a reference may require an extra interaction between a
+   server and the token issuer to resolve the reference to the
+   authorization information.  The mechanics of such an interaction are
+   not defined by this specification.
+
+   This document does not specify the encoding or the contents of the
+   token; hence, detailed recommendations about the means of
+   guaranteeing token integrity protection are outside the scope of this
+   document.  The token integrity protection MUST be sufficient to
+   prevent the token from being modified.
+
+   To deal with token redirect, it is important for the authorization
+   server to include the identity of the intended recipients (the
+   audience), typically a single resource server (or a list of resource
+   servers), in the token.  Restricting the use of the token to a
+   specific scope is also RECOMMENDED.
+
+   The authorization server MUST implement TLS.  Which version(s) ought
+   to be implemented will vary over time and will depend on the
+   widespread deployment and known security vulnerabilities at the time
+   of implementation.  At the time of this writing, TLS version 1.2
+   [RFC5246] is the most recent version, but it has very limited actual
+   deployment and might not be readily available in implementation
+   toolkits.  TLS version 1.0 [RFC2246] is the most widely deployed
+   version and will give the broadest interoperability.
+
+   To protect against token disclosure, confidentiality protection MUST
+   be applied using TLS [RFC5246] with a ciphersuite that provides
+   confidentiality and integrity protection.  This requires that the
+   communication interaction between the client and the authorization
+   server, as well as the interaction between the client and the
+   resource server, utilize confidentiality and integrity protection.
+   Since TLS is mandatory to implement and to use with this
+   specification, it is the preferred approach for preventing token
+
+
+
+Jones & Hardt                Standards Track                   [Page 11]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+   disclosure via the communication channel.  For those cases where the
+   client is prevented from observing the contents of the token, token
+   encryption MUST be applied in addition to the usage of TLS
+   protection.  As a further defense against token disclosure, the
+   client MUST validate the TLS certificate chain when making requests
+   to protected resources, including checking the Certificate Revocation
+   List (CRL) [RFC5280].
+
+   Cookies are typically transmitted in the clear.  Thus, any
+   information contained in them is at risk of disclosure.  Therefore,
+   bearer tokens MUST NOT be stored in cookies that can be sent in the
+   clear.  See "HTTP State Management Mechanism" [RFC6265] for security
+   considerations about cookies.
+
+   In some deployments, including those utilizing load balancers, the
+   TLS connection to the resource server terminates prior to the actual
+   server that provides the resource.  This could leave the token
+   unprotected between the front-end server where the TLS connection
+   terminates and the back-end server that provides the resource.  In
+   such deployments, sufficient measures MUST be employed to ensure
+   confidentiality of the token between the front-end and back-end
+   servers; encryption of the token is one such possible measure.
+
+   To deal with token capture and replay, the following recommendations
+   are made: First, the lifetime of the token MUST be limited; one means
+   of achieving this is by putting a validity time field inside the
+   protected part of the token.  Note that using short-lived (one hour
+   or less) tokens reduces the impact of them being leaked.  Second,
+   confidentiality protection of the exchanges between the client and
+   the authorization server and between the client and the resource
+   server MUST be applied.  As a consequence, no eavesdropper along the
+   communication path is able to observe the token exchange.
+   Consequently, such an on-path adversary cannot replay the token.
+   Furthermore, when presenting the token to a resource server, the
+   client MUST verify the identity of that resource server, as per
+   Section 3.1 of "HTTP Over TLS" [RFC2818].  Note that the client MUST
+   validate the TLS certificate chain when making these requests to
+   protected resources.  Presenting the token to an unauthenticated and
+   unauthorized resource server or failing to validate the certificate
+   chain will allow adversaries to steal the token and gain unauthorized
+   access to protected resources.
+
+
+
+
+
+
+
+
+
+
+Jones & Hardt                Standards Track                   [Page 12]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+5.3.  Summary of Recommendations
+
+   Safeguard bearer tokens:  Client implementations MUST ensure that
+      bearer tokens are not leaked to unintended parties, as they will
+      be able to use them to gain access to protected resources.  This
+      is the primary security consideration when using bearer tokens and
+      underlies all the more specific recommendations that follow.
+
+   Validate TLS certificate chains:  The client MUST validate the TLS
+      certificate chain when making requests to protected resources.
+      Failing to do so may enable DNS hijacking attacks to steal the
+      token and gain unintended access.
+
+   Always use TLS (https):  Clients MUST always use TLS [RFC5246]
+      (https) or equivalent transport security when making requests with
+      bearer tokens.  Failing to do so exposes the token to numerous
+      attacks that could give attackers unintended access.
+
+   Don't store bearer tokens in cookies:  Implementations MUST NOT store
+      bearer tokens within cookies that can be sent in the clear (which
+      is the default transmission mode for cookies).  Implementations
+      that do store bearer tokens in cookies MUST take precautions
+      against cross-site request forgery.
+
+   Issue short-lived bearer tokens:  Token servers SHOULD issue
+      short-lived (one hour or less) bearer tokens, particularly when
+      issuing tokens to clients that run within a web browser or other
+      environments where information leakage may occur.  Using
+      short-lived bearer tokens can reduce the impact of them being
+      leaked.
+
+   Issue scoped bearer tokens:  Token servers SHOULD issue bearer tokens
+      that contain an audience restriction, scoping their use to the
+      intended relying party or set of relying parties.
+
+   Don't pass bearer tokens in page URLs:  Bearer tokens SHOULD NOT be
+      passed in page URLs (for example, as query string parameters).
+      Instead, bearer tokens SHOULD be passed in HTTP message headers or
+      message bodies for which confidentiality measures are taken.
+      Browsers, web servers, and other software may not adequately
+      secure URLs in the browser history, web server logs, and other
+      data structures.  If bearer tokens are passed in page URLs,
+      attackers might be able to steal them from the history data, logs,
+      or other unsecured locations.
+
+
+
+
+
+
+
+Jones & Hardt                Standards Track                   [Page 13]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+6.  IANA Considerations
+
+6.1.  OAuth Access Token Type Registration
+
+   This specification registers the following access token type in the
+   OAuth Access Token Types registry defined in [RFC6749].
+
+6.1.1.  The "Bearer" OAuth Access Token Type
+
+   Type name:
+      Bearer
+
+   Additional Token Endpoint Response Parameters:
+      (none)
+
+   HTTP Authentication Scheme(s):
+      Bearer
+
+   Change controller:
+      IETF
+
+   Specification document(s):
+      RFC 6750
+
+6.2.  OAuth Extensions Error Registration
+
+   This specification registers the following error values in the OAuth
+   Extensions Error registry defined in [RFC6749].
+
+6.2.1.  The "invalid_request" Error Value
+
+   Error name:
+      invalid_request
+
+   Error usage location:
+      Resource access error response
+
+   Related protocol extension:
+      Bearer access token type
+
+   Change controller:
+      IETF
+
+   Specification document(s):
+      RFC 6750
+
+
+
+
+
+
+Jones & Hardt                Standards Track                   [Page 14]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+6.2.2.  The "invalid_token" Error Value
+
+   Error name:
+      invalid_token
+
+   Error usage location:
+      Resource access error response
+
+   Related protocol extension:
+      Bearer access token type
+
+   Change controller:
+      IETF
+
+   Specification document(s):
+      RFC 6750
+
+6.2.3.  The "insufficient_scope" Error Value
+
+   Error name:
+      insufficient_scope
+
+   Error usage location:
+      Resource access error response
+
+   Related protocol extension:
+      Bearer access token type
+
+   Change controller:
+      IETF
+
+   Specification document(s):
+      RFC 6750
+
+7.  References
+
+7.1.  Normative References
+
+   [RFC2119]    Bradner, S., "Key words for use in RFCs to Indicate
+                Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2246]    Dierks, T. and C. Allen, "The TLS Protocol Version 1.0",
+                RFC 2246, January 1999.
+
+   [RFC2616]    Fielding, R., Gettys, J., Mogul, J., Frystyk, H.,
+                Masinter, L., Leach, P., and T. Berners-Lee, "Hypertext
+                Transfer Protocol -- HTTP/1.1", RFC 2616, June 1999.
+
+
+
+
+Jones & Hardt                Standards Track                   [Page 15]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+   [RFC2617]    Franks, J., Hallam-Baker, P., Hostetler, J., Lawrence,
+                S., Leach, P., Luotonen, A., and L. Stewart, "HTTP
+                Authentication: Basic and Digest Access Authentication",
+                RFC 2617, June 1999.
+
+   [RFC2818]    Rescorla, E., "HTTP Over TLS", RFC 2818, May 2000.
+
+   [RFC3986]    Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+                Resource Identifier (URI): Generic Syntax", STD 66,
+                RFC 3986, January 2005.
+
+   [RFC5234]    Crocker, D. and P. Overell, "Augmented BNF for Syntax
+                Specifications: ABNF", STD 68, RFC 5234, January 2008.
+
+   [RFC5246]    Dierks, T. and E. Rescorla, "The Transport Layer
+                Security (TLS) Protocol Version 1.2", RFC 5246,
+                August 2008.
+
+   [RFC5280]    Cooper, D., Santesson, S., Farrell, S., Boeyen, S.,
+                Housley, R., and W. Polk, "Internet X.509 Public Key
+                Infrastructure Certificate and Certificate Revocation
+                List (CRL) Profile", RFC 5280, May 2008.
+
+   [RFC6265]    Barth, A., "HTTP State Management Mechanism", RFC 6265,
+                April 2011.
+
+   [RFC6749]    Hardt, D., Ed., "The OAuth 2.0 Authorization Framework",
+                RFC 6749, October 2012.
+
+   [USASCII]    American National Standards Institute, "Coded Character
+                Set -- 7-bit American Standard Code for Information
+                Interchange", ANSI X3.4, 1986.
+
+   [W3C.REC-html401-19991224]
+                Raggett, D., Le Hors, A., and I. Jacobs, "HTML 4.01
+                Specification", World Wide Web Consortium
+                Recommendation REC-html401-19991224, December 1999,
+                <http://www.w3.org/TR/1999/REC-html401-19991224>.
+
+   [W3C.REC-webarch-20041215]
+                Jacobs, I. and N. Walsh, "Architecture of the World Wide
+                Web, Volume One", World Wide Web Consortium
+                Recommendation REC-webarch-20041215, December 2004,
+                <http://www.w3.org/TR/2004/REC-webarch-20041215>.
+
+
+
+
+
+
+
+Jones & Hardt                Standards Track                   [Page 16]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+7.2.  Informative References
+
+   [HTTP-AUTH]  Fielding, R., Ed., and J. Reschke, Ed., "Hypertext
+                Transfer Protocol (HTTP/1.1): Authentication", Work
+                in Progress, October 2012.
+
+   [NIST800-63] Burr, W., Dodson, D., Newton, E., Perlner, R., Polk, T.,
+                Gupta, S., and E. Nabbus, "NIST Special Publication
+                800-63-1, INFORMATION SECURITY", December 2011,
+                <http://csrc.nist.gov/publications/>.
+
+   [OMAP]       Huff, J., Schlacht, D., Nadalin, A., Simmons, J.,
+                Rosenberg, P., Madsen, P., Ace, T., Rickelton-Abdi, C.,
+                and B. Boyer, "Online Multimedia Authorization Protocol:
+                An Industry Standard for Authorized Access to Internet
+                Multimedia Resources", April 2012,
+                <http://www.oatc.us/Standards/Download.aspx>.
+
+   [OpenID.Messages]
+                Sakimura, N., Bradley, J., Jones, M., de Medeiros, B.,
+                Mortimore, C., and E. Jay, "OpenID Connect Messages
+                1.0", June 2012, <http://openid.net/specs/
+                openid-connect-messages-1_0.html>.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Jones & Hardt                Standards Track                   [Page 17]
+
+RFC 6750              OAuth 2.0 Bearer Token Usage          October 2012
+
+
+Appendix A.  Acknowledgements
+
+   The following people contributed to preliminary versions of this
+   document: Blaine Cook (BT), Brian Eaton (Google), Yaron Y. Goland
+   (Microsoft), Brent Goldman (Facebook), Raffi Krikorian (Twitter),
+   Luke Shepard (Facebook), and Allen Tom (Yahoo!).  The content and
+   concepts within are a product of the OAuth community, the Web
+   Resource Authorization Profiles (WRAP) community, and the OAuth
+   Working Group.  David Recordon created a preliminary version of this
+   specification based upon an early draft of the specification that
+   evolved into OAuth 2.0 [RFC6749].  Michael B. Jones in turn created
+   the first version (00) of this specification using portions of
+   David's preliminary document and edited all subsequent versions.
+
+   The OAuth Working Group has dozens of very active contributors who
+   proposed ideas and wording for this document, including Michael
+   Adams, Amanda Anganes, Andrew Arnott, Derek Atkins, Dirk Balfanz,
+   John Bradley, Brian Campbell, Francisco Corella, Leah Culver, Bill de
+   hOra, Breno de Medeiros, Brian Ellin, Stephen Farrell, Igor Faynberg,
+   George Fletcher, Tim Freeman, Evan Gilbert, Yaron Y. Goland, Eran
+   Hammer, Thomas Hardjono, Dick Hardt, Justin Hart, Phil Hunt, John
+   Kemp, Chasen Le Hara, Barry Leiba, Amos Jeffries, Michael B. Jones,
+   Torsten Lodderstedt, Paul Madsen, Eve Maler, James Manger, Laurence
+   Miao, William J. Mills, Chuck Mortimore, Anthony Nadalin, Axel
+   Nennker, Mark Nottingham, David Recordon, Julian Reschke, Rob
+   Richards, Justin Richer, Peter Saint-Andre, Nat Sakimura, Rob Sayre,
+   Marius Scurtescu, Naitik Shah, Justin Smith, Christian Stuebner,
+   Jeremy Suriel, Doug Tangren, Paul Tarjan, Hannes Tschofenig, Franklin
+   Tse, Sean Turner, Paul Walker, Shane Weeden, Skylar Woodward, and
+   Zachary Zeltsan.
+
+Authors' Addresses
+
+   Michael B. Jones
+   Microsoft
+
+   EMail: mbj@microsoft.com
+   URI:   http://self-issued.info/
+
+
+   Dick Hardt
+   Independent
+
+   EMail: dick.hardt@gmail.com
+   URI:   http://dickhardt.org/
+
+
+
+
+
+
+Jones & Hardt                Standards Track                   [Page 18]
+

--- a/rfc/rfc7009.txt
+++ b/rfc/rfc7009.txt
@@ -1,0 +1,619 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)               T. Lodderstedt, Ed.
+Request for Comments: 7009                           Deutsche Telekom AG
+Category: Standards Track                                      S. Dronia
+ISSN: 2070-1721
+                                                            M. Scurtescu
+                                                                  Google
+                                                             August 2013
+
+
+                       OAuth 2.0 Token Revocation
+
+Abstract
+
+   This document proposes an additional endpoint for OAuth authorization
+   servers, which allows clients to notify the authorization server that
+   a previously obtained refresh or access token is no longer needed.
+   This allows the authorization server to clean up security
+   credentials.  A revocation request will invalidate the actual token
+   and, if applicable, other tokens based on the same authorization
+   grant.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7009.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Lodderstedt, et al.          Standards Track                    [Page 1]
+
+RFC 7009                    Token Revocation                 August 2013
+
+
+Copyright Notice
+
+   Copyright (c) 2013 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+     1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   3
+   2.  Token Revocation  . . . . . . . . . . . . . . . . . . . . . .   3
+     2.1.  Revocation Request  . . . . . . . . . . . . . . . . . . .   4
+     2.2.  Revocation Response . . . . . . . . . . . . . . . . . . .   5
+       2.2.1.  Error Response  . . . . . . . . . . . . . . . . . . .   6
+     2.3.  Cross-Origin Support  . . . . . . . . . . . . . . . . . .   6
+   3.  Implementation Note . . . . . . . . . . . . . . . . . . . . .   7
+   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   8
+     4.1.  OAuth Extensions Error Registration . . . . . . . . . . .   8
+       4.1.1.  The "unsupported_token_type" Error Value  . . . . . .   8
+       4.1.2.  OAuth Token Type Hints Registry . . . . . . . . . . .   8
+         4.1.2.1.  Registration Template . . . . . . . . . . . . . .   9
+         4.1.2.2.  Initial Registry Contents . . . . . . . . . . . .   9
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . .   9
+   6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  10
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  10
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  10
+     7.2.  Informative References  . . . . . . . . . . . . . . . . .  11
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Lodderstedt, et al.          Standards Track                    [Page 2]
+
+RFC 7009                    Token Revocation                 August 2013
+
+
+1.  Introduction
+
+   The OAuth 2.0 core specification [RFC6749] defines several ways for a
+   client to obtain refresh and access tokens.  This specification
+   supplements the core specification with a mechanism to revoke both
+   types of tokens.  A token is a string representing an authorization
+   grant issued by the resource owner to the client.  A revocation
+   request will invalidate the actual token and, if applicable, other
+   tokens based on the same authorization grant and the authorization
+   grant itself.
+
+   From an end-user's perspective, OAuth is often used to log into a
+   certain site or application.  This revocation mechanism allows a
+   client to invalidate its tokens if the end-user logs out, changes
+   identity, or uninstalls the respective application.  Notifying the
+   authorization server that the token is no longer needed allows the
+   authorization server to clean up data associated with that token
+   (e.g., session data) and the underlying authorization grant.  This
+   behavior prevents a situation in which there is still a valid
+   authorization grant for a particular client of which the end-user is
+   not aware.  This way, token revocation prevents abuse of abandoned
+   tokens and facilitates a better end-user experience since invalidated
+   authorization grants will no longer turn up in a list of
+   authorization grants the authorization server might present to the
+   end-user.
+
+1.1.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+2.  Token Revocation
+
+   Implementations MUST support the revocation of refresh tokens and
+   SHOULD support the revocation of access tokens (see Implementation
+   Note).
+
+   The client requests the revocation of a particular token by making an
+   HTTP POST request to the token revocation endpoint URL.  This URL
+   MUST conform to the rules given in [RFC6749], Section 3.1.  Clients
+   MUST verify that the URL is an HTTPS URL.
+
+   The means to obtain the location of the revocation endpoint is out of
+   the scope of this specification.  For example, the client developer
+   may consult the server's documentation or automatic discovery may be
+   used.  As this endpoint is handling security credentials, the
+   endpoint location needs to be obtained from a trustworthy source.
+
+
+
+Lodderstedt, et al.          Standards Track                    [Page 3]
+
+RFC 7009                    Token Revocation                 August 2013
+
+
+   Since requests to the token revocation endpoint result in the
+   transmission of plaintext credentials in the HTTP request, URLs for
+   token revocation endpoints MUST be HTTPS URLs.  The authorization
+   server MUST use Transport Layer Security (TLS) [RFC5246] in a version
+   compliant with [RFC6749], Section 1.6.  Implementations MAY also
+   support additional transport-layer security mechanisms that meet
+   their security requirements.
+
+   If the host of the token revocation endpoint can also be reached over
+   HTTP, then the server SHOULD also offer a revocation service at the
+   corresponding HTTP URI, but it MUST NOT publish this URI as a token
+   revocation endpoint.  This ensures that tokens accidentally sent over
+   HTTP will be revoked.
+
+2.1.  Revocation Request
+
+   The client constructs the request by including the following
+   parameters using the "application/x-www-form-urlencoded" format in
+   the HTTP request entity-body:
+
+   token   REQUIRED.  The token that the client wants to get revoked.
+
+   token_type_hint  OPTIONAL.  A hint about the type of the token
+           submitted for revocation.  Clients MAY pass this parameter in
+           order to help the authorization server to optimize the token
+           lookup.  If the server is unable to locate the token using
+           the given hint, it MUST extend its search across all of its
+           supported token types.  An authorization server MAY ignore
+           this parameter, particularly if it is able to detect the
+           token type automatically.  This specification defines two
+           such values:
+
+           * access_token: An access token as defined in [RFC6749],
+             Section 1.4
+
+           * refresh_token: A refresh token as defined in [RFC6749],
+             Section 1.5
+
+           Specific implementations, profiles, and extensions of this
+           specification MAY define other values for this parameter
+           using the registry defined in Section 4.1.2.
+
+   The client also includes its authentication credentials as described
+   in Section 2.3. of [RFC6749].
+
+
+
+
+
+
+
+Lodderstedt, et al.          Standards Track                    [Page 4]
+
+RFC 7009                    Token Revocation                 August 2013
+
+
+   For example, a client may request the revocation of a refresh token
+   with the following request:
+
+     POST /revoke HTTP/1.1
+     Host: server.example.com
+     Content-Type: application/x-www-form-urlencoded
+     Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW
+
+     token=45ghiukldjahdnhzdauz&token_type_hint=refresh_token
+
+   The authorization server first validates the client credentials (in
+   case of a confidential client) and then verifies whether the token
+   was issued to the client making the revocation request.  If this
+   validation fails, the request is refused and the client is informed
+   of the error by the authorization server as described below.
+
+   In the next step, the authorization server invalidates the token.
+   The invalidation takes place immediately, and the token cannot be
+   used again after the revocation.  In practice, there could be a
+   propagation delay, for example, in which some servers know about the
+   invalidation while others do not.  Implementations should minimize
+   that window, and clients must not try to use the token after receipt
+   of an HTTP 200 response from the server.
+
+   Depending on the authorization server's revocation policy, the
+   revocation of a particular token may cause the revocation of related
+   tokens and the underlying authorization grant.  If the particular
+   token is a refresh token and the authorization server supports the
+   revocation of access tokens, then the authorization server SHOULD
+   also invalidate all access tokens based on the same authorization
+   grant (see Implementation Note).  If the token passed to the request
+   is an access token, the server MAY revoke the respective refresh
+   token as well.
+
+   Note: A client compliant with [RFC6749] must be prepared to handle
+   unexpected token invalidation at any time.  Independent of the
+   revocation mechanism specified in this document, resource owners may
+   revoke authorization grants, or the authorization server may
+   invalidate tokens in order to mitigate security threats.  Thus,
+   having different server policies with respect to cascading the
+   revocation of tokens should not pose interoperability problems.
+
+2.2.  Revocation Response
+
+   The authorization server responds with HTTP status code 200 if the
+   token has been revoked successfully or if the client submitted an
+   invalid token.
+
+
+
+
+Lodderstedt, et al.          Standards Track                    [Page 5]
+
+RFC 7009                    Token Revocation                 August 2013
+
+
+   Note: invalid tokens do not cause an error response since the client
+   cannot handle such an error in a reasonable way.  Moreover, the
+   purpose of the revocation request, invalidating the particular token,
+   is already achieved.
+
+   The content of the response body is ignored by the client as all
+   necessary information is conveyed in the response code.
+
+   An invalid token type hint value is ignored by the authorization
+   server and does not influence the revocation response.
+
+2.2.1.  Error Response
+
+   The error presentation conforms to the definition in Section 5.2 of
+   [RFC6749].  The following additional error code is defined for the
+   token revocation endpoint:
+
+   unsupported_token_type:  The authorization server does not support
+           the revocation of the presented token type.  That is, the
+           client tried to revoke an access token on a server not
+           supporting this feature.
+
+   If the server responds with HTTP status code 503, the client must
+   assume the token still exists and may retry after a reasonable delay.
+   The server may include a "Retry-After" header in the response to
+   indicate how long the service is expected to be unavailable to the
+   requesting client.
+
+2.3.  Cross-Origin Support
+
+   The revocation endpoint MAY support Cross-Origin Resource Sharing
+   (CORS) [W3C.WD-cors-20120403] if it is aimed at use in combination
+   with user-agent-based applications.
+
+   In addition, for interoperability with legacy user-agents, it MAY
+   also offer JSONP (Remote JSON - JSONP) [jsonp] by allowing GET
+   requests with an additional parameter:
+
+   callback  OPTIONAL.  The qualified name of a JavaScript function.
+
+   For example, a client may request the revocation of an access token
+   with the following request (line breaks are for display purposes
+   only):
+
+     https://example.com/revoke?token=agabcdefddddafdd&
+     callback=package.myCallback
+
+
+
+
+
+Lodderstedt, et al.          Standards Track                    [Page 6]
+
+RFC 7009                    Token Revocation                 August 2013
+
+
+   Successful response:
+
+     package.myCallback();
+
+   Error response:
+
+     package.myCallback({"error":"unsupported_token_type"});
+
+   Clients should be aware that when relying on JSONP, a malicious
+   revocation endpoint may attempt to inject malicious code into the
+   client.
+
+3.  Implementation Note
+
+   OAuth 2.0 allows deployment flexibility with respect to the style of
+   access tokens.  The access tokens may be self-contained so that a
+   resource server needs no further interaction with an authorization
+   server issuing these tokens to perform an authorization decision of
+   the client requesting access to a protected resource.  A system
+   design may, however, instead use access tokens that are handles
+   referring to authorization data stored at the authorization server.
+   This consequently requires a resource server to issue a request to
+   the respective authorization server to retrieve the content of the
+   access token every time a client presents an access token.
+
+   While these are not the only options, they illustrate the
+   implications for revocation.  In the latter case, the authorization
+   server is able to revoke an access token previously issued to a
+   client when the resource server relays a received access token.  In
+   the former case, some (currently non-standardized) backend
+   interaction between the authorization server and the resource server
+   may be used when immediate access token revocation is desired.
+   Another design alternative is to issue short-lived access tokens,
+   which can be refreshed at any time using the corresponding refresh
+   tokens.  This allows the authorization server to impose a limit on
+   the time revoked when access tokens are in use.
+
+   Which approach of token revocation is chosen will depend on the
+   overall system design and on the application service provider's risk
+   analysis.  The cost of revocation in terms of required state and
+   communication overhead is ultimately the result of the desired
+   security properties.
+
+
+
+
+
+
+
+
+
+Lodderstedt, et al.          Standards Track                    [Page 7]
+
+RFC 7009                    Token Revocation                 August 2013
+
+
+4.  IANA Considerations
+
+   This specification registers an error value in the "OAuth Extensions
+   Error Registry" and establishes the "OAuth Token Type Hints"
+   registry.
+
+4.1.  OAuth Extensions Error Registration
+
+   This specification registers the following error value in the "OAuth
+   Extensions Error Registry" defined in [RFC6749].
+
+4.1.1.  The "unsupported_token_type" Error Value
+
+   Error name:  unsupported_token_type
+
+   Error Usage Location:  Revocation endpoint error response
+
+   Related Protocol Extension:  Token Revocation Endpoint
+
+   Change controller:  IETF
+
+   Specification document(s):  [RFC7009]
+
+4.1.2.  OAuth Token Type Hints Registry
+
+   This specification establishes the "OAuth Token Type Hints" registry.
+   Possible values of the parameter "token_type_hint" (see Section 2.1)
+   are registered with a Specification Required ([RFC5226]) after a two-
+   week review period on the oauth-ext-review@ietf.org mailing list, on
+   the advice of one or more Designated Experts.  However, to allow for
+   the allocation of values prior to publication, the Designated
+   Expert(s) may approve registration once they are satisfied that such
+   a specification will be published.  Registration requests must be
+   sent to the oauth-ext-review@ietf.org mailing list for review and
+   comment, with an appropriate subject (e.g., "Request for parameter:
+   example").  Within the review period, the Designated Expert(s) will
+   either approve or deny the registration request, communicating this
+   decision to the review list and IANA.  Denials should include an
+   explanation and, if applicable, suggestions as to how to make the
+   request successful.  IANA must only accept registry updates from the
+   Designated Expert(s) and should direct all requests for registration
+   to the review mailing list.
+
+
+
+
+
+
+
+
+
+Lodderstedt, et al.          Standards Track                    [Page 8]
+
+RFC 7009                    Token Revocation                 August 2013
+
+
+4.1.2.1.  Registration Template
+
+   Hint Value:  The additional value, which can be used to indicate a
+      certain token type to the authorization server.
+
+   Change controller:  For Standards Track RFCs, state "IETF".  For
+      others, give the name of the responsible party.  Other details
+      (e.g., postal address, email address, and home page URI) may also
+      be included.
+
+   Specification document(s):  Reference to the document(s) that
+      specifies the type, preferably including a URI that can be used to
+      retrieve a copy of the document(s).  An indication of the relevant
+      sections may also be included but is not required.
+
+4.1.2.2.  Initial Registry Contents
+
+   The OAuth Token Type Hint registry's initial contents are as follows.
+
+             +---------------+-------------------+-----------+
+             |   Hint Value  | Change Controller | Reference |
+             +---------------+-------------------+-----------+
+             |  access_token |        IETF       | [RFC7009] |
+             | refresh_token |        IETF       | [RFC7009] |
+             +---------------+-------------------+-----------+
+
+         Table 1: OAuth Token Type Hints initial registry contents
+
+5.  Security Considerations
+
+   If the authorization server does not support access token revocation,
+   access tokens will not be immediately invalidated when the
+   corresponding refresh token is revoked.  Deployments must take this
+   into account when conducting their security risk analysis.
+
+   Cleaning up tokens using revocation contributes to overall security
+   and privacy since it reduces the likelihood for abuse of abandoned
+   tokens.  This specification in general does not intend to provide
+   countermeasures against token theft and abuse.  For a discussion of
+   respective threats and countermeasures, consult the security
+   considerations given in Section 10 of the OAuth core specification
+   [RFC6749] and the OAuth threat model document [RFC6819].
+
+   Malicious clients could attempt to use the new endpoint to launch
+   denial-of-service attacks on the authorization server.  Appropriate
+   countermeasures, which should be in place for the token endpoint as
+   well, MUST be applied to the revocation endpoint (see [RFC6819],
+   Section 4.4.1.11).  Specifically, invalid token type hints may
+
+
+
+Lodderstedt, et al.          Standards Track                    [Page 9]
+
+RFC 7009                    Token Revocation                 August 2013
+
+
+   misguide the authorization server and cause additional database
+   lookups.  Care MUST be taken to prevent malicious clients from
+   exploiting this feature to launch denial-of-service attacks.
+
+   A malicious client may attempt to guess valid tokens on this endpoint
+   by making revocation requests against potential token strings.
+   According to this specification, a client's request must contain a
+   valid client_id, in the case of a public client, or valid client
+   credentials, in the case of a confidential client.  The token being
+   revoked must also belong to the requesting client.  If an attacker is
+   able to successfully guess a public client's client_id and one of
+   their tokens, or a private client's credentials and one of their
+   tokens, they could do much worse damage by using the token elsewhere
+   than by revoking it.  If they chose to revoke the token, the
+   legitimate client will lose its authorization grant and will need to
+   prompt the user again.  No further damage is done and the guessed
+   token is now worthless.
+
+   Since the revocation endpoint is handling security credentials,
+   clients need to obtain its location from a trustworthy source only.
+   Otherwise, an attacker could capture valid security tokens by
+   utilizing a counterfeit revocation endpoint.  Moreover, in order to
+   detect counterfeit revocation endpoints, clients MUST authenticate
+   the revocation endpoint (certificate validation, etc.).
+
+6.  Acknowledgements
+
+   We would like to thank Peter Mauritius, Amanda Anganes, Mark Wubben,
+   Hannes Tschofenig, Michiel de Jong, Doug Foiles, Paul Madsen, George
+   Fletcher, Sebastian Ebling, Christian Stuebner, Brian Campbell, Igor
+   Faynberg, Lukas Rosenstock, and Justin Richer for their valuable
+   feedback.
+
+7.  References
+
+7.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              May 2008.
+
+   [RFC5246]  Dierks, T. and E. Rescorla, "The Transport Layer Security
+              (TLS) Protocol Version 1.2", RFC 5246, August 2008.
+
+
+
+
+
+Lodderstedt, et al.          Standards Track                   [Page 10]
+
+RFC 7009                    Token Revocation                 August 2013
+
+
+   [RFC6749]  Hardt, D., "The OAuth 2.0 Authorization Framework",
+              RFC 6749, October 2012.
+
+7.2.  Informative References
+
+   [RFC6819]  Lodderstedt, T., McGloin, M., and P. Hunt, "OAuth 2.0
+              Threat Model and Security Considerations", RFC 6819,
+              January 2013.
+
+   [W3C.WD-cors-20120403]
+              Kesteren, A., "Cross-Origin Resource Sharing", World Wide
+              Web Consortium LastCall WD-cors-20120403, April 2012,
+              <http://www.w3.org/TR/2012/WD-cors-20120403>.
+
+   [jsonp]    Ippolito, B., "Remote JSON - JSONP", December 2005,
+              <http://bob.pythonmac.org/archives/2005/12/05/
+              remote-json-jsonp>.
+
+Authors' Addresses
+
+   Torsten Lodderstedt (editor)
+   Deutsche Telekom AG
+
+   EMail: torsten@lodderstedt.net
+
+
+   Stefanie Dronia
+
+   EMail: sdronia@gmx.de
+
+
+   Marius Scurtescu
+   Google
+
+   EMail: mscurtescu@google.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Lodderstedt, et al.          Standards Track                   [Page 11]
+

--- a/rfc/rfc7636.txt
+++ b/rfc/rfc7636.txt
@@ -1,0 +1,1123 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                  N. Sakimura, Ed.
+Request for Comments: 7636                     Nomura Research Institute
+Category: Standards Track                                     J. Bradley
+ISSN: 2070-1721                                            Ping Identity
+                                                              N. Agarwal
+                                                                  Google
+                                                          September 2015
+
+
+          Proof Key for Code Exchange by OAuth Public Clients
+
+Abstract
+
+   OAuth 2.0 public clients utilizing the Authorization Code Grant are
+   susceptible to the authorization code interception attack.  This
+   specification describes the attack as well as a technique to mitigate
+   against the threat through the use of Proof Key for Code Exchange
+   (PKCE, pronounced "pixy").
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7636.
+
+Copyright Notice
+
+   Copyright (c) 2015 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+Sakimura, et al.             Standards Track                    [Page 1]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+Table of Contents
+
+   1. Introduction ....................................................3
+      1.1. Protocol Flow ..............................................5
+   2. Notational Conventions ..........................................6
+   3. Terminology .....................................................7
+      3.1. Abbreviations ..............................................7
+   4. Protocol ........................................................8
+      4.1. Client Creates a Code Verifier .............................8
+      4.2. Client Creates the Code Challenge ..........................8
+      4.3. Client Sends the Code Challenge with the
+           Authorization Request ......................................9
+      4.4. Server Returns the Code ....................................9
+           4.4.1. Error Response ......................................9
+      4.5. Client Sends the Authorization Code and the Code
+           Verifier to the Token Endpoint ............................10
+      4.6. Server Verifies code_verifier before Returning the
+           Tokens ....................................................10
+   5. Compatibility ..................................................11
+   6. IANA Considerations ............................................11
+      6.1. OAuth Parameters Registry .................................11
+      6.2. PKCE Code Challenge Method Registry .......................11
+           6.2.1. Registration Template ..............................12
+           6.2.2. Initial Registry Contents ..........................13
+   7. Security Considerations ........................................13
+      7.1. Entropy of the code_verifier ..............................13
+      7.2. Protection against Eavesdroppers ..........................13
+      7.3. Salting the code_challenge ................................14
+      7.4. OAuth Security Considerations .............................14
+      7.5. TLS Security Considerations ...............................15
+   8. References .....................................................15
+      8.1. Normative References ......................................15
+      8.2. Informative References ....................................16
+   Appendix A.  Notes on Implementing Base64url Encoding without
+                Padding  .............................................17
+   Appendix B.  Example for the S256 code_challenge_method ...........17
+   Acknowledgements ..................................................19
+   Authors' Addresses ................................................20
+
+
+
+
+
+
+
+
+
+
+
+
+
+Sakimura, et al.             Standards Track                    [Page 2]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+1.  Introduction
+
+   OAuth 2.0 [RFC6749] public clients are susceptible to the
+   authorization code interception attack.
+
+   In this attack, the attacker intercepts the authorization code
+   returned from the authorization endpoint within a communication path
+   not protected by Transport Layer Security (TLS), such as inter-
+   application communication within the client's operating system.
+
+   Once the attacker has gained access to the authorization code, it can
+   use it to obtain the access token.
+
+   Figure 1 shows the attack graphically.  In step (1), the native
+   application running on the end device, such as a smartphone, issues
+   an OAuth 2.0 Authorization Request via the browser/operating system.
+   The Redirection Endpoint URI in this case typically uses a custom URI
+   scheme.  Step (1) happens through a secure API that cannot be
+   intercepted, though it may potentially be observed in advanced attack
+   scenarios.  The request then gets forwarded to the OAuth 2.0
+   authorization server in step (2).  Because OAuth requires the use of
+   TLS, this communication is protected by TLS and cannot be
+   intercepted.  The authorization server returns the authorization code
+   in step (3).  In step (4), the Authorization Code is returned to the
+   requester via the Redirection Endpoint URI that was provided in step
+   (1).
+
+   Note that it is possible for a malicious app to register itself as a
+   handler for the custom scheme in addition to the legitimate OAuth 2.0
+   app.  Once it does so, the malicious app is now able to intercept the
+   authorization code in step (4).  This allows the attacker to request
+   and obtain an access token in steps (5) and (6), respectively.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Sakimura, et al.             Standards Track                    [Page 3]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+    +~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
+    | End Device (e.g., Smartphone)  |
+    |                                |
+    | +-------------+   +----------+ | (6) Access Token  +----------+
+    | |Legitimate   |   | Malicious|<--------------------|          |
+    | |OAuth 2.0 App|   | App      |-------------------->|          |
+    | +-------------+   +----------+ | (5) Authorization |          |
+    |        |    ^          ^       |        Grant      |          |
+    |        |     \         |       |                   |          |
+    |        |      \   (4)  |       |                   |          |
+    |    (1) |       \  Authz|       |                   |          |
+    |   Authz|        \ Code |       |                   |  Authz   |
+    | Request|         \     |       |                   |  Server  |
+    |        |          \    |       |                   |          |
+    |        |           \   |       |                   |          |
+    |        v            \  |       |                   |          |
+    | +----------------------------+ |                   |          |
+    | |                            | | (3) Authz Code    |          |
+    | |     Operating System/      |<--------------------|          |
+    | |         Browser            |-------------------->|          |
+    | |                            | | (2) Authz Request |          |
+    | +----------------------------+ |                   +----------+
+    +~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
+
+             Figure 1: Authorization Code Interception Attack
+
+   A number of pre-conditions need to hold for this attack to work:
+
+   1. The attacker manages to register a malicious application on the
+      client device and registers a custom URI scheme that is also used
+      by another application.  The operating systems must allow a custom
+      URI scheme to be registered by multiple applications.
+
+   2. The OAuth 2.0 authorization code grant is used.
+
+   3. The attacker has access to the OAuth 2.0 [RFC6749] "client_id" and
+      "client_secret" (if provisioned).  All OAuth 2.0 native app
+      client-instances use the same "client_id".  Secrets provisioned in
+      client binary applications cannot be considered confidential.
+
+   4. Either one of the following condition is met:
+
+      4a. The attacker (via the installed application) is able to
+          observe only the responses from the authorization endpoint.
+          When "code_challenge_method" value is "plain", only this
+          attack is mitigated.
+
+
+
+
+
+Sakimura, et al.             Standards Track                    [Page 4]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+      4b. A more sophisticated attack scenario allows the attacker to
+          observe requests (in addition to responses) to the
+          authorization endpoint.  The attacker is, however, not able to
+          act as a man in the middle.  This was caused by leaking http
+          log information in the OS.  To mitigate this,
+          "code_challenge_method" value must be set either to "S256" or
+          a value defined by a cryptographically secure
+          "code_challenge_method" extension.
+
+   While this is a long list of pre-conditions, the described attack has
+   been observed in the wild and has to be considered in OAuth 2.0
+   deployments.  While the OAuth 2.0 threat model (Section 4.4.1 of
+   [RFC6819]) describes mitigation techniques, they are, unfortunately,
+   not applicable since they rely on a per-client instance secret or a
+   per-client instance redirect URI.
+
+   To mitigate this attack, this extension utilizes a dynamically
+   created cryptographically random key called "code verifier".  A
+   unique code verifier is created for every authorization request, and
+   its transformed value, called "code challenge", is sent to the
+   authorization server to obtain the authorization code.  The
+   authorization code obtained is then sent to the token endpoint with
+   the "code verifier", and the server compares it with the previously
+   received request code so that it can perform the proof of possession
+   of the "code verifier" by the client.  This works as the mitigation
+   since the attacker would not know this one-time key, since it is sent
+   over TLS and cannot be intercepted.
+
+1.1.  Protocol Flow
+
+                                                 +-------------------+
+                                                 |   Authz Server    |
+       +--------+                                | +---------------+ |
+       |        |--(A)- Authorization Request ---->|               | |
+       |        |       + t(code_verifier), t_m  | | Authorization | |
+       |        |                                | |    Endpoint   | |
+       |        |<-(B)---- Authorization Code -----|               | |
+       |        |                                | +---------------+ |
+       | Client |                                |                   |
+       |        |                                | +---------------+ |
+       |        |--(C)-- Access Token Request ---->|               | |
+       |        |          + code_verifier       | |    Token      | |
+       |        |                                | |   Endpoint    | |
+       |        |<-(D)------ Access Token ---------|               | |
+       +--------+                                | +---------------+ |
+                                                 +-------------------+
+
+                     Figure 2: Abstract Protocol Flow
+
+
+
+Sakimura, et al.             Standards Track                    [Page 5]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+   This specification adds additional parameters to the OAuth 2.0
+   Authorization and Access Token Requests, shown in abstract form in
+   Figure 2.
+
+   A. The client creates and records a secret named the "code_verifier"
+      and derives a transformed version "t(code_verifier)" (referred to
+      as the "code_challenge"), which is sent in the OAuth 2.0
+      Authorization Request along with the transformation method "t_m".
+
+   B. The Authorization Endpoint responds as usual but records
+      "t(code_verifier)" and the transformation method.
+
+   C. The client then sends the authorization code in the Access Token
+      Request as usual but includes the "code_verifier" secret generated
+      at (A).
+
+   D. The authorization server transforms "code_verifier" and compares
+      it to "t(code_verifier)" from (B).  Access is denied if they are
+      not equal.
+
+   An attacker who intercepts the authorization code at (B) is unable to
+   redeem it for an access token, as they are not in possession of the
+   "code_verifier" secret.
+
+2.  Notational Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   "Key words for use in RFCs to Indicate Requirement Levels" [RFC2119].
+   If these words are used without being spelled in uppercase, then they
+   are to be interpreted with their natural language meanings.
+
+   This specification uses the Augmented Backus-Naur Form (ABNF)
+   notation of [RFC5234].
+
+   STRING denotes a sequence of zero or more ASCII [RFC20] characters.
+
+   OCTETS denotes a sequence of zero or more octets.
+
+   ASCII(STRING) denotes the octets of the ASCII [RFC20] representation
+   of STRING where STRING is a sequence of zero or more ASCII
+   characters.
+
+   BASE64URL-ENCODE(OCTETS) denotes the base64url encoding of OCTETS,
+   per Appendix A, producing a STRING.
+
+
+
+
+
+Sakimura, et al.             Standards Track                    [Page 6]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+   BASE64URL-DECODE(STRING) denotes the base64url decoding of STRING,
+   per Appendix A, producing a sequence of octets.
+
+   SHA256(OCTETS) denotes a SHA2 256-bit hash [RFC6234] of OCTETS.
+
+3.  Terminology
+
+   In addition to the terms defined in OAuth 2.0 [RFC6749], this
+   specification defines the following terms:
+
+   code verifier
+      A cryptographically random string that is used to correlate the
+      authorization request to the token request.
+
+   code challenge
+      A challenge derived from the code verifier that is sent in the
+      authorization request, to be verified against later.
+
+   code challenge method
+      A method that was used to derive code challenge.
+
+   Base64url Encoding
+      Base64 encoding using the URL- and filename-safe character set
+      defined in Section 5 of [RFC4648], with all trailing '='
+      characters omitted (as permitted by Section 3.2 of [RFC4648]) and
+      without the inclusion of any line breaks, whitespace, or other
+      additional characters.  (See Appendix A for notes on implementing
+      base64url encoding without padding.)
+
+3.1.  Abbreviations
+
+   ABNF   Augmented Backus-Naur Form
+
+   Authz  Authorization
+
+   PKCE   Proof Key for Code Exchange
+
+   MITM   Man-in-the-middle
+
+   MTI    Mandatory To Implement
+
+
+
+
+
+
+
+
+
+
+
+Sakimura, et al.             Standards Track                    [Page 7]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+4.  Protocol
+
+4.1.  Client Creates a Code Verifier
+
+   The client first creates a code verifier, "code_verifier", for each
+   OAuth 2.0 [RFC6749] Authorization Request, in the following manner:
+
+   code_verifier = high-entropy cryptographic random STRING using the
+   unreserved characters [A-Z] / [a-z] / [0-9] / "-" / "." / "_" / "~"
+   from Section 2.3 of [RFC3986], with a minimum length of 43 characters
+   and a maximum length of 128 characters.
+
+   ABNF for "code_verifier" is as follows.
+
+   code-verifier = 43*128unreserved
+   unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
+   ALPHA = %x41-5A / %x61-7A
+   DIGIT = %x30-39
+
+   NOTE: The code verifier SHOULD have enough entropy to make it
+   impractical to guess the value.  It is RECOMMENDED that the output of
+   a suitable random number generator be used to create a 32-octet
+   sequence.  The octet sequence is then base64url-encoded to produce a
+   43-octet URL safe string to use as the code verifier.
+
+4.2.  Client Creates the Code Challenge
+
+   The client then creates a code challenge derived from the code
+   verifier by using one of the following transformations on the code
+   verifier:
+
+   plain
+      code_challenge = code_verifier
+
+   S256
+      code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))
+
+   If the client is capable of using "S256", it MUST use "S256", as
+   "S256" is Mandatory To Implement (MTI) on the server.  Clients are
+   permitted to use "plain" only if they cannot support "S256" for some
+   technical reason and know via out-of-band configuration that the
+   server supports "plain".
+
+   The plain transformation is for compatibility with existing
+   deployments and for constrained environments that can't use the S256
+   transformation.
+
+
+
+
+
+Sakimura, et al.             Standards Track                    [Page 8]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+   ABNF for "code_challenge" is as follows.
+
+   code-challenge = 43*128unreserved
+   unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
+   ALPHA = %x41-5A / %x61-7A
+   DIGIT = %x30-39
+
+4.3.  Client Sends the Code Challenge with the Authorization Request
+
+   The client sends the code challenge as part of the OAuth 2.0
+   Authorization Request (Section 4.1.1 of [RFC6749]) using the
+   following additional parameters:
+
+   code_challenge
+      REQUIRED.  Code challenge.
+
+   code_challenge_method
+      OPTIONAL, defaults to "plain" if not present in the request.  Code
+      verifier transformation method is "S256" or "plain".
+
+4.4.  Server Returns the Code
+
+   When the server issues the authorization code in the authorization
+   response, it MUST associate the "code_challenge" and
+   "code_challenge_method" values with the authorization code so it can
+   be verified later.
+
+   Typically, the "code_challenge" and "code_challenge_method" values
+   are stored in encrypted form in the "code" itself but could
+   alternatively be stored on the server associated with the code.  The
+   server MUST NOT include the "code_challenge" value in client requests
+   in a form that other entities can extract.
+
+   The exact method that the server uses to associate the
+   "code_challenge" with the issued "code" is out of scope for this
+   specification.
+
+4.4.1.  Error Response
+
+   If the server requires Proof Key for Code Exchange (PKCE) by OAuth
+   public clients and the client does not send the "code_challenge" in
+   the request, the authorization endpoint MUST return the authorization
+   error response with the "error" value set to "invalid_request".  The
+   "error_description" or the response of "error_uri" SHOULD explain the
+   nature of error, e.g., code challenge required.
+
+
+
+
+
+
+Sakimura, et al.             Standards Track                    [Page 9]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+   If the server supporting PKCE does not support the requested
+   transformation, the authorization endpoint MUST return the
+   authorization error response with "error" value set to
+   "invalid_request".  The "error_description" or the response of
+   "error_uri" SHOULD explain the nature of error, e.g., transform
+   algorithm not supported.
+
+4.5.  Client Sends the Authorization Code and the Code Verifier to the
+      Token Endpoint
+
+   Upon receipt of the Authorization Code, the client sends the Access
+   Token Request to the token endpoint.  In addition to the parameters
+   defined in the OAuth 2.0 Access Token Request (Section 4.1.3 of
+   [RFC6749]), it sends the following parameter:
+
+   code_verifier
+      REQUIRED.  Code verifier
+
+   The "code_challenge_method" is bound to the Authorization Code when
+   the Authorization Code is issued.  That is the method that the token
+   endpoint MUST use to verify the "code_verifier".
+
+4.6.  Server Verifies code_verifier before Returning the Tokens
+
+   Upon receipt of the request at the token endpoint, the server
+   verifies it by calculating the code challenge from the received
+   "code_verifier" and comparing it with the previously associated
+   "code_challenge", after first transforming it according to the
+   "code_challenge_method" method specified by the client.
+
+   If the "code_challenge_method" from Section 4.3 was "S256", the
+   received "code_verifier" is hashed by SHA-256, base64url-encoded, and
+   then compared to the "code_challenge", i.e.:
+
+   BASE64URL-ENCODE(SHA256(ASCII(code_verifier))) == code_challenge
+
+   If the "code_challenge_method" from Section 4.3 was "plain", they are
+   compared directly, i.e.:
+
+   code_verifier == code_challenge.
+
+   If the values are equal, the token endpoint MUST continue processing
+   as normal (as defined by OAuth 2.0 [RFC6749]).  If the values are not
+   equal, an error response indicating "invalid_grant" as described in
+   Section 5.2 of [RFC6749] MUST be returned.
+
+
+
+
+
+
+Sakimura, et al.             Standards Track                   [Page 10]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+5.  Compatibility
+
+   Server implementations of this specification MAY accept OAuth2.0
+   clients that do not implement this extension.  If the "code_verifier"
+   is not received from the client in the Authorization Request, servers
+   supporting backwards compatibility revert to the OAuth 2.0 [RFC6749]
+   protocol without this extension.
+
+   As the OAuth 2.0 [RFC6749] server responses are unchanged by this
+   specification, client implementations of this specification do not
+   need to know if the server has implemented this specification or not
+   and SHOULD send the additional parameters as defined in Section 4 to
+   all servers.
+
+6.  IANA Considerations
+
+   IANA has made the following registrations per this document.
+
+6.1.  OAuth Parameters Registry
+
+   This specification registers the following parameters in the IANA
+   "OAuth Parameters" registry defined in OAuth 2.0 [RFC6749].
+
+   o  Parameter name: code_verifier
+   o  Parameter usage location: token request
+   o  Change controller: IESG
+   o  Specification document(s): RFC 7636 (this document)
+
+   o  Parameter name: code_challenge
+   o  Parameter usage location: authorization request
+   o  Change controller: IESG
+   o  Specification document(s): RFC 7636 (this document)
+
+   o  Parameter name: code_challenge_method
+   o  Parameter usage location: authorization request
+   o  Change controller: IESG
+   o  Specification document(s): RFC 7636 (this document)
+
+6.2.  PKCE Code Challenge Method Registry
+
+   This specification establishes the "PKCE Code Challenge Methods"
+   registry.  The new registry should be a sub-registry of the "OAuth
+   Parameters" registry.
+
+   Additional "code_challenge_method" types for use with the
+   authorization endpoint are registered using the Specification
+   Required policy [RFC5226], which includes review of the request by
+   one or more Designated Experts (DEs).  The DEs will ensure that there
+
+
+
+Sakimura, et al.             Standards Track                   [Page 11]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+   is at least a two-week review of the request on the oauth-ext-
+   review@ietf.org mailing list and that any discussion on that list
+   converges before they respond to the request.  To allow for the
+   allocation of values prior to publication, the Designated Expert(s)
+   may approve registration once they are satisfied that an acceptable
+   specification will be published.
+
+   Registration requests and discussion on the oauth-ext-review@ietf.org
+   mailing list should use an appropriate subject, such as "Request for
+   PKCE code_challenge_method: example").
+
+   The Designated Expert(s) should consider the discussion on the
+   mailing list, as well as the overall security properties of the
+   challenge method when evaluating registration requests.  New methods
+   should not disclose the value of the code_verifier in the request to
+   the Authorization endpoint.  Denials should include an explanation
+   and, if applicable, suggestions as to how to make the request
+   successful.
+
+6.2.1.  Registration Template
+
+   Code Challenge Method Parameter Name:
+      The name requested (e.g., "example").  Because a core goal of this
+      specification is for the resulting representations to be compact,
+      it is RECOMMENDED that the name be short -- not to exceed 8
+      characters without a compelling reason to do so.  This name is
+      case-sensitive.  Names may not match other registered names in a
+      case-insensitive manner unless the Designated Expert(s) states
+      that there is a compelling reason to allow an exception in this
+      particular case.
+
+   Change Controller:
+      For Standards Track RFCs, state "IESG".  For others, give the name
+      of the responsible party.  Other details (e.g., postal address,
+      email address, and home page URI) may also be included.
+
+   Specification Document(s):
+      Reference to the document(s) that specifies the parameter,
+      preferably including URI(s) that can be used to retrieve copies of
+      the document(s).  An indication of the relevant sections may also
+      be included but is not required.
+
+
+
+
+
+
+
+
+
+
+Sakimura, et al.             Standards Track                   [Page 12]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+6.2.2.  Initial Registry Contents
+
+   Per this document, IANA has registered the Code Challenge Method
+   Parameter Names defined in Section 4.2 in this registry.
+
+   o  Code Challenge Method Parameter Name: plain
+   o  Change Controller: IESG
+   o  Specification Document(s): Section 4.2 of RFC 7636 (this document)
+
+   o  Code Challenge Method Parameter Name: S256
+   o  Change Controller: IESG
+   o  Specification Document(s): Section 4.2 of RFC 7636 (this document)
+
+7.  Security Considerations
+
+7.1.  Entropy of the code_verifier
+
+   The security model relies on the fact that the code verifier is not
+   learned or guessed by the attacker.  It is vitally important to
+   adhere to this principle.  As such, the code verifier has to be
+   created in such a manner that it is cryptographically random and has
+   high entropy that it is not practical for the attacker to guess.
+
+   The client SHOULD create a "code_verifier" with a minimum of 256 bits
+   of entropy.  This can be done by having a suitable random number
+   generator create a 32-octet sequence.  The octet sequence can then be
+   base64url-encoded to produce a 43-octet URL safe string to use as a
+   "code_challenge" that has the required entropy.
+
+7.2.  Protection against Eavesdroppers
+
+   Clients MUST NOT downgrade to "plain" after trying the "S256" method.
+   Servers that support PKCE are required to support "S256", and servers
+   that do not support PKCE will simply ignore the unknown
+   "code_verifier".  Because of this, an error when "S256" is presented
+   can only mean that the server is faulty or that a MITM attacker is
+   trying a downgrade attack.
+
+   The "S256" method protects against eavesdroppers observing or
+   intercepting the "code_challenge", because the challenge cannot be
+   used without the verifier.  With the "plain" method, there is a
+   chance that "code_challenge" will be observed by the attacker on the
+   device or in the http request.  Since the code challenge is the same
+   as the code verifier in this case, the "plain" method does not
+   protect against the eavesdropping of the initial request.
+
+   The use of "S256" protects against disclosure of the "code_verifier"
+   value to an attacker.
+
+
+
+Sakimura, et al.             Standards Track                   [Page 13]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+   Because of this, "plain" SHOULD NOT be used and exists only for
+   compatibility with deployed implementations where the request path is
+   already protected.  The "plain" method SHOULD NOT be used in new
+   implementations, unless they cannot support "S256" for some technical
+   reason.
+
+   The "S256" code challenge method or other cryptographically secure
+   code challenge method extension SHOULD be used.  The "plain" code
+   challenge method relies on the operating system and transport
+   security not to disclose the request to an attacker.
+
+   If the code challenge method is "plain" and the code challenge is to
+   be returned inside authorization "code" to achieve a stateless
+   server, it MUST be encrypted in such a manner that only the server
+   can decrypt and extract it.
+
+7.3.  Salting the code_challenge
+
+   To reduce implementation complexity, salting is not used in the
+   production of the code challenge, as the code verifier contains
+   sufficient entropy to prevent brute-force attacks.  Concatenating a
+   publicly known value to a code verifier (containing 256 bits of
+   entropy) and then hashing it with SHA256 to produce a code challenge
+   would not increase the number of attempts necessary to brute force a
+   valid value for code verifier.
+
+   While the "S256" transformation is like hashing a password, there are
+   important differences.  Passwords tend to be relatively low-entropy
+   words that can be hashed offline and the hash looked up in a
+   dictionary.  By concatenating a unique though public value to each
+   password prior to hashing, the dictionary space that an attacker
+   needs to search is greatly expanded.
+
+   Modern graphics processors now allow attackers to calculate hashes in
+   real time faster than they could be looked up from a disk.  This
+   eliminates the value of the salt in increasing the complexity of a
+   brute-force attack for even low-entropy passwords.
+
+7.4.  OAuth Security Considerations
+
+   All the OAuth security analysis presented in [RFC6819] applies, so
+   readers SHOULD carefully follow it.
+
+
+
+
+
+
+
+
+
+Sakimura, et al.             Standards Track                   [Page 14]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+7.5.  TLS Security Considerations
+
+   Current security considerations can be found in "Recommendations for
+   Secure Use of Transport Layer Security (TLS) and Datagram Transport
+   Layer Security (DTLS)" [BCP195].  This supersedes the TLS version
+   recommendations in OAuth 2.0 [RFC6749].
+
+8.  References
+
+8.1.  Normative References
+
+   [BCP195]   Sheffer, Y., Holz, R., and P. Saint-Andre,
+              "Recommendations for Secure Use of Transport Layer
+              Security (TLS) and Datagram Transport Layer Security
+              (DTLS)", BCP 195, RFC 7525, May 2015,
+              <http://www.rfc-editor.org/info/bcp195>.
+
+   [RFC20]    Cerf, V., "ASCII format for network interchange", STD 80,
+              RFC 20, DOI 10.17487/RFC0020, October 1969,
+              <http://www.rfc-editor.org/info/rfc20>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <http://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+              Resource Identifier (URI): Generic Syntax", STD 66, RFC
+              3986, DOI 10.17487/RFC3986, January 2005,
+              <http://www.rfc-editor.org/info/rfc3986>.
+
+   [RFC4648]  Josefsson, S., "The Base16, Base32, and Base64 Data
+              Encodings", RFC 4648, DOI 10.17487/RFC4648, October 2006,
+              <http://www.rfc-editor.org/info/rfc4648>.
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              DOI 10.17487/RFC5226, May 2008,
+              <http://www.rfc-editor.org/info/rfc5226>.
+
+   [RFC5234]  Crocker, D., Ed. and P. Overell, "Augmented BNF for Syntax
+              Specifications: ABNF", STD 68, RFC 5234,
+              DOI 10.17487/RFC5234, January 2008,
+              <http://www.rfc-editor.org/info/rfc5234>.
+
+
+
+
+
+
+
+Sakimura, et al.             Standards Track                   [Page 15]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+   [RFC6234]  Eastlake 3rd, D. and T. Hansen, "US Secure Hash Algorithms
+              (SHA and SHA-based HMAC and HKDF)", RFC 6234,
+              DOI 10.17487/RFC6234, May 2011,
+              <http://www.rfc-editor.org/info/rfc6234>.
+
+   [RFC6749]  Hardt, D., Ed., "The OAuth 2.0 Authorization Framework",
+              RFC 6749, DOI 10.17487/RFC6749, October 2012,
+              <http://www.rfc-editor.org/info/rfc6749>.
+
+8.2.  Informative References
+
+   [RFC6819]  Lodderstedt, T., Ed., McGloin, M., and P. Hunt, "OAuth 2.0
+              Threat Model and Security Considerations", RFC 6819,
+              DOI 10.17487/RFC6819, January 2013,
+              <http://www.rfc-editor.org/info/rfc6819>.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Sakimura, et al.             Standards Track                   [Page 16]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+Appendix A.  Notes on Implementing Base64url Encoding without Padding
+
+   This appendix describes how to implement a base64url-encoding
+   function without padding, based upon the standard base64-encoding
+   function that uses padding.
+
+   To be concrete, example C# code implementing these functions is shown
+   below.  Similar code could be used in other languages.
+
+     static string base64urlencode(byte [] arg)
+     {
+       string s = Convert.ToBase64String(arg); // Regular base64 encoder
+       s = s.Split('=')[0]; // Remove any trailing '='s
+       s = s.Replace('+', '-'); // 62nd char of encoding
+       s = s.Replace('/', '_'); // 63rd char of encoding
+       return s;
+     }
+
+   An example correspondence between unencoded and encoded values
+   follows.  The octet sequence below encodes into the string below,
+   which when decoded, reproduces the octet sequence.
+
+   3 236 255 224 193
+
+   A-z_4ME
+
+Appendix B.  Example for the S256 code_challenge_method
+
+   The client uses output of a suitable random number generator to
+   create a 32-octet sequence.  The octets representing the value in
+   this example (using JSON array notation) are:
+
+      [116, 24, 223, 180, 151, 153, 224, 37, 79, 250, 96, 125, 216, 173,
+      187, 186, 22, 212, 37, 77, 105, 214, 191, 240, 91, 88, 5, 88, 83,
+      132, 141, 121]
+
+   Encoding this octet sequence as base64url provides the value of the
+   code_verifier:
+
+       dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+
+   The code_verifier is then hashed via the SHA256 hash function to
+   produce:
+
+     [19, 211, 30, 150, 26, 26, 216, 236, 47, 22, 177, 12, 76, 152, 46,
+      8, 118, 168, 120, 173, 109, 241, 68, 86, 110, 225, 137, 74, 203,
+      112, 249, 195]
+
+
+
+
+Sakimura, et al.             Standards Track                   [Page 17]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+   Encoding this octet sequence as base64url provides the value of the
+   code_challenge:
+
+       E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+
+   The authorization request includes:
+
+       code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+       &code_challenge_method=S256
+
+   The authorization server then records the code_challenge and
+   code_challenge_method along with the code that is granted to the
+   client.
+
+   In the request to the token_endpoint, the client includes the code
+   received in the authorization response as well as the additional
+   parameter:
+
+       code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+
+   The authorization server retrieves the information for the code
+   grant.  Based on the recorded code_challenge_method being S256, it
+   then hashes and base64url-encodes the value of code_verifier:
+
+   BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))
+
+   The calculated value is then compared with the value of
+   "code_challenge":
+
+   BASE64URL-ENCODE(SHA256(ASCII(code_verifier))) == code_challenge
+
+   If the two values are equal, then the authorization server can
+   provide the tokens as long as there are no other errors in the
+   request.  If the values are not equal, then the request must be
+   rejected, and an error returned.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Sakimura, et al.             Standards Track                   [Page 18]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+Acknowledgements
+
+   The initial draft version of this specification was created by the
+   OpenID AB/Connect Working Group of the OpenID Foundation.
+
+   This specification is the work of the OAuth Working Group, which
+   includes dozens of active and dedicated participants.  In particular,
+   the following individuals contributed ideas, feedback, and wording
+   that shaped and formed the final specification:
+
+      Anthony Nadalin, Microsoft
+      Axel Nenker, Deutsche Telekom
+      Breno de Medeiros, Google
+      Brian Campbell, Ping Identity
+      Chuck Mortimore, Salesforce
+      Dirk Balfanz, Google
+      Eduardo Gueiros, Jive Communications
+      Hannes Tschonfenig, ARM
+      James Manger, Telstra
+      Justin Richer, MIT Kerberos
+      Josh Mandel, Boston Children's Hospital
+      Lewis Adam, Motorola Solutions
+      Madjid Nakhjiri, Samsung
+      Michael B. Jones, Microsoft
+      Paul Madsen, Ping Identity
+      Phil Hunt, Oracle
+      Prateek Mishra, Oracle
+      Ryo Ito, mixi
+      Scott Tomilson, Ping Identity
+      Sergey Beryozkin
+      Takamichi Saito
+      Torsten Lodderstedt, Deutsche Telekom
+      William Denniss, Google
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Sakimura, et al.             Standards Track                   [Page 19]
+
+RFC 7636                       OAUTH PKCE                 September 2015
+
+
+Authors' Addresses
+
+   Nat Sakimura (editor)
+   Nomura Research Institute
+   1-6-5 Marunouchi, Marunouchi Kitaguchi Bldg.
+   Chiyoda-ku, Tokyo  100-0005
+   Japan
+
+   Phone: +81-3-5533-2111
+   Email: n-sakimura@nri.co.jp
+   URI:   http://nat.sakimura.org/
+
+
+   John Bradley
+   Ping Identity
+   Casilla 177, Sucursal Talagante
+   Talagante, RM
+   Chile
+
+   Phone: +44 20 8133 3718
+   Email: ve7jtb@ve7jtb.com
+   URI:   http://www.thread-safe.com/
+
+
+   Naveen Agarwal
+   Google
+   1600 Amphitheatre Parkway
+   Mountain View, CA  94043
+   United States
+
+   Phone: +1 650-253-0000
+   Email: naa@google.com
+   URI:   http://google.com/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Sakimura, et al.             Standards Track                   [Page 20]
+

--- a/rfc/rfc7662.txt
+++ b/rfc/rfc7662.txt
@@ -1,0 +1,955 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                    J. Richer, Ed.
+Request for Comments: 7662                                  October 2015
+Category: Standards Track
+ISSN: 2070-1721
+
+
+                     OAuth 2.0 Token Introspection
+
+Abstract
+
+   This specification defines a method for a protected resource to query
+   an OAuth 2.0 authorization server to determine the active state of an
+   OAuth 2.0 token and to determine meta-information about this token.
+   OAuth 2.0 deployments can use this method to convey information about
+   the authorization context of the token from the authorization server
+   to the protected resource.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7662.
+
+Copyright Notice
+
+   Copyright (c) 2015 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+Richer                       Standards Track                    [Page 1]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+     1.1.  Notational Conventions  . . . . . . . . . . . . . . . . .   3
+     1.2.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   3
+   2.  Introspection Endpoint  . . . . . . . . . . . . . . . . . . .   3
+     2.1.  Introspection Request . . . . . . . . . . . . . . . . . .   4
+     2.2.  Introspection Response  . . . . . . . . . . . . . . . . .   6
+     2.3.  Error Response  . . . . . . . . . . . . . . . . . . . . .   8
+   3.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   9
+     3.1.  OAuth Token Introspection Response Registry . . . . . . .   9
+       3.1.1.  Registration Template . . . . . . . . . . . . . . . .  10
+       3.1.2.  Initial Registry Contents . . . . . . . . . . . . . .  10
+   4.  Security Considerations . . . . . . . . . . . . . . . . . . .  12
+   5.  Privacy Considerations  . . . . . . . . . . . . . . . . . . .  14
+   6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  15
+     6.1.  Normative References  . . . . . . . . . . . . . . . . . .  15
+     6.2.  Informative References  . . . . . . . . . . . . . . . . .  16
+   Appendix A.  Use with Proof-of-Possession Tokens  . . . . . . . .  17
+   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . .  17
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  17
+
+1.  Introduction
+
+   In OAuth 2.0 [RFC6749], the contents of tokens are opaque to clients.
+   This means that the client does not need to know anything about the
+   content or structure of the token itself, if there is any.  However,
+   there is still a large amount of metadata that may be attached to a
+   token, such as its current validity, approved scopes, and information
+   about the context in which the token was issued.  These pieces of
+   information are often vital to protected resources making
+   authorization decisions based on the tokens being presented.  Since
+   OAuth 2.0 does not define a protocol for the resource server to learn
+   meta-information about a token that it has received from an
+   authorization server, several different approaches have been
+   developed to bridge this gap.  These include using structured token
+   formats such as JWT [RFC7519] or proprietary inter-service
+   communication mechanisms (such as shared databases and protected
+   enterprise service buses) that convey token information.
+
+   This specification defines a protocol that allows authorized
+   protected resources to query the authorization server to determine
+   the set of metadata for a given token that was presented to them by
+   an OAuth 2.0 client.  This metadata includes whether or not the token
+   is currently active (or if it has expired or otherwise been revoked),
+   what rights of access the token carries (usually conveyed through
+   OAuth 2.0 scopes), and the authorization context in which the token
+   was granted (including who authorized the token and which client it
+
+
+
+Richer                       Standards Track                    [Page 2]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+   was issued to).  Token introspection allows a protected resource to
+   query this information regardless of whether or not it is carried in
+   the token itself, allowing this method to be used along with or
+   independently of structured token values.  Additionally, a protected
+   resource can use the mechanism described in this specification to
+   introspect the token in a particular authorization decision context
+   and ascertain the relevant metadata about the token to make this
+   authorization decision appropriately.
+
+1.1.  Notational Conventions
+
+   The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL NOT',
+   'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED', 'MAY', and
+   'OPTIONAL' in this document are to be interpreted as described in
+   [RFC2119].
+
+   Unless otherwise noted, all the protocol parameter names and values
+   are case sensitive.
+
+1.2.  Terminology
+
+   This section defines the terminology used by this specification.
+   This section is a normative portion of this specification, imposing
+   requirements upon implementations.
+
+   This specification uses the terms "access token", "authorization
+   endpoint", "authorization grant", "authorization server", "client",
+   "client identifier", "protected resource", "refresh token", "resource
+   owner", "resource server", and "token endpoint" defined by OAuth 2.0
+   [RFC6749], and the terms "claim names" and "claim values" defined by
+   JSON Web Token (JWT) [RFC7519].
+
+   This specification defines the following terms:
+
+   Token Introspection
+      The act of inquiring about the current state of an OAuth 2.0 token
+      through use of the network protocol defined in this document.
+
+   Introspection Endpoint
+      The OAuth 2.0 endpoint through which the token introspection
+      operation is accomplished.
+
+2.  Introspection Endpoint
+
+   The introspection endpoint is an OAuth 2.0 endpoint that takes a
+   parameter representing an OAuth 2.0 token and returns a JSON
+   [RFC7159] document representing the meta information surrounding the
+   token, including whether this token is currently active.  The
+
+
+
+Richer                       Standards Track                    [Page 3]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+   definition of an active token is dependent upon the authorization
+   server, but this is commonly a token that has been issued by this
+   authorization server, is not expired, has not been revoked, and is
+   valid for use at the protected resource making the introspection
+   call.
+
+   The introspection endpoint MUST be protected by a transport-layer
+   security mechanism as described in Section 4.  The means by which the
+   protected resource discovers the location of the introspection
+   endpoint are outside the scope of this specification.
+
+2.1.  Introspection Request
+
+   The protected resource calls the introspection endpoint using an HTTP
+   POST [RFC7231] request with parameters sent as
+   "application/x-www-form-urlencoded" data as defined in
+   [W3C.REC-html5-20141028].  The protected resource sends a parameter
+   representing the token along with optional parameters representing
+   additional context that is known by the protected resource to aid the
+   authorization server in its response.
+
+   token
+      REQUIRED.  The string value of the token.  For access tokens, this
+      is the "access_token" value returned from the token endpoint
+      defined in OAuth 2.0 [RFC6749], Section 5.1.  For refresh tokens,
+      this is the "refresh_token" value returned from the token endpoint
+      as defined in OAuth 2.0 [RFC6749], Section 5.1.  Other token types
+      are outside the scope of this specification.
+
+   token_type_hint
+      OPTIONAL.  A hint about the type of the token submitted for
+      introspection.  The protected resource MAY pass this parameter to
+      help the authorization server optimize the token lookup.  If the
+      server is unable to locate the token using the given hint, it MUST
+      extend its search across all of its supported token types.  An
+      authorization server MAY ignore this parameter, particularly if it
+      is able to detect the token type automatically.  Values for this
+      field are defined in the "OAuth Token Type Hints" registry defined
+      in OAuth Token Revocation [RFC7009].
+
+   The introspection endpoint MAY accept other OPTIONAL parameters to
+   provide further context to the query.  For instance, an authorization
+   server may desire to know the IP address of the client accessing the
+   protected resource to determine if the correct client is likely to be
+   presenting the token.  The definition of this or any other parameters
+   are outside the scope of this specification, to be defined by service
+   documentation or extensions to this specification.  If the
+   authorization server is unable to determine the state of the token
+
+
+
+Richer                       Standards Track                    [Page 4]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+   without additional information, it SHOULD return an introspection
+   response indicating the token is not active as described in
+   Section 2.2.
+
+   To prevent token scanning attacks, the endpoint MUST also require
+   some form of authorization to access this endpoint, such as client
+   authentication as described in OAuth 2.0 [RFC6749] or a separate
+   OAuth 2.0 access token such as the bearer token described in OAuth
+   2.0 Bearer Token Usage [RFC6750].  The methods of managing and
+   validating these authentication credentials are out of scope of this
+   specification.
+
+   For example, the following shows a protected resource calling the
+   token introspection endpoint to query about an OAuth 2.0 bearer
+   token.  The protected resource is using a separate OAuth 2.0 bearer
+   token to authorize this call.
+
+   The following is a non-normative example request:
+
+     POST /introspect HTTP/1.1
+     Host: server.example.com
+     Accept: application/json
+     Content-Type: application/x-www-form-urlencoded
+     Authorization: Bearer 23410913-abewfq.123483
+
+     token=2YotnFZFEjr1zCsicMWpAA
+
+
+   In this example, the protected resource uses a client identifier and
+   client secret to authenticate itself to the introspection endpoint.
+   The protected resource also sends a token type hint indicating that
+   it is inquiring about an access token.
+
+   The following is a non-normative example request:
+
+     POST /introspect HTTP/1.1
+     Host: server.example.com
+     Accept: application/json
+     Content-Type: application/x-www-form-urlencoded
+     Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW
+
+     token=mF_9.B5f-4.1JqM&token_type_hint=access_token
+
+
+
+
+
+
+
+
+
+Richer                       Standards Track                    [Page 5]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+2.2.  Introspection Response
+
+   The server responds with a JSON object [RFC7159] in "application/
+   json" format with the following top-level members.
+
+   active
+      REQUIRED.  Boolean indicator of whether or not the presented token
+      is currently active.  The specifics of a token's "active" state
+      will vary depending on the implementation of the authorization
+      server and the information it keeps about its tokens, but a "true"
+      value return for the "active" property will generally indicate
+      that a given token has been issued by this authorization server,
+      has not been revoked by the resource owner, and is within its
+      given time window of validity (e.g., after its issuance time and
+      before its expiration time).  See Section 4 for information on
+      implementation of such checks.
+
+   scope
+      OPTIONAL.  A JSON string containing a space-separated list of
+      scopes associated with this token, in the format described in
+      Section 3.3 of OAuth 2.0 [RFC6749].
+
+   client_id
+      OPTIONAL.  Client identifier for the OAuth 2.0 client that
+      requested this token.
+
+   username
+      OPTIONAL.  Human-readable identifier for the resource owner who
+      authorized this token.
+
+   token_type
+      OPTIONAL.  Type of the token as defined in Section 5.1 of OAuth
+      2.0 [RFC6749].
+
+   exp
+      OPTIONAL.  Integer timestamp, measured in the number of seconds
+      since January 1 1970 UTC, indicating when this token will expire,
+      as defined in JWT [RFC7519].
+
+   iat
+      OPTIONAL.  Integer timestamp, measured in the number of seconds
+      since January 1 1970 UTC, indicating when this token was
+      originally issued, as defined in JWT [RFC7519].
+
+   nbf
+      OPTIONAL.  Integer timestamp, measured in the number of seconds
+      since January 1 1970 UTC, indicating when this token is not to be
+      used before, as defined in JWT [RFC7519].
+
+
+
+Richer                       Standards Track                    [Page 6]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+   sub
+      OPTIONAL.  Subject of the token, as defined in JWT [RFC7519].
+      Usually a machine-readable identifier of the resource owner who
+      authorized this token.
+
+   aud
+      OPTIONAL.  Service-specific string identifier or list of string
+      identifiers representing the intended audience for this token, as
+      defined in JWT [RFC7519].
+
+   iss
+      OPTIONAL.  String representing the issuer of this token, as
+      defined in JWT [RFC7519].
+
+   jti
+      OPTIONAL.  String identifier for the token, as defined in JWT
+      [RFC7519].
+
+   Specific implementations MAY extend this structure with their own
+   service-specific response names as top-level members of this JSON
+   object.  Response names intended to be used across domains MUST be
+   registered in the "OAuth Token Introspection Response" registry
+   defined in Section 3.1.
+
+   The authorization server MAY respond differently to different
+   protected resources making the same request.  For instance, an
+   authorization server MAY limit which scopes from a given token are
+   returned for each protected resource to prevent a protected resource
+   from learning more about the larger network than is necessary for its
+   operation.
+
+   The response MAY be cached by the protected resource to improve
+   performance and reduce load on the introspection endpoint, but at the
+   cost of liveness of the information used by the protected resource to
+   make authorization decisions.  See Section 4 for more information
+   regarding the trade off when the response is cached.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Richer                       Standards Track                    [Page 7]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+   For example, the following response contains a set of information
+   about an active token:
+
+   The following is a non-normative example response:
+
+     HTTP/1.1 200 OK
+     Content-Type: application/json
+
+     {
+      "active": true,
+      "client_id": "l238j323ds-23ij4",
+      "username": "jdoe",
+      "scope": "read write dolphin",
+      "sub": "Z5O3upPC88QrAjx00dis",
+      "aud": "https://protected.example.net/resource",
+      "iss": "https://server.example.com/",
+      "exp": 1419356238,
+      "iat": 1419350238,
+      "extension_field": "twenty-seven"
+     }
+
+   If the introspection call is properly authorized but the token is not
+   active, does not exist on this server, or the protected resource is
+   not allowed to introspect this particular token, then the
+   authorization server MUST return an introspection response with the
+   "active" field set to "false".  Note that to avoid disclosing too
+   much of the authorization server's state to a third party, the
+   authorization server SHOULD NOT include any additional information
+   about an inactive token, including why the token is inactive.
+
+   The following is a non-normative example response for a token that
+   has been revoked or is otherwise invalid:
+
+     HTTP/1.1 200 OK
+     Content-Type: application/json
+
+     {
+      "active": false
+     }
+
+2.3.  Error Response
+
+   If the protected resource uses OAuth 2.0 client credentials to
+   authenticate to the introspection endpoint and its credentials are
+   invalid, the authorization server responds with an HTTP 401
+   (Unauthorized) as described in Section 5.2 of OAuth 2.0 [RFC6749].
+
+
+
+
+
+Richer                       Standards Track                    [Page 8]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+   If the protected resource uses an OAuth 2.0 bearer token to authorize
+   its call to the introspection endpoint and the token used for
+   authorization does not contain sufficient privileges or is otherwise
+   invalid for this request, the authorization server responds with an
+   HTTP 401 code as described in Section 3 of OAuth 2.0 Bearer Token
+   Usage [RFC6750].
+
+   Note that a properly formed and authorized query for an inactive or
+   otherwise invalid token (or a token the protected resource is not
+   allowed to know about) is not considered an error response by this
+   specification.  In these cases, the authorization server MUST instead
+   respond with an introspection response with the "active" field set to
+   "false" as described in Section 2.2.
+
+3.  IANA Considerations
+
+3.1.  OAuth Token Introspection Response Registry
+
+   This specification establishes the "OAuth Token Introspection
+   Response" registry.
+
+   OAuth registration client metadata names and descriptions are
+   registered by Specification Required [RFC5226] after a two-week
+   review period on the oauth-ext-review@ietf.org mailing list, on the
+   advice of one or more Designated Experts.  However, to allow for the
+   allocation of names prior to publication, the Designated Expert(s)
+   may approve registration once they are satisfied that such a
+   specification will be published.
+
+   Registration requests sent to the mailing list for review should use
+   an appropriate subject (e.g., "Request to register OAuth Token
+   Introspection Response name: example").
+
+   Within the review period, the Designated Expert(s) will either
+   approve or deny the registration request, communicating this decision
+   to the review list and IANA.  Denials should include an explanation
+   and, if applicable, suggestions as to how to make the request
+   successful.
+
+   IANA must only accept registry updates from the Designated Expert(s)
+   and should direct all requests for registration to the review mailing
+   list.
+
+
+
+
+
+
+
+
+
+Richer                       Standards Track                    [Page 9]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+3.1.1.  Registration Template
+
+   Name:
+      The name requested (e.g., "example").  This name is case
+      sensitive.  Names that match other registered names in a case
+      insensitive manner SHOULD NOT be accepted.  Names that match
+      claims registered in the "JSON Web Token Claims" registry
+      established by [RFC7519] SHOULD have comparable definitions and
+      semantics.
+
+   Description:
+      Brief description of the metadata value (e.g., "Example
+      description").
+
+   Change controller:
+      For Standards Track RFCs, state "IESG".  For other documents, give
+      the name of the responsible party.  Other details (e.g., postal
+      address, email address, home page URI) may also be included.
+
+   Specification document(s):
+      Reference to the document(s) that specify the token endpoint
+      authorization method, preferably including a URI that can be used
+      to retrieve a copy of the document(s).  An indication of the
+      relevant sections may also be included but is not required.
+
+3.1.2.  Initial Registry Contents
+
+   The initial contents of the "OAuth Token Introspection Response"
+   registry are as follows:
+
+   o  Name: "active"
+   o  Description: Token active status
+   o  Change Controller: IESG
+   o  Specification Document(s): Section 2.2 of RFC 7662 (this
+      document).
+
+   o  Name: "username"
+   o  Description: User identifier of the resource owner
+   o  Change Controller: IESG
+   o  Specification Document(s): Section 2.2 of RFC 7662 (this
+      document).
+
+   o  Name: "client_id"
+   o  Description: Client identifier of the client
+   o  Change Controller: IESG
+   o  Specification Document(s): Section 2.2 of RFC 7662 (this
+      document).
+
+
+
+
+Richer                       Standards Track                   [Page 10]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+   o  Name: "scope"
+   o  Description: Authorized scopes of the token
+   o  Change Controller: IESG
+   o  Specification Document(s): Section 2.2 of RFC 7662 (this
+      document).
+
+   o  Name: "token_type"
+   o  Description: Type of the token
+   o  Change Controller: IESG
+   o  Specification Document(s): Section 2.2 of RFC 7662 (this
+      document).
+
+   o  Name: "exp"
+   o  Description: Expiration timestamp of the token
+   o  Change Controller: IESG
+   o  Specification Document(s): Section 2.2 of RFC 7662 (this
+      document).
+
+   o  Name: "iat"
+   o  Description: Issuance timestamp of the token
+   o  Change Controller: IESG
+   o  Specification Document(s): Section 2.2 of RFC 7662 (this
+      document).
+
+   o  Name: "nbf"
+   o  Description: Timestamp before which the token is not valid
+   o  Change Controller: IESG
+   o  Specification Document(s): Section 2.2 of RFC 7662 (this
+      document).
+
+   o  Name: "sub"
+   o  Description: Subject of the token
+   o  Change Controller: IESG
+   o  Specification Document(s): Section 2.2 of RFC 7662 (this
+      document).
+
+   o  Name: "aud"
+   o  Description: Audience of the token
+   o  Change Controller: IESG
+   o  Specification Document(s): Section 2.2 of RFC 7662 (this
+      document).
+
+   o  Name: "iss"
+   o  Description: Issuer of the token
+   o  Change Controller: IESG
+   o  Specification Document(s): Section 2.2 of RFC 7662 (this
+      document).
+
+
+
+
+Richer                       Standards Track                   [Page 11]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+   o  Name: "jti"
+   o  Description: Unique identifier of the token
+   o  Change Controller: IESG
+   o  Specification Document(s): Section 2.2 of RFC 7662 (this
+      document).
+
+4.  Security Considerations
+
+   Since there are many different and valid ways to implement an OAuth
+   2.0 system, there are consequently many ways for an authorization
+   server to determine whether or not a token is currently "active".
+   However, since resource servers using token introspection rely on the
+   authorization server to determine the state of a token, the
+   authorization server MUST perform all applicable checks against a
+   token's state.  For instance, these tests include the following:
+
+   o  If the token can expire, the authorization server MUST determine
+      whether or not the token has expired.
+   o  If the token can be issued before it is able to be used, the
+      authorization server MUST determine whether or not a token's valid
+      period has started yet.
+   o  If the token can be revoked after it was issued, the authorization
+      server MUST determine whether or not such a revocation has taken
+      place.
+   o  If the token has been signed, the authorization server MUST
+      validate the signature.
+   o  If the token can be used only at certain resource servers, the
+      authorization server MUST determine whether or not the token can
+      be used at the resource server making the introspection call.
+
+   If an authorization server fails to perform any applicable check, the
+   resource server could make an erroneous security decision based on
+   that response.  Note that not all of these checks will be applicable
+   to all OAuth 2.0 deployments and it is up to the authorization server
+   to determine which of these checks (and any other checks) apply.
+
+   If left unprotected and un-throttled, the introspection endpoint
+   could present a means for an attacker to poll a series of possible
+   token values, fishing for a valid token.  To prevent this, the
+   authorization server MUST require authentication of protected
+   resources that need to access the introspection endpoint and SHOULD
+   require protected resources to be specifically authorized to call the
+   introspection endpoint.  The specifics of such authentication
+   credentials are out of scope of this specification, but commonly
+   these credentials could take the form of any valid client
+   authentication mechanism used with the token endpoint, an OAuth 2.0
+   access token, or other HTTP authorization or authentication
+   mechanism.  A single piece of software acting as both a client and a
+
+
+
+Richer                       Standards Track                   [Page 12]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+   protected resource MAY reuse the same credentials between the token
+   endpoint and the introspection endpoint, though doing so potentially
+   conflates the activities of the client and protected resource
+   portions of the software and the authorization server MAY require
+   separate credentials for each mode.
+
+   Since the introspection endpoint takes in OAuth 2.0 tokens as
+   parameters and responds with information used to make authorization
+   decisions, the server MUST support Transport Layer Security (TLS) 1.2
+   [RFC5246] and MAY support additional transport-layer mechanisms
+   meeting its security requirements.  When using TLS, the client or
+   protected resource MUST perform a TLS/SSL server certificate check,
+   as specified in [RFC6125].  Implementation security considerations
+   can be found in Recommendations for Secure Use of TLS and DTLS
+   [BCP195].
+
+   To prevent the values of access tokens from leaking into server-side
+   logs via query parameters, an authorization server offering token
+   introspection MAY disallow the use of HTTP GET on the introspection
+   endpoint and instead require the HTTP POST method to be used at the
+   introspection endpoint.
+
+   To avoid disclosing the internal state of the authorization server,
+   an introspection response for an inactive token SHOULD NOT contain
+   any additional claims beyond the required "active" claim (with its
+   value set to "false").
+
+   Since a protected resource MAY cache the response of the
+   introspection endpoint, designers of an OAuth 2.0 system using this
+   protocol MUST consider the performance and security trade-offs
+   inherent in caching security information such as this.  A less
+   aggressive cache with a short timeout will provide the protected
+   resource with more up-to-date information (due to it needing to query
+   the introspection endpoint more often) at the cost of increased
+   network traffic and load on the introspection endpoint.  A more
+   aggressive cache with a longer duration will minimize network traffic
+   and load on the introspection endpoint, but at the risk of stale
+   information about the token.  For example, the token may be revoked
+   while the protected resource is relying on the value of the cached
+   response to make authorization decisions.  This creates a window
+   during which a revoked token could be used at the protected resource.
+   Consequently, an acceptable cache validity duration needs to be
+   carefully considered given the concerns and sensitivities of the
+   protected resource being accessed and the likelihood of a token being
+   revoked or invalidated in the interim period.  Highly sensitive
+   environments can opt to disable caching entirely on the protected
+   resource to eliminate the risk of stale cached information entirely,
+   again at the cost of increased network traffic and server load.  If
+
+
+
+Richer                       Standards Track                   [Page 13]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+   the response contains the "exp" parameter (expiration), the response
+   MUST NOT be cached beyond the time indicated therein.
+
+   An authorization server offering token introspection must be able to
+   understand the token values being presented to it during this call.
+   The exact means by which this happens is an implementation detail and
+   is outside the scope of this specification.  For unstructured tokens,
+   this could take the form of a simple server-side database query
+   against a data store containing the context information for the
+   token.  For structured tokens, this could take the form of the server
+   parsing the token, validating its signature or other protection
+   mechanisms, and returning the information contained in the token back
+   to the protected resource (allowing the protected resource to be
+   unaware of the token's contents, much like the client).  Note that
+   for tokens carrying encrypted information that is needed during the
+   introspection process, the authorization server must be able to
+   decrypt and validate the token to access this information.  Also note
+   that in cases where the authorization server stores no information
+   about the token and has no means of accessing information about the
+   token by parsing the token itself, it cannot likely offer an
+   introspection service.
+
+5.  Privacy Considerations
+
+   The introspection response may contain privacy-sensitive information
+   such as user identifiers for resource owners.  When this is the case,
+   measures MUST be taken to prevent disclosure of this information to
+   unintended parties.  One method is to transmit user identifiers as
+   opaque service-specific strings, potentially returning different
+   identifiers to each protected resource.
+
+   If the protected resource sends additional information about the
+   client's request to the authorization server (such as the client's IP
+   address) using an extension of this specification, such information
+   could have additional privacy considerations that the extension
+   should detail.  However, the nature and implications of such
+   extensions are outside the scope of this specification.
+
+   Omitting privacy-sensitive information from an introspection response
+   is the simplest way of minimizing privacy issues.
+
+
+
+
+
+
+
+
+
+
+
+Richer                       Standards Track                   [Page 14]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+6.  References
+
+6.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <http://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              DOI 10.17487/RFC5226, May 2008,
+              <http://www.rfc-editor.org/info/rfc5226>.
+
+   [RFC5246]  Dierks, T. and E. Rescorla, "The Transport Layer Security
+              (TLS) Protocol Version 1.2", RFC 5246,
+              DOI 10.17487/RFC5246, August 2008,
+              <http://www.rfc-editor.org/info/rfc5246>.
+
+   [RFC6125]  Saint-Andre, P. and J. Hodges, "Representation and
+              Verification of Domain-Based Application Service Identity
+              within Internet Public Key Infrastructure Using X.509
+              (PKIX) Certificates in the Context of Transport Layer
+              Security (TLS)", RFC 6125, DOI 10.17487/RFC6125, March
+              2011, <http://www.rfc-editor.org/info/rfc6125>.
+
+   [RFC6749]  Hardt, D., Ed., "The OAuth 2.0 Authorization Framework",
+              RFC 6749, DOI 10.17487/RFC6749, October 2012,
+              <http://www.rfc-editor.org/info/rfc6749>.
+
+   [RFC6750]  Jones, M. and D. Hardt, "The OAuth 2.0 Authorization
+              Framework: Bearer Token Usage", RFC 6750,
+              DOI 10.17487/RFC6750, October 2012,
+              <http://www.rfc-editor.org/info/rfc6750>.
+
+   [RFC7009]  Lodderstedt, T., Ed., Dronia, S., and M. Scurtescu, "OAuth
+              2.0 Token Revocation", RFC 7009, DOI 10.17487/RFC7009,
+              August 2013, <http://www.rfc-editor.org/info/rfc7009>.
+
+   [RFC7159]  Bray, T., Ed., "The JavaScript Object Notation (JSON) Data
+              Interchange Format", RFC 7159, DOI 10.17487/RFC7159, March
+              2014, <http://www.rfc-editor.org/info/rfc7159>.
+
+   [RFC7231]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
+              Protocol (HTTP/1.1): Semantics and Content", RFC 7231,
+              DOI 10.17487/RFC7231, June 2014,
+              <http://www.rfc-editor.org/info/rfc7231>.
+
+
+
+
+Richer                       Standards Track                   [Page 15]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+   [RFC7519]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web Token
+              (JWT)", RFC 7519, DOI 10.17487/RFC7519, May 2015,
+              <http://www.rfc-editor.org/info/rfc7519>.
+
+   [W3C.REC-html5-20141028]
+              Hickson, I., Berjon, R., Faulkner, S., Leithead, T.,
+              Navara, E., 0'Connor, E., and S. Pfeiffer, "HTML5", World
+              Wide Web Consortium Recommendation
+              REC-html5-20141028, October 2014,
+              <http://www.w3.org/TR/2014/REC-html5-20141028>.
+
+6.2.  Informative References
+
+   [BCP195]   Sheffer, Y., Holz, R., and P. Saint-Andre,
+              "Recommendations for Secure Use of Transport Layer
+              Security (TLS) and Datagram Transport Layer Security
+              (DTLS)", BCP 195, RFC 7525, May 2015,
+              <http://www.rfc-editor.org/info/bcp195>.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Richer                       Standards Track                   [Page 16]
+
+RFC 7662                   OAuth Introspection              October 2015
+
+
+Appendix A.  Use with Proof-of-Possession Tokens
+
+   With bearer tokens such as those defined by OAuth 2.0 Bearer Token
+   Usage [RFC6750], the protected resource will have in its possession
+   the entire secret portion of the token for submission to the
+   introspection service.  However, for proof-of-possession style
+   tokens, the protected resource will have only a token identifier used
+   during the request, along with the cryptographic signature on the
+   request.  To validate the signature on the request, the protected
+   resource could be able to submit the token identifier to the
+   authorization server's introspection endpoint to obtain the necessary
+   key information needed for that token.  The details of this usage are
+   outside the scope of this specification and will be defined in an
+   extension to this specification in concert with the definition of
+   proof-of-possession tokens.
+
+Acknowledgements
+
+   Thanks to the OAuth Working Group and the User Managed Access Working
+   Group for feedback and review of this document, and to the various
+   implementors of both the client and server components of this
+   specification.  In particular, the author would like to thank Amanda
+   Anganes, John Bradley, Thomas Broyer, Brian Campbell, George
+   Fletcher, Paul Freemantle, Thomas Hardjono, Eve Maler, Josh Mandel,
+   Steve Moore, Mike Schwartz, Prabath Siriwardena, Sarah Squire, and
+   Hannes Tschofennig.
+
+Author's Address
+
+   Justin Richer (editor)
+
+   Email: ietf@justin.richer.org
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Richer                       Standards Track                   [Page 17]
+


### PR DESCRIPTION
## Summary

- Add `README.md` with quick start, Docker usage, and conformance testing guide
- Add `CLAUDE.md` with full project architecture, conformance setup instructions, and conformance client details
- Add `rfc/` directory with downloaded RFC specs (6749, 6750, 7009, 7636, 7662, OIDC Core, OIDC Discovery)
- Add `rfc/rfc.md` with 7-phase RFC compliance review plan and bug inventory
- Document passing of Basic OP (`oidcc-basic-certification-test-plan`) and Comprehensive (`oidcc-test-plan`) conformance test plans
- Conformance clients use wildcard redirect URIs (`localhost.emobix.co.uk:8443/test/*/callback`)

## Test plan

- [x] Basic OP certification test plan — ✅ Passed
- [x] Comprehensive authorization server test — ✅ Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)