### PR TITLE
feat: support GET method for OIDC RP-Initiated Logout

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -16,9 +16,7 @@ import (
 
 	"github.com/eugenioenko/autentico/docs"
 	"github.com/eugenioenko/autentico/pkg/account"
-	"github.com/eugenioenko/autentico/view"
 	"github.com/eugenioenko/autentico/pkg/admin"
-	"github.com/eugenioenko/autentico/pkg/deletion"
 	"github.com/eugenioenko/autentico/pkg/appsettings"
 	"github.com/eugenioenko/autentico/pkg/authorize"
 	"github.com/eugenioenko/autentico/pkg/cleanup"
@@ -26,6 +24,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/db/migrations"
+	"github.com/eugenioenko/autentico/pkg/deletion"
 	"github.com/eugenioenko/autentico/pkg/emailverification"
 	"github.com/eugenioenko/autentico/pkg/federation"
 	"github.com/eugenioenko/autentico/pkg/health"
@@ -43,6 +42,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/user"
 	"github.com/eugenioenko/autentico/pkg/userinfo"
 	"github.com/eugenioenko/autentico/pkg/wellknown"
+	"github.com/eugenioenko/autentico/view"
 	httpSwagger "github.com/swaggo/http-swagger"
 )
 
@@ -139,6 +139,7 @@ func RunStart(c *cli.Context) error {
 	mux.HandleFunc(oauth+"/userinfo", userinfo.HandleUserInfo)
 	mux.HandleFunc(oauth+"/protocol/openid-connect/userinfo", userinfo.HandleUserInfo)
 	mux.HandleFunc("POST "+oauth+"/logout", session.HandleLogout)
+	mux.HandleFunc("GET "+oauth+"/logout", session.HandleRpInitiatedLogout)
 	mux.Handle("GET "+oauth+"/register", adminAPI(client.HandleListClients))
 	mux.Handle("POST "+oauth+"/register", adminAPI(client.HandleRegister))
 	mux.Handle("GET "+oauth+"/register/{client_id}", adminAPI(client.HandleGetClient))
@@ -238,6 +239,7 @@ func RunStart(c *cli.Context) error {
 	fmt.Printf("  Swagger:    %s/swagger/index.html\n", baseURL)
 	fmt.Printf("  Docs:       https://autentico.top\n")
 	fmt.Println()
+	fmt.Printf("  Issuer:     %s%s\n", baseURL, oauth)
 	fmt.Printf("  WellKnown:  %s%s/.well-known/openid-configuration\n", baseURL, oauth)
 	fmt.Printf("  JWKS:       %s%s/.well-known/jwks.json\n", baseURL, oauth)
 	fmt.Printf("  Authorize:  %s%s/authorize\n", baseURL, oauth)

--- a/pkg/session/logout.go
+++ b/pkg/session/logout.go
@@ -1,11 +1,15 @@
 package session
 
 import (
+	"encoding/json"
 	"net/http"
 
+	"github.com/dgrijalva/jwt-go"
+	"github.com/eugenioenko/autentico/pkg/client"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/idpsession"
 	"github.com/eugenioenko/autentico/pkg/jwtutil"
+	"github.com/eugenioenko/autentico/pkg/key"
 	"github.com/eugenioenko/autentico/pkg/utils"
 )
 
@@ -57,4 +61,123 @@ func HandleLogout(w http.ResponseWriter, r *http.Request) {
 	idpsession.ClearCookie(w)
 
 	utils.SuccessResponse(w, "ok", http.StatusOK)
+}
+
+// idTokenHintClaims holds the claims we care about from an id_token_hint.
+// Valid() always returns nil so that expired ID tokens are accepted per the spec.
+type idTokenHintClaims struct {
+	Subject  string `json:"sub"`
+	ClientID string `json:"azp"` // authorized party
+	RawAud   interface{}
+}
+
+func (c *idTokenHintClaims) Valid() error { return nil }
+
+func (c *idTokenHintClaims) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["sub"].(string); ok {
+		c.Subject = v
+	}
+	if v, ok := raw["azp"].(string); ok {
+		c.ClientID = v
+	}
+	c.RawAud = raw["aud"]
+	return nil
+}
+
+// audClientID returns the first audience value as a client_id candidate.
+func (c *idTokenHintClaims) audClientID() string {
+	switch v := c.RawAud.(type) {
+	case string:
+		return v
+	case []interface{}:
+		if len(v) > 0 {
+			if s, ok := v[0].(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// parseIDTokenHint parses an ID token hint without validating expiry.
+// Returns nil claims (no error) when the hint is empty or unparseable — callers
+// should treat missing claims as "no hint provided".
+func parseIDTokenHint(hint string) *idTokenHintClaims {
+	if hint == "" {
+		return nil
+	}
+	claims := &idTokenHintClaims{}
+	_, err := jwt.ParseWithClaims(hint, claims, func(t *jwt.Token) (interface{}, error) {
+		return key.GetPublicKey(), nil
+	})
+	if err != nil {
+		return nil
+	}
+	return claims
+}
+
+// HandleRpInitiatedLogout godoc
+// @Summary RP-Initiated Logout (GET)
+// @Description OIDC RP-Initiated Logout per OpenID Connect RP-Initiated Logout 1.0.
+// @Description Clears the IdP session and optionally redirects to post_logout_redirect_uri.
+// @Tags session
+// @Produce html
+// @Param id_token_hint query string false "Previously issued ID token"
+// @Param post_logout_redirect_uri query string false "URI to redirect to after logout"
+// @Param state query string false "Opaque value passed back to post_logout_redirect_uri"
+// @Param client_id query string false "Client identifier (used to validate post_logout_redirect_uri when no id_token_hint)"
+// @Success 302 {string} string "Redirect"
+// @Router /oauth2/logout [get]
+func HandleRpInitiatedLogout(w http.ResponseWriter, r *http.Request) {
+	idTokenHint := r.URL.Query().Get("id_token_hint")
+	postLogoutRedirectURI := r.URL.Query().Get("post_logout_redirect_uri")
+	state := r.URL.Query().Get("state")
+	clientIDParam := r.URL.Query().Get("client_id")
+
+	// Parse the ID token hint (expired tokens are accepted per spec).
+	hints := parseIDTokenHint(idTokenHint)
+
+	// Determine user and deactivate their sessions if we have a subject.
+	if hints != nil && hints.Subject != "" {
+		query := `UPDATE sessions SET deactivated_at = CURRENT_TIMESTAMP WHERE user_id = ? AND deactivated_at IS NULL`
+		_, _ = db.GetDB().Exec(query, hints.Subject)
+		_ = idpsession.DeactivateAllForUser(hints.Subject)
+	}
+
+	// Always clear the IdP session cookie regardless of token hint.
+	idpsession.ClearCookie(w)
+
+	// Resolve which client to use for post_logout_redirect_uri validation.
+	resolvedClientID := clientIDParam
+	if resolvedClientID == "" && hints != nil {
+		if hints.ClientID != "" {
+			resolvedClientID = hints.ClientID
+		} else {
+			resolvedClientID = hints.audClientID()
+		}
+	}
+
+	// Validate post_logout_redirect_uri against the client's registered URIs.
+	if postLogoutRedirectURI != "" && resolvedClientID != "" {
+		c, err := client.ClientByClientID(resolvedClientID)
+		if err == nil {
+			for _, allowed := range c.GetPostLogoutRedirectURIs() {
+				if allowed == postLogoutRedirectURI {
+					target := postLogoutRedirectURI
+					if state != "" {
+						target += "?state=" + state
+					}
+					http.Redirect(w, r, target, http.StatusFound)
+					return
+				}
+			}
+		}
+	}
+
+	// Fall back to the app root if no valid redirect URI was provided.
+	http.Redirect(w, r, "/", http.StatusFound)
 }

--- a/pkg/session/rp_initiated_logout_test.go
+++ b/pkg/session/rp_initiated_logout_test.go
@@ -1,0 +1,254 @@
+package session
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/db"
+	"github.com/eugenioenko/autentico/pkg/idpsession"
+	testutils "github.com/eugenioenko/autentico/tests/utils"
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestClient inserts a minimal OAuth2 client with the given post-logout redirect URIs.
+func createTestClient(t *testing.T, clientID string, postLogoutURIs []string) {
+	t.Helper()
+	urisJSON := `[]`
+	if len(postLogoutURIs) > 0 {
+		b := `[`
+		for i, u := range postLogoutURIs {
+			if i > 0 {
+				b += ","
+			}
+			b += `"` + u + `"`
+		}
+		b += `]`
+		urisJSON = b
+	}
+	_, err := db.GetDB().Exec(`
+		INSERT INTO clients (id, client_id, client_name, client_type, redirect_uris,
+		                     post_logout_redirect_uris, grant_types, response_types,
+		                     scopes, token_endpoint_auth_method, is_active)
+		VALUES (?, ?, ?, 'public', '["https://example.com/callback"]',
+		        ?, '["authorization_code"]', '["code"]',
+		        'openid', 'none', 1)
+	`, xid.New().String(), clientID, "Test Client "+clientID, urisJSON)
+	require.NoError(t, err)
+}
+
+func TestHandleRpInitiatedLogout_NoParams_RedirectsToRoot(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/logout", nil)
+	rr := httptest.NewRecorder()
+
+	HandleRpInitiatedLogout(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Equal(t, "/", rr.Header().Get("Location"))
+}
+
+func TestHandleRpInitiatedLogout_ClearsIdpSessionCookie(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Values.AuthSsoSessionIdleTimeout = 30 * time.Minute
+	})
+
+	userID := xid.New().String()
+	_, err := db.GetDB().Exec(`INSERT INTO users (id, username, email, password) VALUES (?, ?, ?, ?)`,
+		userID, "rplogoutuser", "rplogout@example.com", "hash")
+	require.NoError(t, err)
+
+	idpSessionID := xid.New().String()
+	err = idpsession.CreateIdpSession(idpsession.IdpSession{
+		ID: idpSessionID, UserID: userID, UserAgent: "ua", IPAddress: "127.0.0.1",
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/logout", nil)
+	req.AddCookie(&http.Cookie{Name: config.GetBootstrap().AuthIdpSessionCookieName, Value: idpSessionID})
+	rr := httptest.NewRecorder()
+
+	HandleRpInitiatedLogout(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+
+	var cleared *http.Cookie
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == config.GetBootstrap().AuthIdpSessionCookieName {
+			cleared = c
+			break
+		}
+	}
+	require.NotNil(t, cleared, "IdP session cookie should be cleared")
+	assert.True(t, cleared.MaxAge < 0, "cookie MaxAge should be negative to clear it")
+}
+
+func TestHandleRpInitiatedLogout_WithIdTokenHint_DeactivatesSessions(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	userID := xid.New().String()
+	_, err := db.GetDB().Exec(`INSERT INTO users (id, username, email, password) VALUES (?, ?, ?, ?)`,
+		userID, "rphintuser", "rphint@example.com", "hash")
+	require.NoError(t, err)
+
+	// Create an active OAuth session for the user.
+	accessToken, sessionID, err := generateTestAccessToken(userID)
+	require.NoError(t, err)
+	_, err = db.GetDB().Exec(`
+		INSERT INTO sessions (id, user_id, access_token, created_at, expires_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, sessionID, userID, accessToken, time.Now(), time.Now().Add(1*time.Hour))
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/logout?id_token_hint="+url.QueryEscape(accessToken), nil)
+	rr := httptest.NewRecorder()
+
+	HandleRpInitiatedLogout(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+
+	// Session should be deactivated.
+	var deactivatedAt interface{}
+	err = db.GetDB().QueryRow(`SELECT deactivated_at FROM sessions WHERE id = ?`, sessionID).Scan(&deactivatedAt)
+	require.NoError(t, err)
+	assert.NotNil(t, deactivatedAt, "session should be deactivated")
+}
+
+func TestHandleRpInitiatedLogout_ValidPostLogoutRedirectURI(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	clientID := "test-rp-logout-client"
+	postLogoutURI := "https://myapp.example.com/logged-out"
+	createTestClient(t, clientID, []string{postLogoutURI})
+
+	target := "/oauth2/logout?" + url.Values{
+		"client_id":               {clientID},
+		"post_logout_redirect_uri": {postLogoutURI},
+	}.Encode()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rr := httptest.NewRecorder()
+
+	HandleRpInitiatedLogout(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Equal(t, postLogoutURI, rr.Header().Get("Location"))
+}
+
+func TestHandleRpInitiatedLogout_ValidPostLogoutRedirectURIWithState(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	clientID := "test-rp-logout-state-client"
+	postLogoutURI := "https://myapp.example.com/logged-out"
+	createTestClient(t, clientID, []string{postLogoutURI})
+
+	target := "/oauth2/logout?" + url.Values{
+		"client_id":               {clientID},
+		"post_logout_redirect_uri": {postLogoutURI},
+		"state":                   {"abc123"},
+	}.Encode()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rr := httptest.NewRecorder()
+
+	HandleRpInitiatedLogout(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Equal(t, postLogoutURI+"?state=abc123", rr.Header().Get("Location"))
+}
+
+func TestHandleRpInitiatedLogout_UnregisteredPostLogoutRedirectURI_RedirectsToRoot(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	clientID := "test-rp-logout-unregistered"
+	createTestClient(t, clientID, []string{"https://allowed.example.com/out"})
+
+	target := "/oauth2/logout?" + url.Values{
+		"client_id":               {clientID},
+		"post_logout_redirect_uri": {"https://evil.example.com/steal"},
+	}.Encode()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rr := httptest.NewRecorder()
+
+	HandleRpInitiatedLogout(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Equal(t, "/", rr.Header().Get("Location"), "unregistered URI must be rejected")
+}
+
+func TestHandleRpInitiatedLogout_UnknownClientID_RedirectsToRoot(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	target := "/oauth2/logout?" + url.Values{
+		"client_id":               {"nonexistent-client"},
+		"post_logout_redirect_uri": {"https://example.com/out"},
+	}.Encode()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rr := httptest.NewRecorder()
+
+	HandleRpInitiatedLogout(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Equal(t, "/", rr.Header().Get("Location"))
+}
+
+func TestHandleRpInitiatedLogout_ClientIdFromIdTokenHint(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	userID := xid.New().String()
+	_, err := db.GetDB().Exec(`INSERT INTO users (id, username, email, password) VALUES (?, ?, ?, ?)`,
+		userID, "rpazpuser", "rpazp@example.com", "hash")
+	require.NoError(t, err)
+
+	// The access token carries the configured audience as "aud".
+	// Register a client with that audience as client_id.
+	aud := config.Get().AuthAccessTokenAudience
+	clientIDFromAud := ""
+	if len(aud) > 0 {
+		clientIDFromAud = aud[0]
+	}
+
+	postLogoutURI := "https://myapp.example.com/done"
+	if clientIDFromAud != "" {
+		// Only run the redirect assertion when a real client_id can be derived.
+		createTestClient(t, clientIDFromAud, []string{postLogoutURI})
+	}
+
+	accessToken, _, err := generateTestAccessToken(userID)
+	require.NoError(t, err)
+
+	target := "/oauth2/logout?" + url.Values{
+		"id_token_hint":            {accessToken},
+		"post_logout_redirect_uri": {postLogoutURI},
+	}.Encode()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rr := httptest.NewRecorder()
+
+	HandleRpInitiatedLogout(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+	if clientIDFromAud != "" {
+		assert.Equal(t, postLogoutURI, rr.Header().Get("Location"))
+	} else {
+		assert.Equal(t, "/", rr.Header().Get("Location"))
+	}
+}
+
+func TestHandleRpInitiatedLogout_InvalidIdTokenHint_StillLoggedOut(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/logout?id_token_hint=not-a-valid-jwt", nil)
+	rr := httptest.NewRecorder()
+
+	HandleRpInitiatedLogout(rr, req)
+
+	// Should still redirect (gracefully, no 4xx)
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Equal(t, "/", rr.Header().Get("Location"))
+}
+

--- a/tests/e2e/rp_initiated_logout_test.go
+++ b/tests/e2e/rp_initiated_logout_test.go
@@ -1,0 +1,155 @@
+package e2e
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/autentico/pkg/client"
+	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRpInitiatedLogout_DeactivatesIdpSession verifies the full RP-Initiated Logout
+// GET flow: login → GET /oauth2/logout?id_token_hint=<id_token> → /authorize shows login page.
+func TestRpInitiatedLogout_DeactivatesIdpSession(t *testing.T) {
+	ts := startTestServer(t)
+	config.Values.AuthSsoSessionIdleTimeout = 30 * time.Minute
+	redirectURI := "http://localhost:3000/callback"
+
+	createTestUser(t, "user@test.com", "password123", "user@test.com")
+
+	// Step 1: Full auth code flow — sets the IdP session cookie in the test client's jar.
+	code := performAuthorizationCodeFlowWithScope(t, ts, "test-client", redirectURI, "user@test.com", "password123", "state1", "openid profile email", "")
+
+	// Step 2: Exchange code for tokens to obtain an id_token.
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", "test-client")
+
+	tokenResp, err := ts.Client.PostForm(ts.BaseURL+"/oauth2/token", form)
+	require.NoError(t, err)
+	defer func() { _ = tokenResp.Body.Close() }()
+
+	body, err := io.ReadAll(tokenResp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, tokenResp.StatusCode, "token exchange failed: %s", string(body))
+
+	var tokens token.TokenResponse
+	err = json.Unmarshal(body, &tokens)
+	require.NoError(t, err)
+	require.NotEmpty(t, tokens.IDToken, "id_token must be present (openid scope was requested)")
+
+	// Step 3: Verify SSO is active — /authorize should auto-redirect (not show login page).
+	authorizeURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
+		"response_type": {"code"},
+		"client_id":     {"test-client"},
+		"redirect_uri":  {redirectURI},
+		"state":         {"state2"},
+	}.Encode()
+
+	preResp, err := ts.Client.Get(authorizeURL)
+	require.NoError(t, err)
+	defer func() { _ = preResp.Body.Close() }()
+	assert.Equal(t, http.StatusFound, preResp.StatusCode, "SSO should be active before logout")
+
+	// Step 4: GET /oauth2/logout with id_token_hint — RP-Initiated Logout.
+	logoutURL := ts.BaseURL + "/oauth2/logout?" + url.Values{
+		"id_token_hint": {tokens.IDToken},
+	}.Encode()
+
+	logoutResp, err := ts.Client.Get(logoutURL)
+	require.NoError(t, err)
+	defer func() { _ = logoutResp.Body.Close() }()
+	assert.Equal(t, http.StatusFound, logoutResp.StatusCode)
+
+	// Step 5: Verify the IdP session cookie is cleared.
+	cookieName := config.GetBootstrap().AuthIdpSessionCookieName
+	var clearedCookie *http.Cookie
+	for _, c := range logoutResp.Cookies() {
+		if c.Name == cookieName {
+			clearedCookie = c
+			break
+		}
+	}
+	require.NotNil(t, clearedCookie, "logout should clear the IdP session cookie")
+	assert.True(t, clearedCookie.MaxAge < 0, "cleared cookie should have negative MaxAge")
+
+	// Step 6: /authorize should now show the login page (SSO revoked).
+	postResp, err := ts.Client.Get(authorizeURL)
+	require.NoError(t, err)
+	defer func() { _ = postResp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, postResp.StatusCode, "should show login page after RP-Initiated Logout")
+	postBody, _ := io.ReadAll(postResp.Body)
+	assert.True(t, strings.Contains(string(postBody), "<form"), "should render login form after logout")
+}
+
+// TestRpInitiatedLogout_PostLogoutRedirectWithState verifies that a registered
+// post_logout_redirect_uri is honoured and the state parameter is passed through.
+func TestRpInitiatedLogout_PostLogoutRedirectWithState(t *testing.T) {
+	ts := startTestServer(t)
+
+	postLogoutURI := "http://localhost:3000/logged-out"
+
+	// Register a client with a post_logout_redirect_uri via the admin API.
+	_, adminToken := createTestAdmin(t, ts, "admin@test.com", "password123", "admin@test.com")
+	clientResp := createTestClient(t, ts, adminToken, client.ClientCreateRequest{
+		ClientName:             "RP Logout Test Client",
+		RedirectURIs:           []string{"http://localhost:3000/callback"},
+		PostLogoutRedirectURIs: []string{postLogoutURI},
+		GrantTypes:             []string{"authorization_code"},
+		ClientType:             "public",
+	})
+	clientID := clientResp["client_id"].(string)
+
+	// GET /oauth2/logout with client_id, post_logout_redirect_uri, and state.
+	logoutURL := ts.BaseURL + "/oauth2/logout?" + url.Values{
+		"client_id":               {clientID},
+		"post_logout_redirect_uri": {postLogoutURI},
+		"state":                   {"logout-state-xyz"},
+	}.Encode()
+
+	resp, err := ts.Client.Get(logoutURL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+	assert.Equal(t, postLogoutURI+"?state=logout-state-xyz", resp.Header.Get("Location"))
+}
+
+// TestRpInitiatedLogout_UnregisteredURIFallsBackToRoot confirms that an unregistered
+// post_logout_redirect_uri is silently rejected and the server falls back to /.
+func TestRpInitiatedLogout_UnregisteredURIFallsBackToRoot(t *testing.T) {
+	ts := startTestServer(t)
+
+	_, adminToken := createTestAdmin(t, ts, "admin@test.com", "password123", "admin@test.com")
+	clientResp := createTestClient(t, ts, adminToken, client.ClientCreateRequest{
+		ClientName:             "RP Logout Reject Test Client",
+		RedirectURIs:           []string{"http://localhost:3000/callback"},
+		PostLogoutRedirectURIs: []string{"http://localhost:3000/logged-out"},
+		GrantTypes:             []string{"authorization_code"},
+		ClientType:             "public",
+	})
+	clientID := clientResp["client_id"].(string)
+
+	logoutURL := ts.BaseURL + "/oauth2/logout?" + url.Values{
+		"client_id":               {clientID},
+		"post_logout_redirect_uri": {"http://evil.example.com/steal"},
+	}.Encode()
+
+	resp, err := ts.Client.Get(logoutURL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+	assert.Equal(t, "/", resp.Header.Get("Location"), "unregistered URI must be rejected")
+}

--- a/tests/e2e/test_server_test.go
+++ b/tests/e2e/test_server_test.go
@@ -102,7 +102,8 @@ func startTestServer(t *testing.T) *TestServer {
 	mux.HandleFunc(oauth+"/revoke", token.HandleRevoke)
 	mux.HandleFunc(oauth+"/userinfo", userinfo.HandleUserInfo)
 	mux.HandleFunc(oauth+"/protocol/openid-connect/userinfo", userinfo.HandleUserInfo)
-	mux.HandleFunc(oauth+"/logout", session.HandleLogout)
+	mux.HandleFunc("POST "+oauth+"/logout", session.HandleLogout)
+	mux.HandleFunc("GET "+oauth+"/logout", session.HandleRpInitiatedLogout)
 	mux.HandleFunc(oauth+"/introspect", introspect.HandleIntrospect)
 
 	// CSRF-protected routes (using plaintext wrapper for HTTP test server)


### PR DESCRIPTION
Closes #104

## Summary

- Adds `HandleRpInitiatedLogout` for `GET /oauth2/logout` per the [OpenID Connect RP-Initiated Logout 1.0](https://openid.net/specs/openid-connect-rpinitiated-1_0.html) spec
- Accepts `id_token_hint`, `post_logout_redirect_uri`, `state`, and `client_id` query params
- Parses `id_token_hint` (signature verified, expiry ignored per spec) to identify the user and deactivate their sessions
- Validates `post_logout_redirect_uri` against the client's registered URIs; falls back to `/` for unregistered or missing URIs
- Fixes the e2e test server which was catching all methods on `/oauth2/logout` instead of splitting `POST`/`GET`

## Test plan

- [ ] 8 new unit tests in `pkg/session/rp_initiated_logout_test.go` — all pass
- [ ] 3 new e2e tests in `tests/e2e/rp_initiated_logout_test.go` covering the full SSO kill flow, `post_logout_redirect_uri` + `state` passthrough, and open-redirect rejection
- [ ] Full e2e suite passes (`go test -p 1 ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)