### PR TITLE
chore: add post-build banner with next steps and feedback prompt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,16 @@ build-go:
 # Build admin UI + account UI + Go binary
 build: admin-ui-build account-ui-build
 	CGO_ENABLED=0 go build -ldflags="-s -w" -o $(APP_NAME) main.go
+	@echo ""
+	@echo "Build complete. Binary: ./$(APP_NAME)"
+	@echo ""
+	@echo "Next steps:"
+	@echo "  ./$(APP_NAME) init     # generate .env with keys and secrets"
+	@echo "  ./$(APP_NAME) start    # start the server"
+	@echo ""
+	@echo "Using Autentico? We'd love to hear from you."
+	@echo "Open an issue and tell us your use case: https://github.com/eugenioenko/autentico/issues"
+	@echo ""
 
 # Run the application
 run:


### PR DESCRIPTION
## Summary
- Prints next steps after `make build` completes (`./autentico init` → `./autentico start`)
- Adds a community feedback prompt linking to GitHub Issues

## Test plan
- [ ] Run `make build` and verify banner appears after the build finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)