### PR TITLE
fix: generate default passkey name instead of empty string

### DIFF
--- a/pkg/account/passkey.go
+++ b/pkg/account/passkey.go
@@ -226,7 +226,7 @@ func HandleAddPasskeyFinish(w http.ResponseWriter, r *http.Request) {
 	pCred := passkey.PasskeyCredential{
 		ID:         credentialID,
 		UserID:     usr.ID,
-		Name:       "",
+		Name:       passkey.GeneratePasskeyName(),
 		Credential: string(credJSON),
 	}
 	if err := passkey.CreatePasskeyCredential(pCred); err != nil {

--- a/pkg/passkey/handler.go
+++ b/pkg/passkey/handler.go
@@ -414,7 +414,7 @@ func HandleRegisterFinish(w http.ResponseWriter, r *http.Request) {
 	pCred := PasskeyCredential{
 		ID:         credentialID,
 		UserID:     usr.ID,
-		Name:       "",
+		Name:       GeneratePasskeyName(),
 		Credential: string(credJSON),
 	}
 	if err := CreatePasskeyCredential(pCred); err != nil {

--- a/pkg/passkey/model.go
+++ b/pkg/passkey/model.go
@@ -1,6 +1,9 @@
 package passkey
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
 	"time"
 
 	"github.com/eugenioenko/autentico/pkg/config"
@@ -62,6 +65,16 @@ func (u WebAuthnUser) WebAuthnID() []byte                         { return u.ID 
 func (u WebAuthnUser) WebAuthnName() string                       { return u.Name }
 func (u WebAuthnUser) WebAuthnDisplayName() string                { return u.Name }
 func (u WebAuthnUser) WebAuthnCredentials() []webauthn.Credential { return u.Credentials }
+
+// GeneratePasskeyName returns a default name like "Passkey a3f2".
+func GeneratePasskeyName() string {
+	b := make([]byte, 2)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "Passkey"
+	}
+	return fmt.Sprintf("Passkey %s", hex.EncodeToString(b))
+}
 
 // NewWebAuthn creates a WebAuthn instance from the current config.
 func NewWebAuthn() (*webauthn.WebAuthn, error) {


### PR DESCRIPTION
## Summary
- Fixes #91 — passkeys were created with an empty name, showing as "Unnamed Passkey" in the account UI
- Added `GeneratePasskeyName()` which returns a random name like "Passkey a3f2" (4 hex chars)
- Applied to both the signup registration flow (`pkg/passkey/handler.go`) and the account-UI add-passkey flow (`pkg/account/passkey.go`)

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./pkg/passkey/... ./pkg/account/...` passes
- [ ] Register a new passkey via signup flow — verify name is not empty
- [ ] Add a passkey via account UI — verify it shows a name like "Passkey a3f2"
- [ ] Verify rename still works from account UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)