### PR TITLE
fix: suppress static asset noise from request logs

### DIFF
--- a/account-ui/src/components/Sidebar.tsx
+++ b/account-ui/src/components/Sidebar.tsx
@@ -40,7 +40,7 @@ const Sidebar: React.FC<SidebarProps> = ({ open, onClose, username, initials, on
       <div className="flex items-center justify-between px-5 h-16">
         <div className="flex items-center gap-2">
           <img
-            src={settings.theme_logo_url || '/favicon.svg'}
+            src={settings.theme_logo_url || '/account/favicon.svg'}
             alt="Logo"
             className="h-6 w-6 object-contain"
           />

--- a/pkg/middleware/logging.go
+++ b/pkg/middleware/logging.go
@@ -7,6 +7,15 @@ import (
 	"time"
 )
 
+var silentPrefixes = []string{
+	"/admin/assets/",
+	"/account/assets/",
+	"/oauth2/static/",
+	"/admin/favicon.svg",
+	"/account/favicon.svg",
+	"/.well-known/appspecific/",
+}
+
 type responseWriter struct {
 	http.ResponseWriter
 	statusCode int
@@ -19,13 +28,16 @@ func (rw *responseWriter) WriteHeader(statusCode int) {
 
 func LoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		p := r.URL.Path
-		// skip logging for static assets
-		if strings.HasPrefix(p, "/admin/assets/") ||
-			strings.HasPrefix(p, "/account/assets/") ||
-			strings.HasPrefix(p, "/assets/") {
-			next.ServeHTTP(w, r)
-			return
+		// Skip logging for static asset GET requests served by embedded file servers.
+		// These are fixed mount points — no API or auth paths share these prefixes.
+		if r.Method == http.MethodGet {
+			p := r.URL.Path
+			for _, prefix := range silentPrefixes {
+				if strings.HasPrefix(p, prefix) {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
 		}
 
 		start := time.Now()


### PR DESCRIPTION
## Summary
- Filter out GET requests to embedded static file paths from request logs
- Filtered prefixes: `/admin/assets/`, `/account/assets/`, `/oauth2/static/`, `/admin/favicon.svg`, `/account/favicon.svg`, `/.well-known/appspecific/`
- Only GET requests are suppressed — POST/PUT/DELETE to these paths are still logged
- Fix account-ui favicon path from `/favicon.svg` to `/account/favicon.svg`

## Test plan
- [ ] Manual: browse admin and account UIs, verify static asset requests no longer appear in logs
- [ ] Manual: verify API calls, auth flows, and login requests are still logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)