### PR TITLE
chore: audit authorization server metadata against RFC 8414

### DIFF
--- a/pkg/model/well_known_config.go
+++ b/pkg/model/well_known_config.go
@@ -1,24 +1,44 @@
 package model
 
+// WellKnownConfigResponse is the authorization server metadata document
+// per RFC 8414 §2 and OIDC Discovery §3. Served at /.well-known/openid-configuration.
 type WellKnownConfigResponse struct {
-	Issuer                            string   `json:"issuer"`
-	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
-	TokenEndpoint                     string   `json:"token_endpoint"`
-	UserInfoEndpoint                  string   `json:"userinfo_endpoint"`
-	RegistrationEndpoint              string   `json:"registration_endpoint"`
-	EndSessionEndpoint                string   `json:"end_session_endpoint"`
-	JwksURI                           string   `json:"jwks_uri"`
-	ResponseTypesSupported            []string `json:"response_types_supported"`
-	SubjectTypesSupported             []string `json:"subject_types_supported"`
-	IDTokenSigningAlgValuesSupported  []string `json:"id_token_signing_alg_values_supported"`
-	ScopesSupported                   []string `json:"scopes_supported"`
+	// RFC 8414 §2: REQUIRED. Issuer identifier (no query or fragment).
+	Issuer string `json:"issuer"`
+	// RFC 8414 §2: REQUIRED (unless no grant types use the authorization endpoint).
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	// RFC 8414 §2: REQUIRED (unless only implicit grant type is supported).
+	TokenEndpoint string `json:"token_endpoint"`
+	// OIDC Discovery §3: RECOMMENDED.
+	UserInfoEndpoint string `json:"userinfo_endpoint"`
+	// RFC 8414 §2 / RFC 7591: OPTIONAL. Dynamic client registration endpoint.
+	RegistrationEndpoint string `json:"registration_endpoint"`
+	// OIDC RP-Initiated Logout 1.0 §2.1: end_session_endpoint.
+	EndSessionEndpoint string `json:"end_session_endpoint"`
+	// RFC 8414 §2: OPTIONAL. JWK Set document URL.
+	JwksURI string `json:"jwks_uri"`
+	// RFC 8414 §2: REQUIRED. OAuth 2.0 response_type values supported.
+	ResponseTypesSupported []string `json:"response_types_supported"`
+	// OIDC Discovery §3: REQUIRED.
+	SubjectTypesSupported []string `json:"subject_types_supported"`
+	// OIDC Discovery §3: REQUIRED.
+	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+	// RFC 8414 §2: RECOMMENDED.
+	ScopesSupported []string `json:"scopes_supported"`
+	// RFC 8414 §2: OPTIONAL (default: client_secret_basic).
 	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
-	ClaimsSupported                   []string `json:"claims_supported"`
-	GrantTypesSupported               []string `json:"grant_types_supported,omitempty"`
-	AcrValuesSupported                []string `json:"acr_values_supported,omitempty"`
-	RequestParameterSupported         bool     `json:"request_parameter_supported"`
-	// RFC 8414 §2
-	IntrospectionEndpoint        string   `json:"introspection_endpoint,omitempty"`
-	RevocationEndpoint           string   `json:"revocation_endpoint,omitempty"`
+	// OIDC Discovery §3: RECOMMENDED.
+	ClaimsSupported []string `json:"claims_supported"`
+	// RFC 8414 §2: OPTIONAL (default: ["authorization_code", "implicit"]).
+	GrantTypesSupported []string `json:"grant_types_supported,omitempty"`
+	// OIDC Core §3: OPTIONAL.
+	AcrValuesSupported []string `json:"acr_values_supported,omitempty"`
+	// OIDC Core §3: OPTIONAL.
+	RequestParameterSupported bool `json:"request_parameter_supported"`
+	// RFC 8414 §2: OPTIONAL. Token introspection endpoint.
+	IntrospectionEndpoint string `json:"introspection_endpoint,omitempty"`
+	// RFC 8414 §2: OPTIONAL. Token revocation endpoint.
+	RevocationEndpoint string `json:"revocation_endpoint,omitempty"`
+	// RFC 8414 §2: OPTIONAL. PKCE code challenge methods.
 	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
 }

--- a/pkg/wellknown/handler.go
+++ b/pkg/wellknown/handler.go
@@ -20,16 +20,17 @@ import (
 // @Router /.well-known/openid-configuration [get]
 func HandleWellKnownConfig(w http.ResponseWriter, r *http.Request) {
 	bs := config.GetBootstrap()
+	// RFC 8414 §2: issuer is REQUIRED — must match the iss claim in issued tokens.
 	// OIDC Discovery §3: issuer MUST exactly match the iss claim in issued tokens.
 	issuer := bs.AppAuthIssuer
 	response := model.WellKnownConfigResponse{
-		// OIDC Discovery §3: REQUIRED fields
+		// RFC 8414 §2: REQUIRED fields
 		Issuer:                issuer,
 		AuthorizationEndpoint: fmt.Sprintf("%s/authorize", issuer),
 		TokenEndpoint:         fmt.Sprintf("%s/token", issuer),
 		JwksURI:               fmt.Sprintf("%s/.well-known/jwks.json", bs.AppAuthIssuer),
-		// OIDC Discovery §3: REQUIRED — only "code" is implemented; implicit flow
-		// variants are not supported, so only advertise what the OP actually supports.
+		// RFC 8414 §2: response_types_supported is REQUIRED. Only "code" is
+		// implemented; implicit flow variants are not supported.
 		ResponseTypesSupported: []string{
 			"code",
 		},
@@ -41,14 +42,14 @@ func HandleWellKnownConfig(w http.ResponseWriter, r *http.Request) {
 		IDTokenSigningAlgValuesSupported: []string{
 			"RS256",
 		},
-		// OIDC Discovery §3: RECOMMENDED / SHOULD fields
+		// RFC 8414 §2: RECOMMENDED / OPTIONAL fields
 		UserInfoEndpoint:     fmt.Sprintf("%s/userinfo", issuer),
-		RegistrationEndpoint: fmt.Sprintf("%s/register", issuer),
-		EndSessionEndpoint:   fmt.Sprintf("%s/logout", issuer),
-		ScopesSupported: []string{
+		RegistrationEndpoint: fmt.Sprintf("%s/register", issuer),   // RFC 8414 §2 / RFC 7591
+		EndSessionEndpoint:   fmt.Sprintf("%s/logout", issuer),     // RP-Initiated Logout 1.0 §2.1
+		ScopesSupported: []string{                                  // RFC 8414 §2: RECOMMENDED
 			"openid", "profile", "email", "address", "phone", "offline_access",
 		},
-		TokenEndpointAuthMethodsSupported: []string{
+		TokenEndpointAuthMethodsSupported: []string{                // RFC 8414 §2: OPTIONAL
 			"client_secret_basic", "client_secret_post",
 		},
 		ClaimsSupported: []string{
@@ -60,13 +61,15 @@ func HandleWellKnownConfig(w http.ResponseWriter, r *http.Request) {
 			"phone_number",
 			"address",
 		},
+		// RFC 8414 §2: OPTIONAL (default: ["authorization_code", "implicit"]).
+		// We explicitly list supported types to override the default.
 		GrantTypesSupported:       []string{"authorization_code", "refresh_token", "password"},
 		AcrValuesSupported:        []string{"1"},
 		RequestParameterSupported: false, // OIDC Core §6: request objects not supported
-		// RFC 8414 §2 / OIDC Discovery §3: additional endpoint metadata
-		IntrospectionEndpoint:         fmt.Sprintf("%s/introspect", issuer),
-		RevocationEndpoint:            fmt.Sprintf("%s/revoke", issuer),
-		CodeChallengeMethodsSupported: []string{"S256"}, // RFC 7636 §6.2
+		// RFC 8414 §2: OPTIONAL endpoint metadata
+		IntrospectionEndpoint:         fmt.Sprintf("%s/introspect", issuer),  // RFC 7662
+		RevocationEndpoint:            fmt.Sprintf("%s/revoke", issuer),      // RFC 7009
+		CodeChallengeMethodsSupported: []string{"S256"},                      // RFC 7636 §6.2
 	}
 
 	utils.WriteApiResponse(w, response, http.StatusOK)

--- a/pkg/wellknown/handler_test.go
+++ b/pkg/wellknown/handler_test.go
@@ -154,6 +154,68 @@ func TestHandleWellKnownConfig_IssuerMatchesTokenIss(t *testing.T) {
 		"OIDC Discovery §3: issuer must exactly match the iss claim source")
 }
 
+// RFC 8414 §2: verify all REQUIRED metadata fields and that OPTIONAL fields
+// with values are present as expected.
+func TestHandleWellKnownConfig_RFC8414_RequiredFields(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	rr := httptest.NewRecorder()
+
+	HandleWellKnownConfig(rr, req)
+
+	// Parse as raw map to check field presence and types
+	var raw map[string]interface{}
+	err := json.Unmarshal(rr.Body.Bytes(), &raw)
+	assert.NoError(t, err)
+
+	// RFC 8414 §2: REQUIRED fields
+	assert.Contains(t, raw, "issuer", "RFC 8414 §2: issuer is REQUIRED")
+	assert.Contains(t, raw, "authorization_endpoint", "RFC 8414 §2: authorization_endpoint is REQUIRED")
+	assert.Contains(t, raw, "token_endpoint", "RFC 8414 §2: token_endpoint is REQUIRED")
+	assert.Contains(t, raw, "response_types_supported", "RFC 8414 §2: response_types_supported is REQUIRED")
+
+	// RFC 8414 §2: RECOMMENDED
+	assert.Contains(t, raw, "scopes_supported", "RFC 8414 §2: scopes_supported is RECOMMENDED")
+
+	// RFC 8414 §2: OPTIONAL but expected for this server
+	assert.Contains(t, raw, "jwks_uri")
+	assert.Contains(t, raw, "registration_endpoint")
+	assert.Contains(t, raw, "grant_types_supported")
+	assert.Contains(t, raw, "token_endpoint_auth_methods_supported")
+	assert.Contains(t, raw, "introspection_endpoint")
+	assert.Contains(t, raw, "revocation_endpoint")
+	assert.Contains(t, raw, "code_challenge_methods_supported")
+
+	// RFC 8414 §3: "Claims with zero elements MUST be omitted from the response."
+	// Verify all array fields have at least one element.
+	for _, arrayField := range []string{
+		"response_types_supported", "scopes_supported",
+		"token_endpoint_auth_methods_supported", "grant_types_supported",
+		"code_challenge_methods_supported",
+	} {
+		arr, ok := raw[arrayField].([]interface{})
+		if ok {
+			assert.NotEmpty(t, arr, "RFC 8414 §3: %s must not be empty if present", arrayField)
+		}
+	}
+}
+
+// RFC 8414 §3: The "issuer" value returned MUST be identical to the authorization
+// server's issuer identifier (simple string comparison).
+func TestHandleWellKnownConfig_RFC8414_IssuerIdentity(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	rr := httptest.NewRecorder()
+
+	HandleWellKnownConfig(rr, req)
+
+	var response model.WellKnownConfigResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	// RFC 8414 §3: issuer must be identical via simple string comparison
+	assert.Equal(t, config.GetBootstrap().AppAuthIssuer, response.Issuer,
+		"RFC 8414 §3: issuer must be identical to the authorization server's issuer identifier")
+}
+
 func TestHandleJWKS(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/oauth2/.well-known/jwks.json", nil)
 	rr := httptest.NewRecorder()

--- a/rfc/rfc.md
+++ b/rfc/rfc.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Nine phases tackling one spec at a time, in dependency order. Each phase: read spec sections, review code paths, fix bugs, add unit + e2e tests (both positive and negative), annotate response/validation code with RFC comments, fill in the MUST/SHOULD/MAY table, review Security Considerations, and verify discovery document reflects the phase's features.
+Ten phases tackling one spec at a time, in dependency order. Each phase: read spec sections, review code paths, fix bugs, add unit + e2e tests (both positive and negative), annotate response/validation code with RFC comments, fill in the MUST/SHOULD/MAY table, review Security Considerations, and verify discovery document reflects the phase's features.
 
 | Phase | Spec | Est. Time | Status |
 |---|---|---|---|
@@ -15,8 +15,9 @@ Nine phases tackling one spec at a time, in dependency order. Each phase: read s
 | 7 | OIDC Discovery 1.0 | 1h | ✅ Done (2026-03-30) |
 | 8 | OIDC RP-Initiated Logout 1.0 | 1.5h | ✅ Done (2026-04-03) |
 | 9 | RFC 7591 — Dynamic Client Registration | 1.5h | ✅ Done (2026-04-03) |
+| 10 | RFC 8414 — OAuth 2.0 Authorization Server Metadata | 0.5h | ✅ Done (2026-04-03) |
 
-**Recommended order:** 1 → 4 → 5 → 2 → 3 → 6 → 7 → 8 → 9
+**Recommended order:** 1 → 4 → 5 → 2 → 3 → 6 → 7 → 8 → 9 → 10
 
 ---
 
@@ -606,3 +607,55 @@ This is analogous to the existing "public endpoints by design" decision for intr
 - Unit: `TestHandleRegister_RFC7591_PublicClient_NoSecret` — public client has no secret (positive) ✅ Added
 - Unit: `TestHandleUpdateClient_RFC7591_InvalidMetadata_ErrorCode` — update `invalid_client_metadata` (negative) ✅ Added
 - Unit: `TestHandleUpdateClient_RFC7591_InvalidRedirectURI_ErrorCode` — update `invalid_redirect_uri` (negative) ✅ Added
+
+---
+
+## Phase 10 — RFC 8414: OAuth 2.0 Authorization Server Metadata
+
+**File:** `rfc/rfc8414.txt` (pre-existing)
+
+**Context:** RFC 8414 defines the OAuth 2.0 authorization server metadata format. It heavily overlaps with OIDC Discovery 1.0 (Phase 7) since both specify the `.well-known` metadata document. This phase verifies that the existing implementation satisfies RFC 8414's requirements and adds RFC 8414 section annotations alongside the existing OIDC Discovery ones.
+
+**Note:** No bugs found. The implementation was fully compliant — this phase is annotations and verification only.
+
+| Section | What to check | Code path |
+|---|---|---|
+| §2 | REQUIRED: `issuer`, `authorization_endpoint`, `token_endpoint`, `response_types_supported` | `pkg/wellknown/handler.go`, `pkg/model/well_known_config.go` |
+| §2 | RECOMMENDED: `scopes_supported` | `pkg/wellknown/handler.go` |
+| §2 | OPTIONAL: `jwks_uri`, `registration_endpoint`, `grant_types_supported`, `token_endpoint_auth_methods_supported`, `introspection_endpoint`, `revocation_endpoint`, `code_challenge_methods_supported` | `pkg/wellknown/handler.go` |
+| §3 | Metadata available at well-known path; `issuer` must match; zero-element arrays omitted | `pkg/wellknown/handler.go`, `pkg/cli/start.go` route |
+
+**MUST / SHOULD / MAY compliance:**
+
+| Keyword | Section | Requirement | Status |
+|---------|---------|-------------|--------|
+| MUST | §2 | `issuer` REQUIRED (HTTPS, no query/fragment) | ✅ Pre-existing + annotated (2026-04-03) |
+| MUST | §2 | `authorization_endpoint` REQUIRED | ✅ Pre-existing + annotated (2026-04-03) |
+| MUST | §2 | `token_endpoint` REQUIRED | ✅ Pre-existing + annotated (2026-04-03) |
+| MUST | §2 | `response_types_supported` REQUIRED | ✅ Pre-existing + annotated (2026-04-03) |
+| MUST | §3 | Metadata served at well-known path | ✅ Pre-existing — `/.well-known/openid-configuration` (§5 permits this suffix) |
+| MUST | §3 | `issuer` in response identical to server's issuer identifier | ✅ Pre-existing — verified by `TestHandleWellKnownConfig_RFC8414_IssuerIdentity` |
+| MUST | §3 | Zero-element arrays omitted from response | ✅ Pre-existing — all arrays are populated; `omitempty` on optional fields |
+| RECOMMENDED | §2 | `scopes_supported` | ✅ Pre-existing + annotated (2026-04-03) |
+| OPTIONAL | §2 | `jwks_uri` | ✅ Pre-existing |
+| OPTIONAL | §2 | `registration_endpoint` | ✅ Pre-existing |
+| OPTIONAL | §2 | `grant_types_supported` (default: authorization_code + implicit) | ✅ Pre-existing — explicitly listed to override default |
+| OPTIONAL | §2 | `token_endpoint_auth_methods_supported` (default: client_secret_basic) | ✅ Pre-existing |
+| OPTIONAL | §2 | `revocation_endpoint` | ✅ Pre-existing (Phase 4) |
+| OPTIONAL | §2 | `introspection_endpoint` | ✅ Pre-existing (Phase 5) |
+| OPTIONAL | §2 | `code_challenge_methods_supported` | ✅ Pre-existing (Phase 3) |
+| OPTIONAL | §2 | `service_documentation` | ⏭ Not implemented — no documentation URL configured |
+| OPTIONAL | §2 | `revocation_endpoint_auth_methods_supported` | ⏭ Not implemented — revocation is public by design |
+| OPTIONAL | §2 | `introspection_endpoint_auth_methods_supported` | ⏭ Not implemented — introspection is public by design |
+
+**Security Considerations (§6):**
+- [x] §6: TLS required for metadata endpoint — enforced at infrastructure level in production
+- [x] §6: Issuer identifier in response must match requested — both use `AppAuthIssuer`; verified by tests
+- [x] §6: Client MUST verify issuer identity — client-side responsibility per spec
+
+**Tests:**
+- Unit: `TestHandleWellKnownConfig_RFC8414_RequiredFields` — all REQUIRED/RECOMMENDED/OPTIONAL fields present, zero-element check ✅ Added
+- Unit: `TestHandleWellKnownConfig_RFC8414_IssuerIdentity` — issuer matches server identifier (positive) ✅ Added
+- Unit: `TestHandleWellKnownConfig_RFC8414_Endpoints` — introspection, revocation, PKCE endpoints ✅ Pre-existing
+- Unit: `TestHandleWellKnownConfig_RequiredFields` — OIDC Discovery required fields ✅ Pre-existing (Phase 7)
+- Unit: `TestHandleWellKnownConfig_IssuerMatchesTokenIss` — issuer matches token iss ✅ Pre-existing (Phase 7)


### PR DESCRIPTION
## Summary

Verification pass for RFC 8414 (OAuth 2.0 Authorization Server Metadata). No bugs found — the `.well-known/openid-configuration` response was already fully compliant via Phase 7 (OIDC Discovery).

- Add RFC 8414 §2 annotations to `WellKnownConfigResponse` model and handler
- Add 2 new tests for required fields and issuer identity verification
- Add Phase 10 to `rfc/rfc.md` with full MUST/SHOULD/MAY compliance table

**This completes the full OAuth 2.0 / OIDC spec coverage:**
RFC 6749, 6750, 7009, 7591, 7636, 7662, 8414 + OIDC Core 1.0, Discovery 1.0, RP-Initiated Logout 1.0

## Test plan

- [x] 2 new RFC 8414 compliance tests (required fields, issuer identity)
- [x] All existing wellknown tests pass
- [x] Full test suite passes (`go test -p 1 ./...` — 38/38 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)