### PR TITLE
chore: update branding to OAuth 2.0 / OIDC after full spec coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Autentico is a self-contained OpenID Connect (OIDC) Identity Provider built with Go and SQLite. It implements the full authentication lifecycle: Authorization Code + PKCE, ROPC, Refresh Token grants, MFA (TOTP + email OTP), WebAuthn/passkeys, SSO sessions, trusted devices, token introspection/revocation, and an embedded React admin UI.
+Autentico is a self-contained OAuth 2.0 / OpenID Connect (OIDC) Identity Provider built with Go and SQLite. It implements the full authentication lifecycle: Authorization Code + PKCE, ROPC, Refresh Token grants, MFA (TOTP + email OTP), WebAuthn/passkeys, SSO sessions, trusted devices, token introspection/revocation, dynamic client registration, and an embedded React admin UI.
 
 ## Common Commands
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Autentico — OIDC Identity Provider
+# Autentico — OAuth 2.0 / OIDC Identity Provider
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/eugenioenko/autentico)](https://goreportcard.com/report/github.com/eugenioenko/autentico)
 [![Test Coverage](https://img.shields.io/badge/coverage-73.4%25-green.svg)](https://github.com/eugenioenko/autentico)
@@ -7,7 +7,7 @@
 [![Go Version](https://img.shields.io/badge/go-1.23+-blue.svg)](https://golang.org/dl/)
 [![License](https://img.shields.io/badge/license-AGPL--v3-blue.svg)](LICENSE)
 
-**Auténtico is a self-contained OpenID Connect (OIDC) Identity Provider built with Go. It handles the full authentication lifecycle — login, MFA, passkeys, sessions, token issuance, and admin — in a single binary backed by SQLite. No external database, no infrastructure dependencies, no ceremony.**
+**Auténtico is a self-contained OAuth 2.0 / OpenID Connect (OIDC) Identity Provider built with Go. It handles the full authentication lifecycle — login, MFA, passkeys, sessions, token issuance, and admin — in a single binary backed by SQLite. No external database, no infrastructure dependencies, no ceremony.**
 
 Identity infrastructure is typically complex to operate: a separate database to provision and back up, a cache tier, a worker queue, multiple services to keep running, and credentials to rotate. Auténtico takes a different approach. The entire IdP — authentication, token issuance, session management, and the admin UI — runs as one Go binary backed by a single SQLite file. You deploy one thing and it works.
 
@@ -44,7 +44,7 @@ Auténtico removes that stack:
 - **Embedded SQLite** — no separate database server; the entire state lives in one file
 - **No external infrastructure** — no Redis, no Postgres, no message queues
 - **Built-in admin UI** — a React dashboard compiled into the binary; nothing to deploy separately
-- **Standards-compliant OIDC** — relying parties configure themselves automatically via OIDC Discovery; tokens are RS256-signed JWTs verifiable without calling home
+- **Standards-compliant OAuth 2.0 / OIDC** — relying parties configure themselves automatically via OIDC Discovery; tokens are RS256-signed JWTs verifiable without calling home
 
 The operational surface area is a binary and a `.env` file. That is a meaningful reduction in the things that can break.
 
@@ -931,7 +931,7 @@ Each RFC is treated as a source of truth:
 - **SHOULD/MAY** clauses are evaluated and explicitly accepted or rejected
 - All decisions are documented and tested
 
-The review is structured as a 7-phase audit. Each phase reads the spec, verifies every MUST/SHOULD/MAY requirement against the implementation, annotates the code with inline RFC section references, adds both positive and negative tests, and checks the Security Considerations section.
+The review is structured as a 10-phase audit. Each phase reads the spec, verifies every MUST/SHOULD/MAY requirement against the implementation, annotates the code with inline RFC section references, adds both positive and negative tests, and checks the Security Considerations section.
 
 | Phase | Spec | Status |
 |---|---|---|
@@ -942,6 +942,9 @@ The review is structured as a 7-phase audit. Each phase reads the spec, verifies
 | 5 | RFC 7662 — Token Introspection | ✅ Done |
 | 6 | OIDC Core 1.0 | ✅ Done |
 | 7 | OIDC Discovery 1.0 | ✅ Done |
+| 8 | OIDC RP-Initiated Logout 1.0 | ✅ Done |
+| 9 | RFC 7591 — Dynamic Client Registration | ✅ Done |
+| 10 | RFC 8414 — Authorization Server Metadata | ✅ Done |
 
 This process effectively turns the RFCs into an executable specification enforced by tests.
 

--- a/docs-web/astro.config.mjs
+++ b/docs-web/astro.config.mjs
@@ -28,7 +28,7 @@ export default defineConfig({
 				},
 			],
 			title: 'Autentico',
-			description: 'Documentation for the Autentico OpenID Connect Identity Provider',
+			description: 'Documentation for the Autentico OAuth 2.0 / OpenID Connect Identity Provider',
 			favicon: '/favicon.svg',
 			logo: {
 				src: './src/assets/logo.svg',

--- a/docs-web/public/llms.txt
+++ b/docs-web/public/llms.txt
@@ -1,6 +1,6 @@
 # Autentico
 
-> Autentico is a self-contained OpenID Connect (OIDC) Identity Provider built with Go and SQLite. Single binary, no external dependencies. Handles login, MFA, passkeys, sessions, token issuance, and admin — backed by a single SQLite file.
+> Autentico is a self-contained OAuth 2.0 / OpenID Connect (OIDC) Identity Provider built with Go and SQLite. Single binary, no external dependencies. Handles login, MFA, passkeys, sessions, token issuance, and admin — backed by a single SQLite file.
 
 ---
 

--- a/docs-web/src/content/docs/index.mdx
+++ b/docs-web/src/content/docs/index.mdx
@@ -22,7 +22,7 @@ import { Card, CardGrid, LinkButton } from "@astrojs/starlight/components";
 
 ## What is Autentico?
 
-Autentico is a self-hosted OpenID Connect Identity Provider built with Go. It handles the full authentication lifecycle: login, MFA, passkeys, session management, token issuance, and administration, all in a single binary backed by SQLite.
+Autentico is a self-hosted OAuth 2.0 / OpenID Connect Identity Provider built with Go. It handles the full authentication lifecycle: login, MFA, passkeys, session management, token issuance, and administration, all in a single binary backed by SQLite.
 
 A typical self-hosted Identity Provider involves a database server, a cache layer, multiple processes, and everything that comes with keeping them running. Autentico removes that stack: just one binary and one database file. The simplicity is operational, not protocol-level.
 
@@ -52,9 +52,10 @@ No Docker, no database to provision, no config files to edit.
 ## Features
 
 <CardGrid>
-  <Card title="OIDC & OAuth2" icon="open-book">
+  <Card title="OAuth 2.0 & OIDC" icon="open-book">
     Authorization Code Flow with PKCE, Refresh Tokens, ROPC, Token Introspection
-    (RFC 7662), Token Revocation (RFC 7009), and a full OIDC Discovery document.
+    (RFC 7662), Token Revocation (RFC 7009), Dynamic Client Registration (RFC 7591),
+    and a full OIDC Discovery document.
   </Card>
   <Card title="Passkeys & MFA" icon="approve-check-circle">
     WebAuthn/FIDO2 passkey authentication, TOTP with in-browser QR enrollment,


### PR DESCRIPTION
## Summary

With all 10 RFC compliance phases complete, updates the project description across README, docs-web, llms.txt, and CLAUDE.md to say "OAuth 2.0 / OIDC" instead of only "OIDC".

Also updates the README compliance table from 7 phases to 10 (adding RP-Initiated Logout, RFC 7591 DCR, RFC 8414 AS Metadata).

**Full spec coverage:**
- RFC 6749 (OAuth 2.0 Core), RFC 6750 (Bearer Token), RFC 7009 (Revocation), RFC 7591 (DCR), RFC 7636 (PKCE), RFC 7662 (Introspection), RFC 8414 (AS Metadata)
- OIDC Core 1.0, Discovery 1.0, RP-Initiated Logout 1.0

## Test plan

- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)