### PR TITLE
fix: proper error codes for admin user endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,16 @@ fmt:
 test:
 	go test -p 1 -v ./...
 
+# Run functional black-box tests (builds binary if needed, starts real server)
+.PHONY: test-functional
+test-functional: build-go
+	cd tests/functional && pnpm install && pnpm test
+
+# Run e2e Go tests
+.PHONY: test-e2e
+test-e2e:
+	go test -p 1 -v ./tests/e2e/...
+
 # Run a linter (requires `golangci-lint`)
 lint:
 	golangci-lint run ./...

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/eugenioenko/autentico/pkg/audit"
 	"github.com/eugenioenko/autentico/pkg/config"
@@ -66,6 +67,10 @@ func HandleCreateUser(w http.ResponseWriter, r *http.Request) {
 	}
 	response, err := CreateUser(request.Username, request.Password, request.Email)
 	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint") {
+			utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "A user with that username or email already exists")
+			return
+		}
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", fmt.Sprintf("User creation error. %v", err))
 		return
 	}
@@ -131,6 +136,10 @@ func HandleUpdateUser(w http.ResponseWriter, r *http.Request) {
 	}
 	err := UpdateUser(id, req)
 	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			utils.WriteErrorResponse(w, http.StatusNotFound, "not_found", "User not found")
+			return
+		}
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
 	}
@@ -162,6 +171,10 @@ func HandleDeleteUser(w http.ResponseWriter, r *http.Request) {
 	}
 	err := DeleteUser(id)
 	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			utils.WriteErrorResponse(w, http.StatusNotFound, "not_found", "User not found")
+			return
+		}
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
 	}

--- a/pkg/user/handler_test.go
+++ b/pkg/user/handler_test.go
@@ -228,8 +228,8 @@ func TestHandleCreateUser_DuplicateUser(t *testing.T) {
 	req = httptest.NewRequest(http.MethodPost, "/admin/api/users", bytes.NewBuffer(body))
 	rr = httptest.NewRecorder()
 	HandleCreateUser(rr, req)
-	assert.Equal(t, http.StatusInternalServerError, rr.Code)
-	assert.Contains(t, rr.Body.String(), "User creation error")
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "already exists")
 }
 
 // --- HandleGetUser tests ---

--- a/tests/functional/FUNCTIONAL.md
+++ b/tests/functional/FUNCTIONAL.md
@@ -71,16 +71,6 @@ These are covered by Playwright browser tests (`tests/browser/`) or Go e2e tests
 
 ## Discoveries
 
-### API issues found
-
-| Severity | Endpoint | Issue |
-|----------|----------|-------|
-| Low | `POST /admin/api/users` (duplicate) | Returns 500 instead of 400 — DB unique constraint error not mapped to a user-facing error response |
-| Low | `PUT /admin/api/users/{id}` (nonexistent) | Returns 500 instead of 404 |
-| Low | `DELETE /admin/api/users/{id}` (nonexistent) | Returns 500 instead of 404 |
-
-These are unhandled database error paths, not security issues. The server catches the error but returns a generic 500 instead of mapping the constraint violation or "not found" condition to the appropriate HTTP status code.
-
 ### API strengths confirmed
 
 - **OAuth 2.0 / OIDC compliance:** Discovery, JWKS, authorization code flow, token exchange, refresh, revocation, introspection — all work correctly end-to-end against a real running instance

--- a/tests/functional/tests/admin-users.test.ts
+++ b/tests/functional/tests/admin-users.test.ts
@@ -110,9 +110,9 @@ describe('Admin Users — error cases', () => {
     const token = await getAdminToken();
     // Create first
     await postJSON(API, { username: 'dupuser', password: 'TestPass123!' }, token);
-    // Try duplicate — server returns 500 (DB constraint error not mapped to 400)
+    // Try duplicate
     const resp = await postJSON(API, { username: 'dupuser', password: 'TestPass123!' }, token);
-    expect(resp.ok).toBe(false);
+    expect(resp.status).toBe(400);
   });
 
   it('returns 404 for nonexistent user GET', async () => {
@@ -121,16 +121,16 @@ describe('Admin Users — error cases', () => {
     expect(resp.status).toBe(404);
   });
 
-  it('returns error for nonexistent user PUT', async () => {
+  it('returns 404 for nonexistent user PUT', async () => {
     const token = await getAdminToken();
     const resp = await putJSON(`${API}/nonexistent-id-12345`, { email: 'x@y.com' }, token);
-    expect(resp.ok).toBe(false);
+    expect(resp.status).toBe(404);
   });
 
-  it('returns error for nonexistent user DELETE', async () => {
+  it('returns 404 for nonexistent user DELETE', async () => {
     const token = await getAdminToken();
     const resp = await deleteRequest(`${API}/nonexistent-id-12345`, token);
-    expect(resp.ok).toBe(false);
+    expect(resp.status).toBe(404);
   });
 
   it('GET list rejects without token', async () => {


### PR DESCRIPTION
## Summary

Fixes three error handling issues in the admin users API discovered by functional tests:

| Endpoint | Before | After |
|----------|--------|-------|
| `POST /admin/api/users` (duplicate username/email) | 500 | 400 "already exists" |
| `PUT /admin/api/users/{id}` (nonexistent) | 500 | 404 "not found" |
| `DELETE /admin/api/users/{id}` (nonexistent) | 500 | 404 "not found" |

Also:
- Updated functional tests to assert correct status codes (was using lenient `resp.ok === false`)
- Removed "API issues found" section from FUNCTIONAL.md (all fixed)
- Updated existing unit test `TestHandleCreateUser_DuplicateUser` for new 400 behavior
- Added Makefile targets: `make test-functional`, `make test-e2e`

## Test plan

- [x] All 104 functional tests pass
- [x] All 821+ Go unit/e2e tests pass
- [x] `TestHandleCreateUser_DuplicateUser` updated to expect 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)