### PR TITLE
fix: allow Google Fonts in CSP header

### DIFF
--- a/pkg/middleware/security_headers.go
+++ b/pkg/middleware/security_headers.go
@@ -13,7 +13,7 @@ func SecurityHeadersMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 
 		// Basic Content Security Policy — restrict scripts/styles to same origin.
-		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; form-action 'self'; frame-ancestors 'none'")
+		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'; form-action 'self'; frame-ancestors 'none'")
 
 		// Permissions Policy — disable browser features not used by the IdP.
 		w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=()")


### PR DESCRIPTION
## Summary
- Adds `https://fonts.googleapis.com` to `style-src` and `https://fonts.gstatic.com` to `font-src` in the CSP header
- Fixes Google Fonts (Inter) not loading after CSP was tightened in #146

## Test plan
- [ ] Verify Inter font loads on login, signup, MFA, and onboarding pages
- [ ] Verify no CSP violations in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)