### PR TITLE
security: store authorize params server-side to prevent form tampering

### DIFF
--- a/pkg/authorize/handler.go
+++ b/pkg/authorize/handler.go
@@ -9,16 +9,13 @@ import (
 	"time"
 
 	authcode "github.com/eugenioenko/autentico/pkg/auth_code"
+	"github.com/eugenioenko/autentico/pkg/authrequest"
 	"github.com/eugenioenko/autentico/pkg/client"
 	"github.com/eugenioenko/autentico/pkg/config"
-	"github.com/eugenioenko/autentico/pkg/federation"
 	"github.com/eugenioenko/autentico/pkg/idpsession"
 	"github.com/eugenioenko/autentico/pkg/middleware"
-	"github.com/eugenioenko/autentico/pkg/signup"
 	"github.com/eugenioenko/autentico/pkg/utils"
 	"github.com/eugenioenko/autentico/view"
-
-	"github.com/gorilla/csrf"
 )
 
 // HandleAuthorize godoc
@@ -179,83 +176,42 @@ func HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Store the authorize parameters server-side and redirect to the login/signup page.
+	// This prevents parameter tampering via hidden form fields (PKCE downgrade, scope
+	// escalation, nonce injection — see issues #184 and #186).
+	authReqID, err := authrequest.Create(authrequest.AuthorizeRequest{
+		ClientID:            request.ClientID,
+		RedirectURI:         request.RedirectURI,
+		Scope:               request.Scope,
+		State:               request.State,
+		Nonce:               request.Nonce,
+		CodeChallenge:       request.CodeChallenge,
+		CodeChallengeMethod: request.CodeChallengeMethod,
+		ResponseType:        request.ResponseType,
+	})
+	if err != nil {
+		slog.Error("authorize: failed to store authorize request", "request_id", middleware.GetRequestID(r.Context()), "error", err)
+		redirectWithError(w, r, request.RedirectURI, request.State, "server_error", "Failed to process authorization request")
+		return
+	}
+
 	// OIDC Core §3.1.2.1: prompt=create signals the client wants the registration form
 	if request.Prompt == "create" {
 		if !config.Get().AuthAllowSelfSignup {
-			renderLogin(w, r, request, "Self-registration is not enabled")
+			http.Redirect(w, r, config.GetBootstrap().AppOAuthPath+"/login?auth_request_id="+authReqID+"&error=Self-registration+is+not+enabled", http.StatusFound)
 			return
 		}
-		signup.RenderSignup(w, r, signup.SignupParams{
-			State:               request.State,
-			RedirectURI:         request.RedirectURI,
-			ClientID:            request.ClientID,
-			Scope:               request.Scope,
-			Nonce:               request.Nonce,
-			CodeChallenge:       request.CodeChallenge,
-			CodeChallengeMethod: request.CodeChallengeMethod,
-		}, get("error"))
+		http.Redirect(w, r, config.GetBootstrap().AppOAuthPath+"/signup?auth_request_id="+authReqID, http.StatusFound)
 		return
 	}
 
-	// If the authorize request arrived as POST, redirect to GET so that the CSRF
-	// middleware runs and sets the CSRF cookie before rendering the login form.
-	if r.Method == http.MethodPost {
-		q := url.Values{}
-		q.Set("response_type", request.ResponseType)
-		q.Set("client_id", request.ClientID)
-		q.Set("redirect_uri", request.RedirectURI)
-		q.Set("scope", request.Scope)
-		q.Set("state", request.State)
-		q.Set("nonce", request.Nonce)
-		q.Set("code_challenge", request.CodeChallenge)
-		q.Set("code_challenge_method", request.CodeChallengeMethod)
-		q.Set("prompt", request.Prompt)
-		q.Set("max_age", request.MaxAge)
-		http.Redirect(w, r, "/oauth2/authorize?"+q.Encode(), http.StatusFound)
-		return
+	loginURL := config.GetBootstrap().AppOAuthPath + "/login?auth_request_id=" + authReqID
+	if errMsg := get("error"); errMsg != "" {
+		loginURL += "&error=" + url.QueryEscape(errMsg)
 	}
-
-	renderLogin(w, r, request, get("error"))
+	http.Redirect(w, r, loginURL, http.StatusFound)
 }
 
-// renderLogin renders the login form, or an error-only page when errorMsg is a fatal
-// configuration problem (e.g. invalid redirect URI) where submitting the form makes no sense.
-func renderLogin(w http.ResponseWriter, r *http.Request, request AuthorizeRequest, errorMsg string) {
-	cfg := config.Get()
-	tmpl, err := view.ParseTemplate("login")
-	if err != nil {
-		slog.Error("authorize: failed to parse login template", "request_id", middleware.GetRequestID(r.Context()), "error", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-
-	federatedProviders, _ := federation.ListEnabledProviderViews()
-
-	data := map[string]any{
-		"State":               request.State,
-		"RedirectURI":         request.RedirectURI,
-		"ClientID":            request.ClientID,
-		"Scope":               request.Scope,
-		"Nonce":               request.Nonce,
-		"CodeChallenge":       request.CodeChallenge,
-		"CodeChallengeMethod": request.CodeChallengeMethod,
-		"Error":               errorMsg,
-		"AuthMode":            cfg.AuthMode,
-		"AllowSelfSignup":     cfg.AuthAllowSelfSignup,
-		"ProfileFieldEmail":   cfg.ProfileFieldEmail,
-		csrf.TemplateTag:      csrf.TemplateField(r),
-		"ThemeTitle":          cfg.Theme.Title,
-		"ThemeLogoUrl":        cfg.Theme.LogoUrl,
-		"ThemeCssResolved":    template.CSS(cfg.ThemeCssResolved),
-		"SmtpConfigured":     cfg.SmtpHost != "",
-		"FederatedProviders":  federatedProviders,
-	}
-
-	if err = tmpl.ExecuteTemplate(w, "layout", data); err != nil {
-		slog.Error("authorize: failed to execute login template", "request_id", middleware.GetRequestID(r.Context()), "error", err)
-		http.Error(w, "Template Execution Error", http.StatusInternalServerError)
-	}
-}
 
 // redirectWithError redirects back to the redirect_uri with OAuth2 error params.
 // Per RFC 6749 §4.1.2.1 and Appendix B, all query values are percent-encoded.

--- a/pkg/authorize/handler_test.go
+++ b/pkg/authorize/handler_test.go
@@ -25,14 +25,14 @@ func TestHandleAuthorize(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	// Verify the response
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "form")
-	assert.Contains(t, rr.Body.String(), "username")
-	assert.Contains(t, rr.Body.String(), "password")
+	// Authorize now stores the request server-side and redirects to the login page
+	assert.Equal(t, http.StatusFound, rr.Code)
+	loc := rr.Header().Get("Location")
+	assert.Contains(t, loc, "/oauth2/login")
+	assert.Contains(t, loc, "auth_request_id=")
 }
 
-func TestHandleAuthorize_PostRedirectsToGet(t *testing.T) {
+func TestHandleAuthorize_PostRedirectsToLogin(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.InsertTestClient(t, "test-client", []string{"http://localhost/callback"})
 
@@ -43,14 +43,11 @@ func TestHandleAuthorize_PostRedirectsToGet(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	// POST must redirect to GET so the CSRF middleware can set the cookie
+	// POST also stores the request and redirects to login
 	assert.Equal(t, http.StatusFound, rr.Code)
 	loc := rr.Header().Get("Location")
-	assert.Contains(t, loc, "/oauth2/authorize")
-	assert.Contains(t, loc, "response_type=code")
-	assert.Contains(t, loc, "client_id=test-client")
-	assert.Contains(t, loc, "state=xyz")
-	assert.Contains(t, loc, "nonce=abc")
+	assert.Contains(t, loc, "/oauth2/login")
+	assert.Contains(t, loc, "auth_request_id=")
 }
 
 func TestHandleAuthorize_PostInvalidClient_ShowsError(t *testing.T) {
@@ -254,10 +251,10 @@ func TestHandleAuthorize_AutoLogin_Disabled(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	// Should show login form, not redirect
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "form")
-	assert.Contains(t, rr.Body.String(), "username")
+	// Should redirect to login page, not auto-login
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "/oauth2/login")
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=")
 }
 
 func TestHandleAuthorize_AutoLogin_ExpiredSession(t *testing.T) {
@@ -290,9 +287,10 @@ func TestHandleAuthorize_AutoLogin_ExpiredSession(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	// Should show login form since last activity was too long ago
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "form")
+	// Should redirect to login since last activity was too long ago
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "/oauth2/login")
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=")
 }
 
 func TestHandleAuthorize_AutoLogin_DeactivatedSession(t *testing.T) {
@@ -325,9 +323,10 @@ func TestHandleAuthorize_AutoLogin_DeactivatedSession(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	// Should show login form since session is deactivated
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "form")
+	// Should redirect to login since session is deactivated
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "/oauth2/login")
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=")
 }
 
 func TestHandleAuthorize_PKCE_PlainRejected(t *testing.T) {
@@ -356,9 +355,10 @@ func TestHandleAuthorize_PKCE_PlainAllowed_WhenFlagDisabled(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	// Should render login form, not an error
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "form")
+	// Should redirect to login, not an error
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "/oauth2/login")
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=")
 }
 
 func TestHandleAuthorize_PKCE_S256Accepted(t *testing.T) {
@@ -370,8 +370,8 @@ func TestHandleAuthorize_PKCE_S256Accepted(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "form")
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=")
 }
 
 func TestHandleAuthorize_PKCE_RequiredForPublicClient(t *testing.T) {
@@ -405,8 +405,8 @@ func TestHandleAuthorize_PKCE_NotRequiredForConfidentialClient(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "form")
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=")
 }
 
 func TestHandleAuthorize_InvalidScope(t *testing.T) {
@@ -442,8 +442,8 @@ func TestHandleAuthorize_AllowedScope(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "form")
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=")
 }
 
 func TestHandleAuthorize_AutoLogin_NoCookie(t *testing.T) {
@@ -460,8 +460,8 @@ func TestHandleAuthorize_AutoLogin_NoCookie(t *testing.T) {
 	HandleAuthorize(rr, req)
 
 	// Should show login form since no cookie
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "form")
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=")
 }
 
 func TestHandleAuthorize_PromptNone_NoSession(t *testing.T) {
@@ -516,8 +516,9 @@ func TestHandleAuthorize_WithFederation(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "Google")
+	// Should redirect to login (federation providers are rendered on the login page)
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=")
 }
 
 func TestHandleAuthorize_PromptLogin_NoSession(t *testing.T) {
@@ -529,8 +530,8 @@ func TestHandleAuthorize_PromptLogin_NoSession(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "form")
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=")
 }
 
 func TestHandleAuthorize_MaxAge_ExceedsSession_ForcesLogin(t *testing.T) {
@@ -557,7 +558,8 @@ func TestHandleAuthorize_MaxAge_ExceedsSession_ForcesLogin(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code, "max_age exceeded must show login form")
+	assert.Equal(t, http.StatusFound, rr.Code, "max_age exceeded must redirect to login")
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=", "must redirect to login with auth_request_id")
 	assert.NotContains(t, rr.Header().Get("Location"), "code=", "must not issue auth code when max_age exceeded")
 }
 
@@ -612,7 +614,8 @@ func TestHandleAuthorize_PromptLogin_BypassesSSO(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code, "prompt=login must show login form, not auto-login")
+	assert.Equal(t, http.StatusFound, rr.Code, "prompt=login must redirect to login, not auto-login")
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=")
 	assert.NotContains(t, rr.Header().Get("Location"), "code=", "must not issue auth code via SSO bypass")
 }
 
@@ -641,7 +644,8 @@ func TestHandleAuthorize_PromptConsent_BypassesSSO(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code, "prompt=consent must show login form, not auto-login")
+	assert.Equal(t, http.StatusFound, rr.Code, "prompt=consent must redirect to login, not auto-login")
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=")
 	assert.NotContains(t, rr.Header().Get("Location"), "code=", "must not issue auth code via SSO bypass")
 }
 
@@ -657,8 +661,10 @@ func TestHandleAuthorize_AllowSelfSignup(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "Create account")
+	// No prompt=create — redirects to login page (signup link available on login page)
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "/oauth2/login")
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=")
 }
 
 // OIDC Core §3.1.2.1: prompt=create renders the signup form directly
@@ -674,11 +680,10 @@ func TestHandleAuthorize_PromptCreate_RendersSignup(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code)
-	body := rr.Body.String()
-	assert.Contains(t, body, `name="username"`)
-	assert.Contains(t, body, `name="password"`)
-	assert.Contains(t, body, `name="confirm_password"`)
+	// prompt=create renders signup page
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "/oauth2/signup")
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=")
 }
 
 // prompt=create with self-signup disabled must show login page with error
@@ -694,8 +699,10 @@ func TestHandleAuthorize_PromptCreate_SignupDisabled(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "Self-registration is not enabled")
+	// Signup disabled — redirects to login with error
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "/oauth2/login")
+	assert.Contains(t, rr.Header().Get("Location"), "Self-registration")
 }
 
 func TestHandleAuthorize_InvalidPrompt(t *testing.T) {
@@ -708,8 +715,8 @@ func TestHandleAuthorize_InvalidPrompt(t *testing.T) {
 	HandleAuthorize(rr, req)
 
 	// Should ignore invalid prompt and show login form
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "form")
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "auth_request_id=")
 }
 
 func TestHandleAuthorize_InvalidRedirectURI_Extra(t *testing.T) {
@@ -760,8 +767,9 @@ func TestHandleAuthorize_WithGenericError(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "server_error")
+	// Error passed through to login redirect
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "server_error")
 }
 
 // TestHandleAuthorize_RequestObjectRejected verifies that a request containing

--- a/pkg/authorize/login_error_test.go
+++ b/pkg/authorize/login_error_test.go
@@ -18,6 +18,7 @@ func TestHandleAuthorize_WithLoginError(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "invalid_credentials")
+	// Error is passed through to the login redirect
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "invalid_credentials")
 }

--- a/pkg/authorize/signup_test.go
+++ b/pkg/authorize/signup_test.go
@@ -22,6 +22,7 @@ func TestHandleAuthorize_NoSelfSignup(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.NotContains(t, rr.Body.String(), "Create account")
+	// No prompt=create — redirects to login (signup link visibility is tested on the login page)
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "/oauth2/login")
 }

--- a/pkg/authrequest/create.go
+++ b/pkg/authrequest/create.go
@@ -1,0 +1,28 @@
+package authrequest
+
+import (
+	"time"
+
+	"github.com/eugenioenko/autentico/pkg/db"
+	"github.com/rs/xid"
+)
+
+// TTL is the lifetime of an authorize request. Requests older than this
+// are considered expired and will be rejected by the login/signup handlers.
+const TTL = 10 * time.Minute
+
+// Create stores a new authorize request and returns its ID.
+func Create(req AuthorizeRequest) (string, error) {
+	req.ID = xid.New().String()
+	req.CreatedAt = time.Now().UTC()
+	req.ExpiresAt = time.Now().Add(TTL).UTC()
+
+	_, err := db.GetDB().Exec(`
+		INSERT INTO authorize_requests (id, client_id, redirect_uri, scope, state, nonce, code_challenge, code_challenge_method, response_type, created_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, req.ID, req.ClientID, req.RedirectURI, req.Scope, req.State, req.Nonce, req.CodeChallenge, req.CodeChallengeMethod, req.ResponseType, req.CreatedAt, req.ExpiresAt)
+	if err != nil {
+		return "", err
+	}
+	return req.ID, nil
+}

--- a/pkg/authrequest/delete.go
+++ b/pkg/authrequest/delete.go
@@ -1,0 +1,10 @@
+package authrequest
+
+import "github.com/eugenioenko/autentico/pkg/db"
+
+// Delete removes an authorize request by ID. Called after the request
+// has been consumed (auth code issued) to prevent reuse.
+func Delete(id string) error {
+	_, err := db.GetDB().Exec(`DELETE FROM authorize_requests WHERE id = ?`, id)
+	return err
+}

--- a/pkg/authrequest/model.go
+++ b/pkg/authrequest/model.go
@@ -1,0 +1,20 @@
+package authrequest
+
+import "time"
+
+// AuthorizeRequest stores the OAuth2 authorization parameters server-side
+// between the authorize and login steps. This prevents parameter tampering
+// via hidden form fields (PKCE downgrade, scope escalation, nonce injection).
+type AuthorizeRequest struct {
+	ID                  string    `db:"id"`
+	ClientID            string    `db:"client_id"`
+	RedirectURI         string    `db:"redirect_uri"`
+	Scope               string    `db:"scope"`
+	State               string    `db:"state"`
+	Nonce               string    `db:"nonce"`
+	CodeChallenge       string    `db:"code_challenge"`
+	CodeChallengeMethod string    `db:"code_challenge_method"`
+	ResponseType        string    `db:"response_type"`
+	CreatedAt           time.Time `db:"created_at"`
+	ExpiresAt           time.Time `db:"expires_at"`
+}

--- a/pkg/authrequest/read.go
+++ b/pkg/authrequest/read.go
@@ -1,0 +1,25 @@
+package authrequest
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/eugenioenko/autentico/pkg/db"
+)
+
+// GetByID retrieves an authorize request by ID. Returns an error if the
+// request does not exist or has expired.
+func GetByID(id string) (*AuthorizeRequest, error) {
+	var req AuthorizeRequest
+	err := db.GetDB().QueryRow(`
+		SELECT id, client_id, redirect_uri, scope, state, nonce, code_challenge, code_challenge_method, response_type, created_at, expires_at
+		FROM authorize_requests WHERE id = ?
+	`, id).Scan(&req.ID, &req.ClientID, &req.RedirectURI, &req.Scope, &req.State, &req.Nonce, &req.CodeChallenge, &req.CodeChallengeMethod, &req.ResponseType, &req.CreatedAt, &req.ExpiresAt)
+	if err != nil {
+		return nil, err
+	}
+	if time.Now().After(req.ExpiresAt) {
+		return nil, fmt.Errorf("authorize request has expired")
+	}
+	return &req, nil
+}

--- a/pkg/cleanup/service.go
+++ b/pkg/cleanup/service.go
@@ -18,6 +18,7 @@ func Run(retention time.Duration) {
 		table string
 		sql   string
 	}{
+		{"authorize_requests", `DELETE FROM authorize_requests WHERE expires_at < ?`},
 		{"auth_codes", `DELETE FROM auth_codes WHERE expires_at < ?`},
 		{"mfa_challenges", `DELETE FROM mfa_challenges WHERE expires_at < ?`},
 		{"passkey_challenges", `DELETE FROM passkey_challenges WHERE expires_at < ?`},

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -122,7 +122,9 @@ func RunStart(c *cli.Context) error {
 
 	mux.Handle("GET "+oauth+"/authorize", csrfProtected(authorize.HandleAuthorize))
 	mux.Handle("POST "+oauth+"/authorize", http.HandlerFunc(authorize.HandleAuthorize))
+	mux.Handle("GET "+oauth+"/login", csrfProtected(login.HandleLoginPage))
 	mux.Handle("POST "+oauth+"/login", rateLimited(csrfProtected(login.HandleLoginUser)))
+	mux.Handle("GET "+oauth+"/signup", csrfProtected(signup.HandleSignupPage))
 	mux.Handle(oauth+"/mfa", rateLimited(csrfProtected(mfa.HandleMfa)))
 	mux.Handle(oauth+"/mfa/", rateLimited(csrfProtected(mfa.HandleMfa)))
 	mux.Handle("GET "+oauth+"/passkey/login/begin", rateLimitedFunc(passkey.HandleLoginBegin))

--- a/pkg/db/migrations/006_authorize_requests.go
+++ b/pkg/db/migrations/006_authorize_requests.go
@@ -1,0 +1,17 @@
+package migrations
+
+const migration006 = `
+CREATE TABLE IF NOT EXISTS authorize_requests (
+    id TEXT PRIMARY KEY,
+    client_id TEXT NOT NULL,
+    redirect_uri TEXT NOT NULL,
+    scope TEXT NOT NULL DEFAULT '',
+    state TEXT NOT NULL DEFAULT '',
+    nonce TEXT NOT NULL DEFAULT '',
+    code_challenge TEXT NOT NULL DEFAULT '',
+    code_challenge_method TEXT NOT NULL DEFAULT '',
+    response_type TEXT NOT NULL DEFAULT 'code',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at DATETIME NOT NULL
+);
+`

--- a/pkg/db/migrations/migrations.go
+++ b/pkg/db/migrations/migrations.go
@@ -7,7 +7,7 @@ import (
 
 // SchemaVersion is the schema version this binary expects.
 // Increment this and add a new Migration entry each time the schema changes.
-var SchemaVersion = 5
+var SchemaVersion = 6
 
 // Migration represents a single schema change.
 type Migration struct {
@@ -22,6 +22,7 @@ var migrations = []Migration{
 	{Version: 3, SQL: migration003},
 	{Version: 4, SQL: migration004},
 	{Version: 5, SQL: migration005},
+	{Version: 6, SQL: migration006},
 }
 
 func getUserVersion(db *sql.DB) (int, error) {

--- a/pkg/federation/handler.go
+++ b/pkg/federation/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/eugenioenko/autentico/pkg/audit"
 	authcode "github.com/eugenioenko/autentico/pkg/auth_code"
+	"github.com/eugenioenko/autentico/pkg/authrequest"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/idpsession"
 	"github.com/eugenioenko/autentico/pkg/middleware"
@@ -44,15 +45,27 @@ func HandleFederationBegin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Look up stored authorize request (issues #184, #186).
+	authReqID := q.Get("auth_request_id")
+	if authReqID == "" {
+		http.Error(w, "missing auth_request_id", http.StatusBadRequest)
+		return
+	}
+	authReq, err := authrequest.GetByID(authReqID)
+	if err != nil {
+		http.Error(w, "invalid or expired authorization request", http.StatusBadRequest)
+		return
+	}
+
 	state := FederationState{
 		Nonce:               nonce,
 		ProviderID:          providerID,
-		RedirectURI:         q.Get("redirect_uri"),
-		ClientID:            q.Get("client_id"),
-		Scope:               q.Get("scope"),
-		State:               q.Get("state"),
-		CodeChallenge:       q.Get("code_challenge"),
-		CodeChallengeMethod: q.Get("code_challenge_method"),
+		RedirectURI:         authReq.RedirectURI,
+		ClientID:            authReq.ClientID,
+		Scope:               authReq.Scope,
+		State:               authReq.State,
+		CodeChallenge:       authReq.CodeChallenge,
+		CodeChallengeMethod: authReq.CodeChallengeMethod,
 	}
 
 	signedState, err := SignState(state)

--- a/pkg/federation/handler_test.go
+++ b/pkg/federation/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/eugenioenko/autentico/pkg/authrequest"
 	"github.com/eugenioenko/autentico/pkg/db"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
 	"github.com/stretchr/testify/assert"
@@ -321,8 +322,15 @@ func TestHandleFederationBegin_Success(t *testing.T) {
 		ID: "mock", Name: "Mock", Issuer: ts.URL, ClientID: "c1", ClientSecret: "s1", Enabled: true,
 	})
 
-	// 3. Begin federation
-	req := httptest.NewRequest(http.MethodGet, "/oauth2/federation/mock?redirect_uri=http://localhost/cb", nil)
+	// 3. Create an authorize request and begin federation
+	authReqID, _ := authrequest.Create(authrequest.AuthorizeRequest{
+		ClientID:    "c1",
+		RedirectURI: "http://localhost/cb",
+		Scope:       "openid",
+		State:       "test-state",
+		ResponseType: "code",
+	})
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/federation/mock?auth_request_id="+authReqID, nil)
 	req.SetPathValue("id", "mock")
 	rr := httptest.NewRecorder()
 	HandleFederationBegin(rr, req)

--- a/pkg/login/handler.go
+++ b/pkg/login/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html/template"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -11,16 +12,90 @@ import (
 
 	"github.com/eugenioenko/autentico/pkg/audit"
 	authcode "github.com/eugenioenko/autentico/pkg/auth_code"
-	"github.com/eugenioenko/autentico/pkg/client"
+	"github.com/eugenioenko/autentico/pkg/authrequest"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/emailverification"
+	"github.com/eugenioenko/autentico/pkg/federation"
 	"github.com/eugenioenko/autentico/pkg/idpsession"
 	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/mfa"
 	"github.com/eugenioenko/autentico/pkg/trusteddevice"
 	"github.com/eugenioenko/autentico/pkg/user"
 	"github.com/eugenioenko/autentico/pkg/utils"
+	"github.com/eugenioenko/autentico/view"
+	"github.com/gorilla/csrf"
 )
+
+// HandleLoginPage renders the login form. It reads the auth_request_id from the
+// query string and looks up the stored authorize parameters from the database.
+func HandleLoginPage(w http.ResponseWriter, r *http.Request) {
+	authReqID := r.URL.Query().Get("auth_request_id")
+	if authReqID == "" {
+		renderLoginError(w, "Missing authorization request. Please return to the application and try again.")
+		return
+	}
+
+	authReq, err := authrequest.GetByID(authReqID)
+	if err != nil {
+		slog.Warn("login_page: invalid or expired auth request", "auth_request_id", authReqID, "error", err)
+		renderLoginError(w, "Authorization request expired. Please return to the application and try again.")
+		return
+	}
+
+	errorMsg := r.URL.Query().Get("error")
+	renderLogin(w, r, authReq, errorMsg)
+}
+
+// renderLogin renders the login form using stored authorize request parameters.
+func renderLogin(w http.ResponseWriter, r *http.Request, authReq *authrequest.AuthorizeRequest, errorMsg string) {
+	cfg := config.Get()
+	tmpl, err := view.ParseTemplate("login")
+	if err != nil {
+		slog.Error("login: failed to parse login template", "request_id", middleware.GetRequestID(r.Context()), "error", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	federatedProviders, _ := federation.ListEnabledProviderViews()
+
+	data := map[string]any{
+		"AuthRequestID":       authReq.ID,
+		"ClientID":            authReq.ClientID,
+		"Error":               errorMsg,
+		"AuthMode":            cfg.AuthMode,
+		"AllowSelfSignup":     cfg.AuthAllowSelfSignup,
+		"ProfileFieldEmail":   cfg.ProfileFieldEmail,
+		csrf.TemplateTag:      csrf.TemplateField(r),
+		"ThemeTitle":          cfg.Theme.Title,
+		"ThemeLogoUrl":        cfg.Theme.LogoUrl,
+		"ThemeCssResolved":    template.CSS(cfg.ThemeCssResolved),
+		"SmtpConfigured":      cfg.SmtpHost != "",
+		"FederatedProviders":  federatedProviders,
+	}
+
+	if err = tmpl.ExecuteTemplate(w, "layout", data); err != nil {
+		slog.Error("login: failed to execute login template", "request_id", middleware.GetRequestID(r.Context()), "error", err)
+		http.Error(w, "Template Execution Error", http.StatusInternalServerError)
+	}
+}
+
+// renderLoginError renders a branded error page for authorization request failures.
+func renderLoginError(w http.ResponseWriter, errorMsg string) {
+	cfg := config.Get()
+	tmpl, err := view.ParseTemplate("error")
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	data := map[string]any{
+		"Error":            errorMsg,
+		"ThemeTitle":       cfg.Theme.Title,
+		"ThemeLogoUrl":     cfg.Theme.LogoUrl,
+		"ThemeCssResolved": template.CSS(cfg.ThemeCssResolved),
+	}
+	w.WriteHeader(http.StatusBadRequest)
+	_ = tmpl.ExecuteTemplate(w, "layout", data)
+}
 
 // HandleLoginUser godoc
 // @Summary Log in a user
@@ -48,16 +123,33 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Look up the stored authorize request — all OAuth parameters come from the
+	// server-side record, not from the POST body. This prevents parameter tampering
+	// (PKCE downgrade, scope escalation, nonce injection — issues #184, #186).
+	authReqID := r.FormValue("auth_request_id")
+	if authReqID == "" {
+		renderLoginError(w, "Missing authorization request. Please return to the application and try again.")
+		return
+	}
+
+	authReq, err := authrequest.GetByID(authReqID)
+	if err != nil {
+		slog.Warn("login: invalid or expired auth request", "request_id", middleware.GetRequestID(r.Context()), "auth_request_id", authReqID, "error", err)
+		renderLoginError(w, "Authorization request expired. Please return to the application and try again.")
+		return
+	}
+
+	// Only username and password come from the POST body
 	request := LoginRequest{
 		Username:            r.FormValue("username"),
 		Password:            r.FormValue("password"),
-		RedirectURI:         r.FormValue("redirect_uri"),
-		State:               r.FormValue("state"),
-		ClientID:            r.FormValue("client_id"),
-		Scope:               r.FormValue("scope"),
-		Nonce:               r.FormValue("nonce"),
-		CodeChallenge:       r.FormValue("code_challenge"),
-		CodeChallengeMethod: r.FormValue("code_challenge_method"),
+		RedirectURI:         authReq.RedirectURI,
+		State:               authReq.State,
+		ClientID:            authReq.ClientID,
+		Scope:               authReq.Scope,
+		Nonce:               authReq.Nonce,
+		CodeChallenge:       authReq.CodeChallenge,
+		CodeChallengeMethod: authReq.CodeChallengeMethod,
 	}
 
 	if config.Get().AuthMode == "passkey_only" {
@@ -65,40 +157,9 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate redirect_uri format first
-	if !utils.IsValidRedirectURI(request.RedirectURI) {
-		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Invalid redirect_uri")
-		return
-	}
-
-	// Validate client_id is registered and redirect_uri is allowed for this client
-	registeredClient, err := client.ClientByClientID(request.ClientID)
-	if err != nil {
-		slog.Warn("login: unknown client_id", "request_id", middleware.GetRequestID(r.Context()), "client_id", request.ClientID, "ip", utils.GetClientIP(r))
-		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_client", "Unknown client_id")
-		return
-	}
-	if !registeredClient.IsActive {
-		slog.Warn("login: inactive client", "request_id", middleware.GetRequestID(r.Context()), "client_id", request.ClientID, "ip", utils.GetClientIP(r))
-		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_client", "Client is inactive")
-		return
-	}
-	if !client.IsValidRedirectURI(registeredClient, request.RedirectURI) {
-		slog.Warn("login: redirect_uri not registered for client", "request_id", middleware.GetRequestID(r.Context()), "client_id", request.ClientID, "redirect_uri", request.RedirectURI, "ip", utils.GetClientIP(r))
-		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Redirect URI not allowed for this client")
-		return
-	}
-
-	// Reject any scope that the client is not allowed to use
-	if !client.ValidateScopes(registeredClient, request.Scope) {
-		slog.Warn("login: invalid scope for client", "request_id", middleware.GetRequestID(r.Context()), "client_id", request.ClientID, "scope", request.Scope, "ip", utils.GetClientIP(r))
-		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_scope", "One or more requested scopes are not allowed for this client")
-		return
-	}
-
 	err = ValidateLoginRequest(request)
 	if err != nil {
-		redirectToLogin(w, r, request, fmt.Sprintf("user credentials error. %v", err))
+		redirectToLogin(w, r, authReqID, fmt.Sprintf("user credentials error. %v", err))
 		return
 	}
 
@@ -111,7 +172,7 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 		}
 		detail := audit.Detail("username", request.Username, "reason", loginError)
 		audit.Log(audit.EventLoginFailed, nil, audit.TargetUser, "", detail, utils.GetClientIP(r))
-		redirectToLogin(w, r, request, loginError)
+		redirectToLogin(w, r, authReqID, loginError)
 		return
 	}
 
@@ -151,7 +212,7 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 				method = "totp"
 			} else {
 				slog.Error("login: email MFA required but SMTP is not configured", "request_id", middleware.GetRequestID(r.Context()))
-				redirectToLogin(w, r, request, "Email verification is not available. Please contact support.")
+				redirectToLogin(w, r, authReqID,"Email verification is not available. Please contact support.")
 				return
 			}
 		}
@@ -170,14 +231,14 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 		stateJSON, err := json.Marshal(loginState)
 		if err != nil {
 			slog.Error("login: failed to serialize login state", "request_id", middleware.GetRequestID(r.Context()), "error", err)
-			redirectToLogin(w, r, request, "Something went wrong. Please try again.")
+			redirectToLogin(w, r, authReqID,"Something went wrong. Please try again.")
 			return
 		}
 
 		challengeID, err := authcode.GenerateSecureCode()
 		if err != nil {
 			slog.Error("login: failed to generate challenge ID", "request_id", middleware.GetRequestID(r.Context()), "error", err)
-			redirectToLogin(w, r, request, "Something went wrong. Please try again.")
+			redirectToLogin(w, r, authReqID,"Something went wrong. Please try again.")
 			return
 		}
 
@@ -191,7 +252,7 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 
 		if err := mfa.CreateMfaChallenge(challenge); err != nil {
 			slog.Error("login: failed to create MFA challenge", "request_id", middleware.GetRequestID(r.Context()), "error", err)
-			redirectToLogin(w, r, request, "Something went wrong. Please try again.")
+			redirectToLogin(w, r, authReqID,"Something went wrong. Please try again.")
 			return
 		}
 
@@ -219,7 +280,7 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 	authCode, err := authcode.GenerateSecureCode()
 	if err != nil {
 		slog.Error("login: failed to generate auth code", "request_id", middleware.GetRequestID(r.Context()), "error", err)
-		redirectToLogin(w, r, request, "Something went wrong. Please try again.")
+		redirectToLogin(w, r, authReqID,"Something went wrong. Please try again.")
 		return
 	}
 
@@ -239,9 +300,12 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 	err = authcode.CreateAuthCode(code)
 	if err != nil {
 		slog.Error("login: failed to create auth code", "request_id", middleware.GetRequestID(r.Context()), "error", err)
-		redirectToLogin(w, r, request, "Something went wrong. Please try again.")
+		redirectToLogin(w, r, authReqID, "Something went wrong. Please try again.")
 		return
 	}
+
+	// Consume the authorize request to prevent reuse (e.g. browser back button)
+	_ = authrequest.Delete(authReqID)
 
 	audit.Log(audit.EventLoginSuccess, usr, audit.TargetUser, usr.ID, audit.Detail("method", "password"), utils.GetClientIP(r))
 
@@ -254,23 +318,9 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, request.RedirectURI+"?"+params.Encode(), http.StatusFound)
 }
 
-// redirectToLogin redirects back to the authorize endpoint with an error message,
-// preserving all original OAuth parameters so the login form is re-rendered.
-func redirectToLogin(w http.ResponseWriter, r *http.Request, req LoginRequest, loginError string) {
-	params := url.Values{}
-	params.Set("response_type", "code")
-	params.Set("client_id", req.ClientID)
-	params.Set("redirect_uri", req.RedirectURI)
-	params.Set("state", req.State)
-	params.Set("scope", req.Scope)
-	params.Set("error", loginError)
-	if req.Nonce != "" {
-		params.Set("nonce", req.Nonce)
-	}
-	if req.CodeChallenge != "" {
-		params.Set("code_challenge", req.CodeChallenge)
-		params.Set("code_challenge_method", req.CodeChallengeMethod)
-	}
-	redirectURL := config.GetBootstrap().AppOAuthPath + "/authorize?" + params.Encode()
-	http.Redirect(w, r, redirectURL, http.StatusFound)
+// redirectToLogin redirects back to the login page with an error message,
+// preserving the auth request ID so the form is re-rendered with stored params.
+func redirectToLogin(w http.ResponseWriter, r *http.Request, authReqID string, loginError string) {
+	loginURL := config.GetBootstrap().AppOAuthPath + "/login?auth_request_id=" + authReqID + "&error=" + url.QueryEscape(loginError)
+	http.Redirect(w, r, loginURL, http.StatusFound)
 }

--- a/pkg/login/handler_test.go
+++ b/pkg/login/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eugenioenko/autentico/pkg/authrequest"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/trusteddevice"
@@ -18,22 +19,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// createTestAuthRequest creates an authorize request for the given client and returns its ID.
+func createTestAuthRequest(t *testing.T, clientID, redirectURI string) string {
+	t.Helper()
+	id, err := authrequest.Create(authrequest.AuthorizeRequest{
+		ClientID:    clientID,
+		RedirectURI: redirectURI,
+		Scope:       "openid profile email",
+		State:       "test-state",
+		ResponseType: "code",
+	})
+	require.NoError(t, err)
+	return id
+}
+
 func TestHandleLoginUser_Success(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.WithConfigOverride(t, func() {
 		config.Values.AuthSsoSessionIdleTimeout = 0
 	})
 
-	// Create user and client
 	_, _ = user.CreateUser("testuser", "password123", "test@example.com")
 	testutils.InsertTestClient(t, "test-client", []string{"http://localhost/callback"})
+	authReqID := createTestAuthRequest(t, "test-client", "http://localhost/callback")
 
 	form := url.Values{}
 	form.Set("username", "testuser")
 	form.Set("password", "password123")
-	form.Set("client_id", "test-client")
-	form.Set("redirect_uri", "http://localhost/callback")
-	form.Set("state", "xyz")
+	form.Set("auth_request_id", authReqID)
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -54,12 +67,12 @@ func TestHandleLoginUser_MfaTotp(t *testing.T) {
 
 	_, _ = user.CreateUser("mfauser", "password123", "mfa@example.com")
 	testutils.InsertTestClient(t, "test-client", []string{"http://localhost/callback"})
+	authReqID := createTestAuthRequest(t, "test-client", "http://localhost/callback")
 
 	form := url.Values{}
 	form.Set("username", "mfauser")
 	form.Set("password", "password123")
-	form.Set("client_id", "test-client")
-	form.Set("redirect_uri", "http://localhost/callback")
+	form.Set("auth_request_id", authReqID)
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -73,72 +86,71 @@ func TestHandleLoginUser_MfaTotp(t *testing.T) {
 
 func TestHandleLoginUser_PasskeyOnly(t *testing.T) {
 	testutils.WithTestDB(t)
+	testutils.InsertTestClient(t, "c1", []string{"http://localhost"})
 	testutils.WithConfigOverride(t, func() {
 		config.Values.AuthMode = "passkey_only"
 	})
+	authReqID := createTestAuthRequest(t, "c1", "http://localhost")
 
-	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", nil)
+	form := url.Values{}
+	form.Set("auth_request_id", authReqID)
+	form.Set("username", "test")
+	form.Set("password", "test")
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rr := httptest.NewRecorder()
 	HandleLoginUser(rr, req)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 	assert.Contains(t, rr.Body.String(), "Password login is disabled")
 }
 
-func TestHandleLoginUser_InvalidRedirect(t *testing.T) {
+func TestHandleLoginUser_MissingAuthRequestID(t *testing.T) {
 	testutils.WithTestDB(t)
 	form := url.Values{}
-	form.Set("redirect_uri", "not-a-url")
+	form.Set("username", "testuser")
+	form.Set("password", "password123")
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rr := httptest.NewRecorder()
 	HandleLoginUser(rr, req)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
-	assert.Contains(t, rr.Body.String(), "Invalid redirect_uri")
+	assert.Contains(t, rr.Body.String(), "Missing authorization request")
 }
 
-func TestHandleLoginUser_InactiveClient(t *testing.T) {
-	testutils.WithTestDB(t)
-	_, _ = db.GetDB().Exec(`INSERT INTO clients (id, client_id, client_name, is_active, redirect_uris) VALUES ('c1', 'inactive', 'Inc', FALSE, '["http://localhost"]')`)
-
-	form := url.Values{}
-	form.Set("client_id", "inactive")
-	form.Set("redirect_uri", "http://localhost")
-	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	rr := httptest.NewRecorder()
-	HandleLoginUser(rr, req)
-	assert.Equal(t, http.StatusBadRequest, rr.Code)
-	assert.Contains(t, rr.Body.String(), "Client is inactive")
-}
-
-func TestHandleLoginUser_InvalidScope(t *testing.T) {
+func TestHandleLoginUser_ExpiredAuthRequest(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.InsertTestClient(t, "c1", []string{"http://localhost"})
 
+	// Create an auth request with an already-expired TTL
+	_, err := db.GetDB().Exec(`
+		INSERT INTO authorize_requests (id, client_id, redirect_uri, scope, state, response_type, created_at, expires_at)
+		VALUES ('expired-req', 'c1', 'http://localhost', 'openid', 'st', 'code', datetime('now', '-20 minutes'), datetime('now', '-10 minutes'))
+	`)
+	require.NoError(t, err)
+
 	form := url.Values{}
-	form.Set("client_id", "c1")
-	form.Set("redirect_uri", "http://localhost")
-	form.Set("scope", "invalid")
+	form.Set("username", "testuser")
+	form.Set("password", "password123")
+	form.Set("auth_request_id", "expired-req")
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rr := httptest.NewRecorder()
 	HandleLoginUser(rr, req)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
-	assert.Contains(t, rr.Body.String(), "One or more requested scopes are not allowed")
+	assert.Contains(t, rr.Body.String(), "Authorization request expired")
 }
 
 func TestHandleLoginUser_LockedAccount(t *testing.T) {
 	testutils.WithTestDB(t)
 	u, _ := user.CreateUser("lockeduser", "password123", "l@test.com")
 	testutils.InsertTestClient(t, "c1", []string{"http://localhost"})
-	// Lock the user
 	_, _ = db.GetDB().Exec("UPDATE users SET locked_until = datetime('now', '+1 hour') WHERE id = ?", u.ID)
+	authReqID := createTestAuthRequest(t, "c1", "http://localhost")
 
 	form := url.Values{}
 	form.Set("username", "lockeduser")
 	form.Set("password", "password123")
-	form.Set("client_id", "c1")
-	form.Set("redirect_uri", "http://localhost")
+	form.Set("auth_request_id", authReqID)
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -146,7 +158,7 @@ func TestHandleLoginUser_LockedAccount(t *testing.T) {
 	HandleLoginUser(rr, req)
 
 	assert.Equal(t, http.StatusFound, rr.Code)
-	assert.Contains(t, rr.Header().Get("Location"), "error=Account+is+temporarily+locked")
+	assert.Contains(t, rr.Header().Get("Location"), "Account+is+temporarily+locked")
 }
 
 func TestHandleLoginUser_EmailMfaNoSmtp(t *testing.T) {
@@ -154,24 +166,23 @@ func TestHandleLoginUser_EmailMfaNoSmtp(t *testing.T) {
 	testutils.WithConfigOverride(t, func() {
 		config.Values.RequireMfa = true
 		config.Values.MfaMethod = "email"
-		config.Values.SmtpHost = "" // No SMTP
+		config.Values.SmtpHost = ""
 	})
 
 	_, _ = user.CreateUser("mfauseremail", "password123", "u@test.com")
 	testutils.InsertTestClient(t, "c1", []string{"http://localhost"})
+	authReqID := createTestAuthRequest(t, "c1", "http://localhost")
 
 	form := url.Values{}
 	form.Set("username", "mfauseremail")
 	form.Set("password", "password123")
-	form.Set("client_id", "c1")
-	form.Set("redirect_uri", "http://localhost")
+	form.Set("auth_request_id", authReqID)
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rr := httptest.NewRecorder()
 	HandleLoginUser(rr, req)
 
-	// Now redirects back to login with an error message instead of JSON
 	assert.Equal(t, http.StatusFound, rr.Code)
 	assert.Contains(t, rr.Header().Get("Location"), "error=")
 }
@@ -179,12 +190,12 @@ func TestHandleLoginUser_EmailMfaNoSmtp(t *testing.T) {
 func TestHandleLoginUser_InvalidCredentialsFormat(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.InsertTestClient(t, "c1", []string{"http://localhost"})
+	authReqID := createTestAuthRequest(t, "c1", "http://localhost")
 
 	form := url.Values{}
 	form.Set("username", "a") // too short
 	form.Set("password", "short")
-	form.Set("client_id", "c1")
-	form.Set("redirect_uri", "http://localhost")
+	form.Set("auth_request_id", authReqID)
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -195,30 +206,31 @@ func TestHandleLoginUser_InvalidCredentialsFormat(t *testing.T) {
 	assert.Contains(t, rr.Header().Get("Location"), "error=user+credentials+error")
 }
 
-func TestHandleLoginUser_UnknownClient(t *testing.T) {
+func TestHandleLoginUser_InvalidAuthRequestID(t *testing.T) {
 	testutils.WithTestDB(t)
 
 	form := url.Values{}
-	form.Set("client_id", "nonexistent")
-	form.Set("redirect_uri", "http://localhost")
+	form.Set("auth_request_id", "nonexistent-id")
+	form.Set("username", "testuser")
+	form.Set("password", "password123")
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rr := httptest.NewRecorder()
 	HandleLoginUser(rr, req)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
-	assert.Contains(t, rr.Body.String(), "Unknown client_id")
+	assert.Contains(t, rr.Body.String(), "Authorization request expired")
 }
 
 func TestHandleLoginUser_WrongPassword(t *testing.T) {
 	testutils.WithTestDB(t)
 	_, _ = user.CreateUser("testuser", "correct-password", "test@test.com")
 	testutils.InsertTestClient(t, "c1", []string{"http://localhost"})
+	authReqID := createTestAuthRequest(t, "c1", "http://localhost")
 
 	form := url.Values{}
 	form.Set("username", "testuser")
 	form.Set("password", "wrong-password")
-	form.Set("client_id", "c1")
-	form.Set("redirect_uri", "http://localhost")
+	form.Set("auth_request_id", authReqID)
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -232,12 +244,12 @@ func TestHandleLoginUser_WrongPassword(t *testing.T) {
 func TestHandleLoginUser_NonexistentUser(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.InsertTestClient(t, "c1", []string{"http://localhost"})
+	authReqID := createTestAuthRequest(t, "c1", "http://localhost")
 
 	form := url.Values{}
 	form.Set("username", "nonexistent")
 	form.Set("password", "password123")
-	form.Set("client_id", "c1")
-	form.Set("redirect_uri", "http://localhost")
+	form.Set("auth_request_id", authReqID)
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -277,11 +289,12 @@ func TestHandleLoginUser_SkipMfaIfTrusted(t *testing.T) {
 		ExpiresAt:  time.Now().Add(time.Hour),
 	})
 
+	authReqID := createTestAuthRequest(t, "c1", "http://localhost")
+
 	form := url.Values{}
 	form.Set("username", "testuser")
 	form.Set("password", "password123")
-	form.Set("client_id", "c1")
-	form.Set("redirect_uri", "http://localhost")
+	form.Set("auth_request_id", authReqID)
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -310,8 +323,7 @@ func TestHandleLoginUser_MfaMethodBoth_TotpVerified(t *testing.T) {
 	form := url.Values{}
 	form.Set("username", "mfauser")
 	form.Set("password", "password123")
-	form.Set("client_id", "c1")
-	form.Set("redirect_uri", "http://localhost")
+	form.Set("auth_request_id", createTestAuthRequest(t, "c1", "http://localhost"))
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -337,8 +349,7 @@ func TestHandleLoginUser_MfaMethodBoth_NoTotpVerified(t *testing.T) {
 	form := url.Values{}
 	form.Set("username", "mfauser")
 	form.Set("password", "password123")
-	form.Set("client_id", "c1")
-	form.Set("redirect_uri", "http://localhost")
+	form.Set("auth_request_id", createTestAuthRequest(t, "c1", "http://localhost"))
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -358,29 +369,13 @@ func TestRedirectToLogin_Extra(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/?anything=1", nil)
 	rr := httptest.NewRecorder()
 	
-	loginReq := LoginRequest{
-		ClientID:            "c1",
-		RedirectURI:         "http://cb",
-		State:               "s1",
-		Scope:               "openid",
-		Nonce:               "n1",
-		CodeChallenge:       "cc1",
-		CodeChallengeMethod: "S256",
-	}
-	
-	redirectToLogin(rr, req, loginReq, "some error")
-	
+	redirectToLogin(rr, req, "test-auth-req-id", "some error")
+
 	assert.Equal(t, http.StatusFound, rr.Code)
 	loc := rr.Header().Get("Location")
-	assert.Contains(t, loc, "/oauth2/authorize")
-	assert.Contains(t, loc, "error=some+error")
-	assert.Contains(t, loc, "client_id=c1")
-	assert.Contains(t, loc, "redirect_uri=http%3A%2F%2Fcb")
-	assert.Contains(t, loc, "state=s1")
-	assert.Contains(t, loc, "scope=openid")
-	assert.Contains(t, loc, "nonce=n1")
-	assert.Contains(t, loc, "code_challenge=cc1")
-	assert.Contains(t, loc, "code_challenge_method=S256")
+	assert.Contains(t, loc, "/oauth2/login")
+	assert.Contains(t, loc, "auth_request_id=test-auth-req-id")
+	assert.Contains(t, loc, "some+error")
 }
 
 func TestHandleLoginUser_DbError_Session(t *testing.T) {
@@ -391,8 +386,7 @@ func TestHandleLoginUser_DbError_Session(t *testing.T) {
 	form := url.Values{}
 	form.Set("username", "testuser")
 	form.Set("password", "password123")
-	form.Set("client_id", "c1")
-	form.Set("redirect_uri", "http://localhost")
+	form.Set("auth_request_id", createTestAuthRequest(t, "c1", "http://localhost"))
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -403,7 +397,7 @@ func TestHandleLoginUser_DbError_Session(t *testing.T) {
 
 	HandleLoginUser(rr, req)
 
-	// Since client lookup is first and fails if DB is closed, it returns 400
+	// Auth request lookup fails with closed DB → returns error page
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
@@ -420,8 +414,7 @@ func TestHandleLoginUser_MfaEnrollment(t *testing.T) {
 	form := url.Values{}
 	form.Set("username", "enrolluser")
 	form.Set("password", "password123")
-	form.Set("client_id", "c1")
-	form.Set("redirect_uri", "http://localhost")
+	form.Set("auth_request_id", createTestAuthRequest(t, "c1", "http://localhost"))
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -447,8 +440,7 @@ func TestHandleLoginUser_MfaEmailEnrollment(t *testing.T) {
 	form := url.Values{}
 	form.Set("username", "enrolluser")
 	form.Set("password", "password123")
-	form.Set("client_id", "c1")
-	form.Set("redirect_uri", "http://localhost")
+	form.Set("auth_request_id", createTestAuthRequest(t, "c1", "http://localhost"))
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -478,8 +470,7 @@ func TestHandleLoginUser_UnverifiedEmail_Blocked(t *testing.T) {
 	form := url.Values{}
 	form.Set("username", "unverified")
 	form.Set("password", "password123")
-	form.Set("client_id", "c1")
-	form.Set("redirect_uri", "http://localhost")
+	form.Set("auth_request_id", createTestAuthRequest(t, "c1", "http://localhost"))
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -506,8 +497,7 @@ func TestHandleLoginUser_AdminExemptFromEmailVerification(t *testing.T) {
 	form := url.Values{}
 	form.Set("username", "adminuser")
 	form.Set("password", "password123")
-	form.Set("client_id", "c1")
-	form.Set("redirect_uri", "http://localhost")
+	form.Set("auth_request_id", createTestAuthRequest(t, "c1", "http://localhost"))
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -540,8 +530,7 @@ func TestHandleLoginUser_VerifiedUser_Proceeds(t *testing.T) {
 	form := url.Values{}
 	form.Set("username", "verifieduser")
 	form.Set("password", "password123")
-	form.Set("client_id", "c1")
-	form.Set("redirect_uri", "http://localhost")
+	form.Set("auth_request_id", createTestAuthRequest(t, "c1", "http://localhost"))
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")

--- a/pkg/passkey/handler.go
+++ b/pkg/passkey/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/eugenioenko/autentico/pkg/audit"
 	authcode "github.com/eugenioenko/autentico/pkg/auth_code"
+	"github.com/eugenioenko/autentico/pkg/authrequest"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/idpsession"
 	"github.com/eugenioenko/autentico/pkg/middleware"
@@ -84,16 +85,28 @@ func HandleRegisterBegin(w http.ResponseWriter, r *http.Request) {
 		usr = &user.User{ID: created.ID, Username: created.Username, Email: created.Email}
 	}
 
+	// Look up stored authorize request (issues #184, #186).
+	authReqID := q.Get("auth_request_id")
+	if authReqID == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing auth_request_id")
+		return
+	}
+	authReq, err := authrequest.GetByID(authReqID)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid or expired authorization request")
+		return
+	}
+
 	regState := RegistrationState{
 		Username:            username,
 		Email:               email,
-		RedirectURI:         q.Get("redirect_uri"),
-		State:               q.Get("state"),
-		ClientID:            q.Get("client_id"),
-		Scope:               q.Get("scope"),
-		Nonce:               q.Get("nonce"),
-		CodeChallenge:       q.Get("code_challenge"),
-		CodeChallengeMethod: q.Get("code_challenge_method"),
+		RedirectURI:         authReq.RedirectURI,
+		State:               authReq.State,
+		ClientID:            authReq.ClientID,
+		Scope:               authReq.Scope,
+		Nonce:               authReq.Nonce,
+		CodeChallenge:       authReq.CodeChallenge,
+		CodeChallengeMethod: authReq.CodeChallengeMethod,
 	}
 	stateJSON, err := json.Marshal(regState)
 	if err != nil {
@@ -188,14 +201,27 @@ func HandleLoginBegin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Look up stored authorize request — OAuth parameters come from the server-side
+	// record, not from query params (issues #184, #186).
+	authReqID := q.Get("auth_request_id")
+	if authReqID == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing auth_request_id")
+		return
+	}
+	authReq, err := authrequest.GetByID(authReqID)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid or expired authorization request")
+		return
+	}
+
 	loginState := LoginState{
-		RedirectURI:            q.Get("redirect_uri"),
-		State:               q.Get("state"),
-		ClientID:            q.Get("client_id"),
-		Scope:               q.Get("scope"),
-		Nonce:               q.Get("nonce"),
-		CodeChallenge:       q.Get("code_challenge"),
-		CodeChallengeMethod: q.Get("code_challenge_method"),
+		RedirectURI:         authReq.RedirectURI,
+		State:               authReq.State,
+		ClientID:            authReq.ClientID,
+		Scope:               authReq.Scope,
+		Nonce:               authReq.Nonce,
+		CodeChallenge:       authReq.CodeChallenge,
+		CodeChallengeMethod: authReq.CodeChallengeMethod,
 	}
 	stateJSON, err := json.Marshal(loginState)
 	if err != nil {

--- a/pkg/passkey/handler_test.go
+++ b/pkg/passkey/handler_test.go
@@ -8,12 +8,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eugenioenko/autentico/pkg/authrequest"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func createPasskeyAuthRequest(t *testing.T) string {
+	t.Helper()
+	id, err := authrequest.Create(authrequest.AuthorizeRequest{
+		ClientID: "c1", RedirectURI: "http://localhost/cb", Scope: "openid", State: "st1", ResponseType: "code",
+	})
+	require.NoError(t, err)
+	return id
+}
 
 // setupPasskeyTestUser inserts a minimal user row and returns (id, username).
 func setupPasskeyTestUser(t *testing.T) (id, username string) {
@@ -46,7 +56,7 @@ func TestHandleRegisterBegin_Success(t *testing.T) {
 	username := "new-passkey-user@example.com"
 
 	req := httptest.NewRequest(http.MethodGet,
-		"/oauth2/passkey/register/begin?username="+username+"&redirect_uri=http://localhost/cb&state=st1&client_id=c1&scope=openid",
+		"/oauth2/passkey/register/begin?username="+username+"&auth_request_id="+createPasskeyAuthRequest(t),
 		nil)
 	rr := httptest.NewRecorder()
 	HandleRegisterBegin(rr, req)
@@ -94,7 +104,7 @@ func TestHandleRegisterBegin_Success_Extra(t *testing.T) {
 	// User does not exist - should be created automatically
 	username := "brand-new-user"
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth2/passkey/register/begin?username="+username, nil)
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/passkey/register/begin?username="+username+"&auth_request_id="+createPasskeyAuthRequest(t), nil)
 	rr := httptest.NewRecorder()
 	HandleRegisterBegin(rr, req)
 
@@ -140,7 +150,7 @@ func TestHandleLoginBegin_NoCreds_PasswordMode(t *testing.T) {
 
 	_, username := setupPasskeyTestUser(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth2/passkey/login/begin?username="+username, nil)
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/passkey/login/begin?username="+username+"&auth_request_id="+createPasskeyAuthRequest(t), nil)
 	rr := httptest.NewRecorder()
 	HandleLoginBegin(rr, req)
 
@@ -156,7 +166,7 @@ func TestHandleLoginBegin_NoCreds_PasswordAndPasskeyMode(t *testing.T) {
 
 	_, username := setupPasskeyTestUser(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth2/passkey/login/begin?username="+username, nil)
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/passkey/login/begin?username="+username+"&auth_request_id="+createPasskeyAuthRequest(t), nil)
 	rr := httptest.NewRecorder()
 	HandleLoginBegin(rr, req)
 
@@ -174,7 +184,7 @@ func TestHandleLoginBegin_NoCreds_PasskeyOnlyMode(t *testing.T) {
 	_, username := setupPasskeyTestUser(t)
 
 	req := httptest.NewRequest(http.MethodGet,
-		"/oauth2/passkey/login/begin?username="+username+"&redirect_uri=http://localhost/cb&state=st1&client_id=c1&scope=openid",
+		"/oauth2/passkey/login/begin?username="+username+"&auth_request_id="+createPasskeyAuthRequest(t),
 		nil)
 	rr := httptest.NewRecorder()
 	HandleLoginBegin(rr, req)
@@ -200,7 +210,7 @@ func TestHandleLoginBegin_WithCreds(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodGet,
-		"/oauth2/passkey/login/begin?username="+username+"&redirect_uri=http://localhost/cb&state=st1&client_id=c1&scope=openid",
+		"/oauth2/passkey/login/begin?username="+username+"&auth_request_id="+createPasskeyAuthRequest(t),
 		nil)
 	rr := httptest.NewRecorder()
 	HandleLoginBegin(rr, req)
@@ -227,7 +237,7 @@ func TestHandleLoginBegin_WithCreds_CreatesChallenge(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodGet,
-		"/oauth2/passkey/login/begin?username="+username+"&redirect_uri=http://localhost/cb&state=st1&client_id=c1&scope=openid",
+		"/oauth2/passkey/login/begin?username="+username+"&auth_request_id="+createPasskeyAuthRequest(t),
 		nil)
 	rr := httptest.NewRecorder()
 	HandleLoginBegin(rr, req)
@@ -262,7 +272,7 @@ func TestHandleLoginBegin_Success_Extra(t *testing.T) {
 		VALUES ('pk1', ?, 'Passkey 1', '{}', CURRENT_TIMESTAMP)
 	`, userID)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth2/passkey/login/begin?username="+username, nil)
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/passkey/login/begin?username="+username+"&auth_request_id="+createPasskeyAuthRequest(t), nil)
 	rr := httptest.NewRecorder()
 	HandleLoginBegin(rr, req)
 

--- a/pkg/signup/handler.go
+++ b/pkg/signup/handler.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/eugenioenko/autentico/pkg/audit"
 	authcode "github.com/eugenioenko/autentico/pkg/auth_code"
+	"github.com/eugenioenko/autentico/pkg/authrequest"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/emailverification"
 	"github.com/eugenioenko/autentico/pkg/idpsession"
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/mfa"
 	"github.com/eugenioenko/autentico/pkg/user"
 	"github.com/eugenioenko/autentico/pkg/utils"
@@ -36,6 +38,30 @@ import (
 // @Success 302 {string} string "Redirect back to client with code (POST)"
 // @Router /oauth2/signup [get]
 // @Router /oauth2/signup [post]
+// HandleSignupPage renders the signup form (GET). Reads auth_request_id from query.
+func HandleSignupPage(w http.ResponseWriter, r *http.Request) {
+	if !config.Get().AuthAllowSelfSignup {
+		http.NotFound(w, r)
+		return
+	}
+
+	authReqID := r.URL.Query().Get("auth_request_id")
+	if authReqID == "" {
+		renderSignupError(w, "Missing authorization request. Please return to the application and try again.")
+		return
+	}
+
+	authReq, err := authrequest.GetByID(authReqID)
+	if err != nil {
+		slog.Warn("signup_page: invalid or expired auth request", "auth_request_id", authReqID, "error", err)
+		renderSignupError(w, "Authorization request expired. Please return to the application and try again.")
+		return
+	}
+
+	errMsg := r.URL.Query().Get("error")
+	RenderSignup(w, r, authReq, errMsg)
+}
+
 func HandleSignup(w http.ResponseWriter, r *http.Request) {
 	if !config.Get().AuthAllowSelfSignup {
 		http.NotFound(w, r)
@@ -51,30 +77,30 @@ func HandleSignup(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleSignupPost(w http.ResponseWriter, r *http.Request) {
-	// In passkey_only mode the form is never POSTed — JS handles everything via
-	// /passkey/register/begin and /passkey/register/finish. Re-render the form.
-	if config.Get().AuthMode == "passkey_only" {
-		RenderSignup(w, r, SignupParams{}, "")
-		return
-	}
-
 	if err := r.ParseForm(); err != nil {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Request payload needs to be application/x-www-form-urlencoded")
 		return
 	}
 
-	params := SignupParams{
-		State:               r.FormValue("state"),
-		RedirectURI:         r.FormValue("redirect_uri"),
-		ClientID:            r.FormValue("client_id"),
-		Scope:               r.FormValue("scope"),
-		Nonce:               r.FormValue("nonce"),
-		CodeChallenge:       r.FormValue("code_challenge"),
-		CodeChallengeMethod: r.FormValue("code_challenge_method"),
+	// Look up stored authorize request — all OAuth parameters come from the
+	// server-side record, not from the POST body (issues #184, #186).
+	authReqID := r.FormValue("auth_request_id")
+	if authReqID == "" {
+		renderSignupError(w, "Missing authorization request. Please return to the application and try again.")
+		return
 	}
 
-	if !utils.IsValidRedirectURI(params.RedirectURI) {
-		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Invalid redirect_uri")
+	authReq, err := authrequest.GetByID(authReqID)
+	if err != nil {
+		slog.Warn("signup: invalid or expired auth request", "request_id", middleware.GetRequestID(r.Context()), "auth_request_id", authReqID, "error", err)
+		renderSignupError(w, "Authorization request expired. Please return to the application and try again.")
+		return
+	}
+
+	// In passkey_only mode the form is never POSTed — JS handles everything via
+	// /passkey/register/begin and /passkey/register/finish. Re-render the form.
+	if config.Get().AuthMode == "passkey_only" {
+		RenderSignup(w, r, authReq, "")
 		return
 	}
 
@@ -87,7 +113,7 @@ func handleSignupPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if password != confirmPassword {
-		redirectSignupError(w, r, params, "Passwords do not match")
+		redirectSignupErrorWithID(w, r, authReqID, "Passwords do not match")
 		return
 	}
 
@@ -97,7 +123,7 @@ func handleSignupPost(w http.ResponseWriter, r *http.Request) {
 		Email:    email,
 	}
 	if err := user.ValidateUserCreateRequest(req); err != nil {
-		redirectSignupError(w, r, params, err.Error())
+		redirectSignupErrorWithID(w, r, authReqID, err.Error())
 		return
 	}
 
@@ -129,14 +155,14 @@ func handleSignupPost(w http.ResponseWriter, r *http.Request) {
 	}
 	for field, visibility := range fieldVisibility {
 		if visibility == "required" && profileFields[field] == "" {
-			redirectSignupError(w, r, params, "Please fill in all required fields")
+			redirectSignupErrorWithID(w, r, authReqID, "Please fill in all required fields")
 			return
 		}
 	}
 
 	usr, err := user.CreateUser(username, password, email)
 	if err != nil {
-		redirectSignupError(w, r, params, "Could not create account. Username may already be taken.")
+		redirectSignupErrorWithID(w, r, authReqID, "Could not create account. Username may already be taken.")
 		return
 	}
 	audit.Log(audit.EventUserCreated, nil, audit.TargetUser, usr.ID, audit.Detail("source", "signup", "username", username), utils.GetClientIP(r))
@@ -163,24 +189,24 @@ func handleSignupPost(w http.ResponseWriter, r *http.Request) {
 			expiresAt := time.Now().Add(config.Get().EmailVerificationExpiration)
 			_ = user.SetEmailVerificationToken(usr.ID, tokenHash, expiresAt)
 			verifyURL := emailverification.BuildVerifyURL(rawToken, emailverification.OAuthParams{
-				RedirectURI:         params.RedirectURI,
-				State:               params.State,
-				ClientID:            params.ClientID,
-				Scope:               params.Scope,
-				Nonce:               params.Nonce,
-				CodeChallenge:       params.CodeChallenge,
-				CodeChallengeMethod: params.CodeChallengeMethod,
+				RedirectURI:         authReq.RedirectURI,
+				State:               authReq.State,
+				ClientID:            authReq.ClientID,
+				Scope:               authReq.Scope,
+				Nonce:               authReq.Nonce,
+				CodeChallenge:       authReq.CodeChallenge,
+				CodeChallengeMethod: authReq.CodeChallengeMethod,
 			})
 			_ = mfa.SendVerificationEmail(usr.Email, verifyURL)
 		}
 		emailverification.RenderVerifyEmail(w, r, "sent", usr.Username, emailverification.OAuthParams{
-			RedirectURI:         params.RedirectURI,
-			State:               params.State,
-			ClientID:            params.ClientID,
-			Scope:               params.Scope,
-			Nonce:               params.Nonce,
-			CodeChallenge:       params.CodeChallenge,
-			CodeChallengeMethod: params.CodeChallengeMethod,
+			RedirectURI:         authReq.RedirectURI,
+			State:               authReq.State,
+			ClientID:            authReq.ClientID,
+			Scope:               authReq.Scope,
+			Nonce:               authReq.Nonce,
+			CodeChallenge:       authReq.CodeChallenge,
+			CodeChallengeMethod: authReq.CodeChallengeMethod,
 		}, "")
 		return
 	}
@@ -203,44 +229,38 @@ func handleSignupPost(w http.ResponseWriter, r *http.Request) {
 	authCode, err := authcode.GenerateSecureCode()
 	if err != nil {
 		slog.Error("signup: failed to generate auth code", "error", err)
-		redirectSignupError(w, r, params, "Something went wrong. Please try again.")
+		redirectSignupErrorWithID(w, r, authReqID, "Something went wrong. Please try again.")
 		return
 	}
 
 	code := authcode.AuthCode{
 		Code:                authCode,
 		UserID:              usr.ID,
-		ClientID:            params.ClientID,
-		RedirectURI:         params.RedirectURI,
-		Scope:               params.Scope,
-		Nonce:               params.Nonce,
-		CodeChallenge:       params.CodeChallenge,
-		CodeChallengeMethod: params.CodeChallengeMethod,
+		ClientID:            authReq.ClientID,
+		RedirectURI:         authReq.RedirectURI,
+		Scope:               authReq.Scope,
+		Nonce:               authReq.Nonce,
+		CodeChallenge:       authReq.CodeChallenge,
+		CodeChallengeMethod: authReq.CodeChallengeMethod,
 		ExpiresAt:           time.Now().Add(config.Get().AuthAuthorizationCodeExpiration),
 		Used:                false,
 	}
 
 	if err = authcode.CreateAuthCode(code); err != nil {
 		slog.Error("signup: failed to create auth code", "error", err)
-		redirectSignupError(w, r, params, "Something went wrong. Please try again.")
+		redirectSignupErrorWithID(w, r, authReqID, "Something went wrong. Please try again.")
 		return
 	}
 
-	redirectURL := fmt.Sprintf("%s?code=%s&state=%s", params.RedirectURI, code.Code, params.State)
+	// Consume the authorize request to prevent reuse
+	_ = authrequest.Delete(authReqID)
+
+	redirectURL := fmt.Sprintf("%s?code=%s&state=%s", authReq.RedirectURI, code.Code, authReq.State)
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
-type SignupParams struct {
-	State               string
-	RedirectURI         string
-	ClientID            string
-	Scope               string
-	Nonce               string
-	CodeChallenge       string
-	CodeChallengeMethod string
-}
-
-func RenderSignup(w http.ResponseWriter, r *http.Request, params SignupParams, errMsg string) {
+// RenderSignup renders the signup form using stored authorize request parameters.
+func RenderSignup(w http.ResponseWriter, r *http.Request, authReq *authrequest.AuthorizeRequest, errMsg string) {
 	cfg := config.Get()
 	tmpl, err := view.ParseTemplate("signup")
 	if err != nil {
@@ -249,13 +269,8 @@ func RenderSignup(w http.ResponseWriter, r *http.Request, params SignupParams, e
 	}
 
 	data := map[string]any{
-		"State":               params.State,
-		"RedirectURI":         params.RedirectURI,
-		"ClientID":            params.ClientID,
-		"Scope":               params.Scope,
-		"Nonce":               params.Nonce,
-		"CodeChallenge":       params.CodeChallenge,
-		"CodeChallengeMethod": params.CodeChallengeMethod,
+		"AuthRequestID":       authReq.ID,
+		"ClientID":            authReq.ClientID,
 		"Error":               errMsg,
 		"AuthMode":            cfg.AuthMode,
 		"ProfileFieldEmail":        cfg.ProfileFieldEmail,
@@ -264,7 +279,6 @@ func RenderSignup(w http.ResponseWriter, r *http.Request, params SignupParams, e
 		"ThemeTitle":          cfg.Theme.Title,
 		"ThemeLogoUrl":        cfg.Theme.LogoUrl,
 		"ThemeCssResolved":    template.CSS(cfg.ThemeCssResolved),
-		// Profile field visibility
 		"ProfileFieldGivenName":  cfg.ProfileFieldGivenName,
 		"ProfileFieldFamilyName": cfg.ProfileFieldFamilyName,
 		"ProfileFieldPhone":      cfg.ProfileFieldPhone,
@@ -278,19 +292,27 @@ func RenderSignup(w http.ResponseWriter, r *http.Request, params SignupParams, e
 	}
 }
 
-// redirectSignupError redirects back to /oauth2/authorize?prompt=create with the error
-// and all OAuth params preserved, so the user stays in the authorize flow.
-func redirectSignupError(w http.ResponseWriter, r *http.Request, params SignupParams, errMsg string) {
-	q := url.Values{}
-	q.Set("response_type", "code")
-	q.Set("prompt", "create")
-	q.Set("error", errMsg)
-	q.Set("client_id", params.ClientID)
-	q.Set("redirect_uri", params.RedirectURI)
-	q.Set("scope", params.Scope)
-	q.Set("state", params.State)
-	q.Set("nonce", params.Nonce)
-	q.Set("code_challenge", params.CodeChallenge)
-	q.Set("code_challenge_method", params.CodeChallengeMethod)
-	http.Redirect(w, r, "/oauth2/authorize?"+q.Encode(), http.StatusFound)
+// redirectSignupErrorWithID redirects back to the signup page with an error message,
+// preserving the auth request ID so the form is re-rendered with stored params.
+func redirectSignupErrorWithID(w http.ResponseWriter, r *http.Request, authReqID string, errMsg string) {
+	signupURL := config.GetBootstrap().AppOAuthPath + "/signup?auth_request_id=" + authReqID + "&error=" + url.QueryEscape(errMsg)
+	http.Redirect(w, r, signupURL, http.StatusFound)
+}
+
+// renderSignupError renders a branded error page for authorization request failures.
+func renderSignupError(w http.ResponseWriter, errorMsg string) {
+	cfg := config.Get()
+	tmpl, err := view.ParseTemplate("error")
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	data := map[string]any{
+		"Error":            errorMsg,
+		"ThemeTitle":       cfg.Theme.Title,
+		"ThemeLogoUrl":     cfg.Theme.LogoUrl,
+		"ThemeCssResolved": template.CSS(cfg.ThemeCssResolved),
+	}
+	w.WriteHeader(http.StatusBadRequest)
+	_ = tmpl.ExecuteTemplate(w, "layout", data)
 }

--- a/pkg/signup/handler_test.go
+++ b/pkg/signup/handler_test.go
@@ -9,12 +9,27 @@ import (
 	"time"
 
 	"github.com/eugenioenko/autentico/pkg/appsettings"
+	"github.com/eugenioenko/autentico/pkg/authrequest"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/user"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func createSignupAuthRequest(t *testing.T, clientID, redirectURI string) string {
+	t.Helper()
+	id, err := authrequest.Create(authrequest.AuthorizeRequest{
+		ClientID:    clientID,
+		RedirectURI: redirectURI,
+		Scope:       "openid profile email",
+		State:       "test-state",
+		ResponseType: "code",
+	})
+	require.NoError(t, err)
+	return id
+}
 
 func TestHandleSignup_DisabledReturns404(t *testing.T) {
 	testutils.WithTestDB(t)
@@ -46,7 +61,7 @@ func TestHandleSignup_WrongMethod(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
 }
 
-func TestHandleSignup_Post_InvalidRedirectURI(t *testing.T) {
+func TestHandleSignup_Post_MissingAuthRequestID(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.WithConfigOverride(t, func() {
 		config.Values.AuthAllowSelfSignup = true
@@ -56,8 +71,6 @@ func TestHandleSignup_Post_InvalidRedirectURI(t *testing.T) {
 	form.Set("username", "newuser")
 	form.Set("password", "password123")
 	form.Set("confirm_password", "password123")
-	form.Set("redirect_uri", "not-a-valid-uri") // syntactically invalid
-	form.Set("state", "xyz123")
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/signup", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -66,21 +79,22 @@ func TestHandleSignup_Post_InvalidRedirectURI(t *testing.T) {
 	HandleSignup(rr, req)
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
-	assert.Contains(t, rr.Body.String(), "Invalid redirect_uri")
+	assert.Contains(t, rr.Body.String(), "Missing authorization request")
 }
 
 func TestHandleSignup_Post_PasswordMismatch(t *testing.T) {
 	testutils.WithTestDB(t)
+	testutils.InsertTestClient(t, "c1", []string{"http://localhost/callback"})
 	testutils.WithConfigOverride(t, func() {
 		config.Values.AuthAllowSelfSignup = true
 	})
+	authReqID := createSignupAuthRequest(t, "c1", "http://localhost/callback")
 
 	form := url.Values{}
 	form.Set("username", "newuser")
 	form.Set("password", "password123")
 	form.Set("confirm_password", "different456")
-	form.Set("redirect_uri", "http://localhost/callback")
-	form.Set("state", "xyz123")
+	form.Set("auth_request_id", authReqID)
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/signup", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -90,8 +104,7 @@ func TestHandleSignup_Post_PasswordMismatch(t *testing.T) {
 
 	assert.Equal(t, http.StatusFound, rr.Code)
 	loc := rr.Header().Get("Location")
-	assert.Contains(t, loc, "prompt=create")
-	assert.Contains(t, loc, "error=Passwords+do+not+match")
+	assert.Contains(t, loc, "Passwords+do+not+match")
 }
 
 func TestHandleSignup_Post_ValidationError(t *testing.T) {
@@ -105,8 +118,7 @@ func TestHandleSignup_Post_ValidationError(t *testing.T) {
 	form.Set("username", "ab") // too short
 	form.Set("password", "password123")
 	form.Set("confirm_password", "password123")
-	form.Set("redirect_uri", "http://localhost/callback")
-	form.Set("state", "xyz123")
+	form.Set("auth_request_id", createSignupAuthRequest(t, "test-client", "http://localhost/callback"))
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/signup", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -116,7 +128,7 @@ func TestHandleSignup_Post_ValidationError(t *testing.T) {
 
 	assert.Equal(t, http.StatusFound, rr.Code)
 	loc := rr.Header().Get("Location")
-	assert.Contains(t, loc, "prompt=create")
+	assert.Contains(t, loc, "auth_request_id=")
 	assert.Contains(t, loc, "error=")
 }
 
@@ -134,8 +146,7 @@ func TestHandleSignup_Post_DuplicateUser(t *testing.T) {
 	form.Set("username", "existinguser")
 	form.Set("password", "password123")
 	form.Set("confirm_password", "password123")
-	form.Set("redirect_uri", "http://localhost/callback")
-	form.Set("state", "xyz123")
+	form.Set("auth_request_id", createSignupAuthRequest(t, "test-client", "http://localhost/callback"))
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/signup", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -145,8 +156,8 @@ func TestHandleSignup_Post_DuplicateUser(t *testing.T) {
 
 	assert.Equal(t, http.StatusFound, rr.Code)
 	loc := rr.Header().Get("Location")
-	assert.Contains(t, loc, "prompt=create")
-	assert.Contains(t, loc, "error=Could+not+create+account")
+	assert.Contains(t, loc, "auth_request_id=")
+	assert.Contains(t, loc, "Could+not+create+account")
 }
 
 func TestHandleSignup_Post_Success(t *testing.T) {
@@ -161,9 +172,7 @@ func TestHandleSignup_Post_Success(t *testing.T) {
 	form.Set("username", "newuser")
 	form.Set("password", "password123")
 	form.Set("confirm_password", "password123")
-	form.Set("redirect_uri", "http://localhost/callback")
-	form.Set("state", "abc123")
-	form.Set("client_id", "test-client")
+	form.Set("auth_request_id", createSignupAuthRequest(t, "test-client", "http://localhost/callback"))
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/signup", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -175,7 +184,7 @@ func TestHandleSignup_Post_Success(t *testing.T) {
 	location := rr.Header().Get("Location")
 	assert.Contains(t, location, "http://localhost/callback")
 	assert.Contains(t, location, "code=")
-	assert.Contains(t, location, "state=abc123")
+	assert.Contains(t, location, "state=test-state")
 }
 
 func TestHandleSignup_Post_SetsIdpSessionCookie(t *testing.T) {
@@ -191,8 +200,7 @@ func TestHandleSignup_Post_SetsIdpSessionCookie(t *testing.T) {
 	form.Set("username", "newuser")
 	form.Set("password", "password123")
 	form.Set("confirm_password", "password123")
-	form.Set("redirect_uri", "http://localhost/callback")
-	form.Set("state", "abc123")
+	form.Set("auth_request_id", createSignupAuthRequest(t, "test-client", "http://localhost/callback"))
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/signup", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -222,7 +230,11 @@ func TestHandleSignup_Post_PasskeyOnly(t *testing.T) {
 		config.Values.AuthMode = "passkey_only"
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "/oauth2/signup", nil)
+	authReqID := createSignupAuthRequest(t, "test-client", "http://localhost/callback")
+	form := url.Values{}
+	form.Set("auth_request_id", authReqID)
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/signup", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rr := httptest.NewRecorder()
 
 	HandleSignup(rr, req)
@@ -241,7 +253,7 @@ func TestHandleSignup_Post_RequiredFieldsMissing(t *testing.T) {
 	form.Set("username", "newuser")
 	form.Set("password", "password123")
 	form.Set("confirm_password", "password123")
-	form.Set("redirect_uri", "http://localhost/callback")
+	form.Set("auth_request_id", createSignupAuthRequest(t, "test-client", "http://localhost/callback"))
 	// given_name is missing
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/signup", strings.NewReader(form.Encode()))
@@ -252,8 +264,8 @@ func TestHandleSignup_Post_RequiredFieldsMissing(t *testing.T) {
 
 	assert.Equal(t, http.StatusFound, rr.Code)
 	loc := rr.Header().Get("Location")
-	assert.Contains(t, loc, "prompt=create")
-	assert.Contains(t, loc, "error=Please+fill+in+all+required+fields")
+	assert.Contains(t, loc, "auth_request_id=")
+	assert.Contains(t, loc, "Please+fill+in+all+required+fields")
 }
 
 func TestHandleSignup_Post_EmailIsUsername(t *testing.T) {
@@ -267,7 +279,7 @@ func TestHandleSignup_Post_EmailIsUsername(t *testing.T) {
 	form.Set("username", "user@example.com")
 	form.Set("password", "password123")
 	form.Set("confirm_password", "password123")
-	form.Set("redirect_uri", "http://localhost/callback")
+	form.Set("auth_request_id", createSignupAuthRequest(t, "test-client", "http://localhost/callback"))
 	// email is NOT set explicitly
 
 	req := httptest.NewRequest(http.MethodPost, "/oauth2/signup", strings.NewReader(form.Encode()))
@@ -315,7 +327,7 @@ func TestHandleSignup_Post_RequireEmailVerification_ShowsVerifyPage(t *testing.T
 	form.Set("password", "password123")
 	form.Set("confirm_password", "password123")
 	form.Set("email", "verifyme@test.com")
-	form.Set("redirect_uri", "http://localhost/callback")
+	form.Set("auth_request_id", createSignupAuthRequest(t, "test-client", "http://localhost/callback"))
 	form.Set("state", "xyz")
 	form.Set("client_id", "test-client")
 
@@ -347,7 +359,7 @@ func TestHandleSignup_Post_RequireEmailVerification_AdminExempt(t *testing.T) {
 	form.Set("username", "noemailuser")
 	form.Set("password", "password123")
 	form.Set("confirm_password", "password123")
-	form.Set("redirect_uri", "http://localhost/callback")
+	form.Set("auth_request_id", createSignupAuthRequest(t, "test-client", "http://localhost/callback"))
 	form.Set("state", "xyz")
 	form.Set("client_id", "test-client")
 	// No email provided

--- a/tests/browser/tests/auth-flow.spec.ts
+++ b/tests/browser/tests/auth-flow.spec.ts
@@ -20,7 +20,7 @@ test("onboarding creates admin account", async ({ page }) => {
 
 test("admin UI dashboard loads after login", async ({ page }) => {
   await page.goto("/admin/");
-  await page.waitForURL("**/oauth2/authorize**", { timeout: TIMEOUT });
+  await page.waitForURL("**/oauth2/login**", { timeout: TIMEOUT });
 
   await page.fill("#username", ADMIN_USERNAME);
   await page.fill("#password", ADMIN_PASSWORD);
@@ -32,7 +32,7 @@ test("admin UI dashboard loads after login", async ({ page }) => {
 
 test("admin UI logout requires re-authentication", async ({ page }) => {
   await page.goto("/admin/");
-  await page.waitForURL("**/oauth2/authorize**", { timeout: TIMEOUT });
+  await page.waitForURL("**/oauth2/login**", { timeout: TIMEOUT });
   await page.fill("#username", ADMIN_USERNAME);
   await page.fill("#password", ADMIN_PASSWORD);
   await page.click('button[type="submit"]');
@@ -43,7 +43,7 @@ test("admin UI logout requires re-authentication", async ({ page }) => {
   await page.click('text=Logout');
 
   // Should redirect to login page
-  await page.waitForURL("**/oauth2/authorize**", { timeout: TIMEOUT });
+  await page.waitForURL("**/oauth2/login**", { timeout: TIMEOUT });
   await expect(page.locator("#username")).toBeVisible({ timeout: TIMEOUT });
   await expect(page.locator("#password")).toBeVisible({ timeout: TIMEOUT });
 });
@@ -51,7 +51,7 @@ test("admin UI logout requires re-authentication", async ({ page }) => {
 test("signup via prompt=create from login page", async ({ page, context }) => {
   // Step 1: Log in as admin and enable self-signup via settings API
   await page.goto("/admin/");
-  await page.waitForURL("**/oauth2/authorize**", { timeout: TIMEOUT });
+  await page.waitForURL("**/oauth2/login**", { timeout: TIMEOUT });
   await page.fill("#username", ADMIN_USERNAME);
   await page.fill("#password", ADMIN_PASSWORD);
   await page.click('button[type="submit"]');
@@ -81,7 +81,7 @@ test("signup via prompt=create from login page", async ({ page, context }) => {
 
   // Step 3: Navigate to account UI — redirects to login
   await page.goto("/account/");
-  await page.waitForURL("**/oauth2/authorize**", { timeout: TIMEOUT });
+  await page.waitForURL("**/oauth2/login**", { timeout: TIMEOUT });
 
   // Step 4: Click "Create account" link
   await page.click('text=Create account');
@@ -104,7 +104,7 @@ test("signup via prompt=create from login page", async ({ page, context }) => {
 
 test("account UI login and dashboard", async ({ page }) => {
   await page.goto("/account/");
-  await page.waitForURL("**/oauth2/authorize**", { timeout: TIMEOUT });
+  await page.waitForURL("**/oauth2/login**", { timeout: TIMEOUT });
 
   await page.fill("#username", ADMIN_USERNAME);
   await page.fill("#password", ADMIN_PASSWORD);
@@ -116,7 +116,7 @@ test("account UI login and dashboard", async ({ page }) => {
 
 test("account UI logout requires re-authentication", async ({ page }) => {
   await page.goto("/account/");
-  await page.waitForURL("**/oauth2/authorize**", { timeout: TIMEOUT });
+  await page.waitForURL("**/oauth2/login**", { timeout: TIMEOUT });
 
   await page.fill("#username", ADMIN_USERNAME);
   await page.fill("#password", ADMIN_PASSWORD);
@@ -128,7 +128,7 @@ test("account UI logout requires re-authentication", async ({ page }) => {
   await page.getByTestId("sign-out").click();
 
   // Should redirect to login page
-  await page.waitForURL("**/oauth2/authorize**", { timeout: TIMEOUT });
+  await page.waitForURL("**/oauth2/login**", { timeout: TIMEOUT });
   await expect(page.locator("#username")).toBeVisible({ timeout: TIMEOUT });
   await expect(page.locator("#password")).toBeVisible({ timeout: TIMEOUT });
 });

--- a/tests/e2e/auth_code_flow_test.go
+++ b/tests/e2e/auth_code_flow_test.go
@@ -184,42 +184,25 @@ func TestAuthorizationCodeFlow_StatePreserved(t *testing.T) {
 
 	createTestUser(t, "user@test.com", "password123", "user@test.com")
 
-	// GET /oauth2/authorize
-	authorizeURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
+	authReqID, csrfToken := authorizeAndGetLoginPage(t, ts, url.Values{
 		"response_type":         {"code"},
 		"client_id":             {"test-client"},
 		"redirect_uri":          {redirectURI},
 		"state":                 {expectedState},
 		"code_challenge":        {testCodeChallenge},
 		"code_challenge_method": {"S256"},
-	}.Encode()
+	})
 
-	resp, err := ts.Client.Get(authorizeURL)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	csrfToken := getCSRFToken(string(body))
-	require.NotEmpty(t, csrfToken)
-
-	// POST /oauth2/login
 	form := url.Values{}
 	form.Set("username", "user@test.com")
 	form.Set("password", "password123")
-	form.Set("redirect_uri", redirectURI)
-	form.Set("state", expectedState)
-	form.Set("client_id", "test-client")
-	form.Set("code_challenge", testCodeChallenge)
-	form.Set("code_challenge_method", "S256")
+	form.Set("auth_request_id", authReqID)
 	form.Set("gorilla.csrf.Token", csrfToken)
 
 	loginReq, err := http.NewRequest("POST", ts.BaseURL+"/oauth2/login", strings.NewReader(form.Encode()))
 	require.NoError(t, err)
 	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	loginReq.Header.Set("Referer", ts.BaseURL+"/oauth2/authorize")
+	loginReq.Header.Set("Referer", ts.BaseURL+"/oauth2/login")
 
 	loginResp, err := ts.Client.Do(loginReq)
 	require.NoError(t, err)
@@ -668,40 +651,27 @@ func TestAuthorizationCodeFlow_StateWithSpecialChars(t *testing.T) {
 
 	createTestUser(t, "user@test.com", "password123", "user@test.com")
 
-	authorizeURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
+	params := url.Values{
 		"response_type":         {"code"},
 		"client_id":             {"test-client"},
 		"redirect_uri":          {redirectURI},
 		"state":                 {specialState},
 		"code_challenge":        {testCodeChallenge},
 		"code_challenge_method": {"S256"},
-	}.Encode()
+	}
 
-	resp, err := ts.Client.Get(authorizeURL)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	csrfToken := getCSRFToken(string(body))
-	require.NotEmpty(t, csrfToken)
+	authRequestID, csrfToken := authorizeAndGetLoginPage(t, ts, params)
 
 	form := url.Values{}
 	form.Set("username", "user@test.com")
 	form.Set("password", "password123")
-	form.Set("redirect_uri", redirectURI)
-	form.Set("state", specialState)
-	form.Set("client_id", "test-client")
-	form.Set("code_challenge", testCodeChallenge)
-	form.Set("code_challenge_method", "S256")
+	form.Set("auth_request_id", authRequestID)
 	form.Set("gorilla.csrf.Token", csrfToken)
 
 	loginReq, err := http.NewRequest("POST", ts.BaseURL+"/oauth2/login", strings.NewReader(form.Encode()))
 	require.NoError(t, err)
 	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	loginReq.Header.Set("Referer", ts.BaseURL+"/oauth2/authorize")
+	loginReq.Header.Set("Referer", ts.BaseURL+"/oauth2/login")
 
 	loginResp, err := ts.Client.Do(loginReq)
 	require.NoError(t, err)

--- a/tests/e2e/basic_auth_test.go
+++ b/tests/e2e/basic_auth_test.go
@@ -137,17 +137,23 @@ func TestAuthorize_RendersLoginPage(t *testing.T) {
 		"code_challenge_method": {"S256"},
 	}.Encode()
 
+	// Authorize now redirects to /login?auth_request_id=xxx
 	resp, err := ts.Client.Get(authorizeURL)
 	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
 
-	body, err := io.ReadAll(resp.Body)
+	loginLocation := resp.Header.Get("Location")
+	require.Contains(t, loginLocation, "auth_request_id=")
+
+	// Follow redirect to the login page
+	loginResp, err := ts.Client.Get(ts.BaseURL + loginLocation)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+	defer func() { _ = loginResp.Body.Close() }()
 
-	doc := string(body)
-	assert.Contains(t, doc, "http://localhost:3000/callback")
-	assert.Contains(t, doc, "<body id=\"autentico\">")
+	body, _ := io.ReadAll(loginResp.Body)
+	require.Equal(t, http.StatusOK, loginResp.StatusCode)
+	assert.Contains(t, string(body), "<body id=\"autentico\">")
 }
 
 func TestAuthorize_InvalidRequest(t *testing.T) {

--- a/tests/e2e/client_validation_test.go
+++ b/tests/e2e/client_validation_test.go
@@ -24,20 +24,22 @@ func authorizeURL(ts *TestServer, clientID, redirectURI, state string) string {
 	}.Encode()
 }
 
-// csrfTokenFromAuthorize fetches the authorize page for a known-good client
-// and extracts the CSRF token. This is used to obtain a valid CSRF cookie+token
-// pair before testing the login endpoint with invalid parameters.
+// csrfTokenFromAuthorize fetches the authorize page for a known-good client,
+// follows the redirect to the login page, and extracts the CSRF token.
+// This is used to obtain a valid CSRF cookie+token pair before testing
+// the login endpoint with invalid parameters.
 func csrfTokenFromAuthorize(t *testing.T, ts *TestServer) string {
 	t.Helper()
-	resp, err := ts.Client.Get(authorizeURL(ts, "test-client", "http://localhost:3000/callback", "state"))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode, "authorize page failed: %s", string(body))
-	token := getCSRFToken(string(body))
-	require.NotEmpty(t, token, "CSRF token not found in authorize page")
-	return token
+	params := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"test-client"},
+		"redirect_uri":          {"http://localhost:3000/callback"},
+		"state":                 {"state"},
+		"code_challenge":        {testCodeChallenge},
+		"code_challenge_method": {"S256"},
+	}
+	_, csrfToken := authorizeAndGetLoginPage(t, ts, params)
+	return csrfToken
 }
 
 // postLogin sends a POST to /oauth2/login with the given form values and CSRF token.
@@ -47,7 +49,7 @@ func postLogin(t *testing.T, ts *TestServer, form url.Values, csrfToken string) 
 	req, err := http.NewRequest("POST", ts.BaseURL+"/oauth2/login", strings.NewReader(form.Encode()))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Referer", ts.BaseURL+"/oauth2/authorize")
+	req.Header.Set("Referer", ts.BaseURL+"/oauth2/login")
 	resp, err := ts.Client.Do(req)
 	require.NoError(t, err)
 	return resp
@@ -86,16 +88,15 @@ func TestAuthorize_RedirectURINotRegistered(t *testing.T) {
 
 // --- /oauth2/login tests ---
 
-func TestLogin_UnknownClientID(t *testing.T) {
+// TestLogin_MissingAuthRequestID verifies that POST /oauth2/login without an
+// auth_request_id returns an error (server-side authorize request storage).
+func TestLogin_MissingAuthRequestID(t *testing.T) {
 	ts := startTestServer(t)
 	csrfToken := csrfTokenFromAuthorize(t, ts)
 
 	form := url.Values{}
 	form.Set("username", "user@test.com")
 	form.Set("password", "password123")
-	form.Set("redirect_uri", "http://localhost:3000/callback")
-	form.Set("state", "s1")
-	form.Set("client_id", "nonexistent-client-xyz")
 
 	resp := postLogin(t, ts, form, csrfToken)
 	defer func() { _ = resp.Body.Close() }()
@@ -104,58 +105,9 @@ func TestLogin_UnknownClientID(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Contains(t, string(body), "Unknown client_id")
+	assert.Contains(t, string(body), "Missing authorization request")
 }
 
-func TestLogin_InactiveClient(t *testing.T) {
-	ts := startTestServer(t)
-
-	_, err := db.GetDB().Exec(`
-		INSERT INTO clients (id, client_id, client_name, client_type, redirect_uris, is_active)
-		VALUES ('inactive-e2e-id', 'inactive-e2e-client', 'Inactive E2E Client', 'public', '["http://localhost:3000/callback"]', FALSE)
-	`)
-	require.NoError(t, err)
-
-	csrfToken := csrfTokenFromAuthorize(t, ts)
-
-	form := url.Values{}
-	form.Set("username", "user@test.com")
-	form.Set("password", "password123")
-	form.Set("redirect_uri", "http://localhost:3000/callback")
-	form.Set("state", "s1")
-	form.Set("client_id", "inactive-e2e-client")
-
-	resp := postLogin(t, ts, form, csrfToken)
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Contains(t, string(body), "Client is inactive")
-}
-
-func TestLogin_RedirectURINotAllowedForClient(t *testing.T) {
-	ts := startTestServer(t)
-	csrfToken := csrfTokenFromAuthorize(t, ts)
-
-	// test-client only allows http://localhost:3000/callback, not evil.example.com
-	form := url.Values{}
-	form.Set("username", "user@test.com")
-	form.Set("password", "password123")
-	form.Set("redirect_uri", "http://evil.example.com/callback")
-	form.Set("state", "s1")
-	form.Set("client_id", "test-client")
-
-	resp := postLogin(t, ts, form, csrfToken)
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Contains(t, string(body), "Redirect URI not allowed for this client")
-}
 
 // seedScopedClient inserts a client that only allows "openid profile" scopes.
 func seedScopedClient(t *testing.T) {
@@ -192,27 +144,30 @@ func TestAuthorize_InvalidScope(t *testing.T) {
 	assert.Contains(t, resp.Header.Get("Location"), "error=invalid_scope")
 }
 
-func TestLogin_InvalidScope(t *testing.T) {
+// TestLogin_InvalidScope_NowHandledByAuthorize verifies that scope validation
+// is handled by the authorize endpoint, which stores valid params server-side.
+// The login endpoint trusts the stored params and no longer validates scope.
+func TestLogin_InvalidScope_NowHandledByAuthorize(t *testing.T) {
 	ts := startTestServer(t)
 	seedScopedClient(t)
-	csrfToken := csrfTokenFromAuthorize(t, ts)
 
-	form := url.Values{}
-	form.Set("username", "user@test.com")
-	form.Set("password", "password123")
-	form.Set("redirect_uri", "http://localhost:3000/callback")
-	form.Set("state", "s1")
-	form.Set("client_id", "scoped-e2e-client")
-	form.Set("scope", "offline_access") // not in client's allowed scopes
+	// Attempting invalid scope at authorize endpoint → redirect back with error
+	authURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"scoped-e2e-client"},
+		"redirect_uri":          {"http://localhost:3000/callback"},
+		"state":                 {"s1"},
+		"scope":                 {"offline_access"},
+		"code_challenge":        {testCodeChallenge},
+		"code_challenge_method": {"S256"},
+	}.Encode()
 
-	resp := postLogin(t, ts, form, csrfToken)
+	resp, err := ts.Client.Get(authURL)
+	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Contains(t, string(body), "invalid_scope")
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Location"), "error=invalid_scope")
 }
 
 func TestToken_PasswordGrant_InvalidScope(t *testing.T) {

--- a/tests/e2e/rp_initiated_logout_test.go
+++ b/tests/e2e/rp_initiated_logout_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
@@ -86,14 +85,16 @@ func TestRpInitiatedLogout_DeactivatesIdpSession(t *testing.T) {
 	require.NotNil(t, clearedCookie, "logout should clear the IdP session cookie")
 	assert.True(t, clearedCookie.MaxAge < 0, "cleared cookie should have negative MaxAge")
 
-	// Step 6: /authorize should now show the login page (SSO revoked).
+	// Step 6: /authorize should now redirect to login page (SSO revoked).
 	postResp, err := ts.Client.Get(authorizeURL)
 	require.NoError(t, err)
 	defer func() { _ = postResp.Body.Close() }()
 
-	assert.Equal(t, http.StatusOK, postResp.StatusCode, "should show login page after RP-Initiated Logout")
-	postBody, _ := io.ReadAll(postResp.Body)
-	assert.True(t, strings.Contains(string(postBody), "<form"), "should render login form after logout")
+	// Authorize now redirects to /oauth2/login?auth_request_id=xxx
+	assert.Equal(t, http.StatusFound, postResp.StatusCode, "should redirect to login page after RP-Initiated Logout")
+	postLocation := postResp.Header.Get("Location")
+	assert.Contains(t, postLocation, "/oauth2/login", "should redirect to login page after logout")
+	assert.Contains(t, postLocation, "auth_request_id=", "should include auth_request_id after logout")
 }
 
 // TestRpInitiatedLogout_PostLogoutRedirectWithState verifies that a registered

--- a/tests/e2e/server_test.go
+++ b/tests/e2e/server_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/eugenioenko/autentico/pkg/model"
@@ -67,34 +66,18 @@ func TestServerJWKS(t *testing.T) {
 func TestServerAuthorizeRendersLoginPage(t *testing.T) {
 	ts := startTestServer(t)
 
-	authorizeURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
+	params := url.Values{
 		"response_type":         {"code"},
 		"client_id":             {"test-client"},
 		"redirect_uri":          {"http://localhost:3000/callback"},
 		"state":                 {"abc123"},
 		"code_challenge":        {testCodeChallenge},
 		"code_challenge_method": {"S256"},
-	}.Encode()
+	}
 
-	resp, err := ts.Client.Get(authorizeURL)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	// Authorize now redirects to /oauth2/login?auth_request_id=xxx
+	authRequestID, csrfToken := authorizeAndGetLoginPage(t, ts, params)
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	bodyStr := string(body)
-
-	// Verify the login form is rendered
-	assert.True(t, strings.Contains(bodyStr, "<form"), "response should contain a form element")
-	assert.True(t, strings.Contains(bodyStr, `name="username"`), "response should contain username field")
-	assert.True(t, strings.Contains(bodyStr, `name="password"`), "response should contain password field")
-	assert.True(t, strings.Contains(bodyStr, `name="state"`), "response should contain state hidden field")
-	assert.True(t, strings.Contains(bodyStr, `value="abc123"`), "state value should be preserved")
-
-	// Verify CSRF token is present
-	csrfToken := getCSRFToken(bodyStr)
+	assert.NotEmpty(t, authRequestID, "auth_request_id should be present")
 	assert.NotEmpty(t, csrfToken, "CSRF token should be present in the login page")
 }

--- a/tests/e2e/session_test.go
+++ b/tests/e2e/session_test.go
@@ -98,7 +98,7 @@ func TestLogout_DeactivatesIdpSession(t *testing.T) {
 	assert.Equal(t, "", clearedCookie.Value)
 	assert.True(t, clearedCookie.MaxAge < 0, "cleared cookie should have negative MaxAge")
 
-	// Visit /authorize again — should show login page (not auto-redirect)
+	// Visit /authorize again — should redirect to login page (not auto-login with code)
 	authorizeURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
 		"response_type":         {"code"},
 		"client_id":             {"test-client"},
@@ -112,7 +112,11 @@ func TestLogout_DeactivatesIdpSession(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode, "should show login page, not auto-redirect")
+	// Authorize now redirects to /oauth2/login?auth_request_id=xxx (not auto-login to client)
+	assert.Equal(t, http.StatusFound, resp.StatusCode, "should redirect to login page, not auto-login")
+	location := resp.Header.Get("Location")
+	assert.Contains(t, location, "/oauth2/login", "should redirect to login page")
+	assert.Contains(t, location, "auth_request_id=", "should include auth_request_id")
 }
 
 func TestLogout_NoAuthNoParams_ShowsLogoutPage(t *testing.T) {
@@ -196,7 +200,7 @@ func TestAutoLogin_IdleTimeoutExpired(t *testing.T) {
 	_, err := db.GetDB().Exec(`UPDATE idp_sessions SET last_activity_at = ?`, time.Now().Add(-10*time.Minute))
 	require.NoError(t, err)
 
-	// Visit /authorize — should show login page (session idle timeout expired)
+	// Visit /authorize — should redirect to login page (session idle timeout expired)
 	authorizeURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
 		"response_type":         {"code"},
 		"client_id":             {"test-client"},
@@ -210,10 +214,11 @@ func TestAutoLogin_IdleTimeoutExpired(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode, "should show login page when idle timeout expired")
-
-	body, _ := io.ReadAll(resp.Body)
-	assert.True(t, strings.Contains(string(body), "<form"), "should render login form")
+	// Authorize now redirects to /oauth2/login?auth_request_id=xxx
+	assert.Equal(t, http.StatusFound, resp.StatusCode, "should redirect to login page when idle timeout expired")
+	location := resp.Header.Get("Location")
+	assert.Contains(t, location, "/oauth2/login", "should redirect to login page")
+	assert.Contains(t, location, "auth_request_id=", "should include auth_request_id")
 }
 
 func TestAutoLogin_DeactivatedIdpSession(t *testing.T) {
@@ -230,7 +235,7 @@ func TestAutoLogin_DeactivatedIdpSession(t *testing.T) {
 	_, err := db.GetDB().Exec(`UPDATE idp_sessions SET deactivated_at = CURRENT_TIMESTAMP`)
 	require.NoError(t, err)
 
-	// Visit /authorize — should show login page (session deactivated)
+	// Visit /authorize — should redirect to login page (session deactivated)
 	authorizeURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
 		"response_type":         {"code"},
 		"client_id":             {"test-client"},
@@ -244,10 +249,11 @@ func TestAutoLogin_DeactivatedIdpSession(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode, "should show login page when IdP session deactivated")
-
-	body, _ := io.ReadAll(resp.Body)
-	assert.True(t, strings.Contains(string(body), "<form"), "should render login form")
+	// Authorize now redirects to /oauth2/login?auth_request_id=xxx
+	assert.Equal(t, http.StatusFound, resp.StatusCode, "should redirect to login page when IdP session deactivated")
+	location := resp.Header.Get("Location")
+	assert.Contains(t, location, "/oauth2/login", "should redirect to login page")
+	assert.Contains(t, location, "auth_request_id=", "should include auth_request_id")
 }
 
 func TestAdminSessionDeactivation_BlocksFurtherRequests(t *testing.T) {

--- a/tests/e2e/signup_test.go
+++ b/tests/e2e/signup_test.go
@@ -29,7 +29,7 @@ func TestSelfSignup_RendersForm(t *testing.T) {
 	ts := startTestServer(t)
 	config.Values.AuthAllowSelfSignup = true
 
-	signupURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
+	params := url.Values{
 		"response_type":         {"code"},
 		"prompt":                {"create"},
 		"redirect_uri":          {"http://localhost:3000/callback"},
@@ -37,22 +37,11 @@ func TestSelfSignup_RendersForm(t *testing.T) {
 		"client_id":             {"test-client"},
 		"code_challenge":        {testCodeChallenge},
 		"code_challenge_method": {"S256"},
-	}.Encode()
+	}
 
-	resp, err := ts.Client.Get(signupURL)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-
-	bodyStr := string(body)
-	assert.Contains(t, bodyStr, `name="username"`)
-	assert.Contains(t, bodyStr, `name="password"`)
-	assert.Contains(t, bodyStr, `name="confirm_password"`)
-	assert.Contains(t, bodyStr, `value="abc123"`)
-	assert.NotEmpty(t, getCSRFToken(bodyStr), "CSRF token should be present")
+	authRequestID, csrfToken := authorizeAndGetSignupPage(t, ts, params)
+	assert.NotEmpty(t, authRequestID, "auth_request_id should be present")
+	assert.NotEmpty(t, csrfToken, "CSRF token should be present")
 }
 
 func TestSelfSignup_Complete(t *testing.T) {
@@ -114,8 +103,7 @@ func TestSelfSignup_StatePreserved(t *testing.T) {
 	redirectURI := "http://localhost:3000/callback"
 	expectedState := "opaque-state-value-99"
 
-	// GET authorize?prompt=create
-	signupURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
+	params := url.Values{
 		"response_type":         {"code"},
 		"prompt":                {"create"},
 		"redirect_uri":          {redirectURI},
@@ -123,27 +111,16 @@ func TestSelfSignup_StatePreserved(t *testing.T) {
 		"client_id":             {"test-client"},
 		"code_challenge":        {testCodeChallenge},
 		"code_challenge_method": {"S256"},
-	}.Encode()
+	}
 
-	resp, err := ts.Client.Get(signupURL)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	authRequestID, csrfToken := authorizeAndGetSignupPage(t, ts, params)
 
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-
-	csrfToken := getCSRFToken(string(body))
-	require.NotEmpty(t, csrfToken)
-
-	// POST signup
+	// POST signup with auth_request_id
 	form := url.Values{}
 	form.Set("username", "stateuser")
 	form.Set("password", "password123")
 	form.Set("confirm_password", "password123")
-	form.Set("redirect_uri", redirectURI)
-	form.Set("state", expectedState)
-	form.Set("client_id", "test-client")
+	form.Set("auth_request_id", authRequestID)
 	form.Set("gorilla.csrf.Token", csrfToken)
 
 	signupReq, err := http.NewRequest("POST", ts.BaseURL+"/oauth2/signup", strings.NewReader(form.Encode()))
@@ -172,8 +149,8 @@ func TestSelfSignup_PromptCreate(t *testing.T) {
 	config.Values.ProfileFieldEmail = "hidden"
 	redirectURI := "http://localhost:3000/callback"
 
-	// Step 1: GET /oauth2/authorize?prompt=create should render the signup form
-	authorizeURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
+	// Step 1: GET /oauth2/authorize?prompt=create → redirect to signup page
+	params := url.Values{
 		"response_type":         {"code"},
 		"client_id":             {"test-client"},
 		"redirect_uri":          {redirectURI},
@@ -181,38 +158,22 @@ func TestSelfSignup_PromptCreate(t *testing.T) {
 		"prompt":                {"create"},
 		"code_challenge":        {testCodeChallenge},
 		"code_challenge_method": {"S256"},
-	}.Encode()
+	}
 
-	resp, err := ts.Client.Get(authorizeURL)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode, "prompt=create should render signup form")
-
-	bodyStr := string(body)
-	assert.Contains(t, bodyStr, `name="username"`)
-	assert.Contains(t, bodyStr, `name="password"`)
-	assert.Contains(t, bodyStr, `name="confirm_password"`)
-
-	csrfToken := getCSRFToken(bodyStr)
-	require.NotEmpty(t, csrfToken, "CSRF token should be present in signup form")
+	authRequestID, csrfToken := authorizeAndGetSignupPage(t, ts, params)
 
 	// Step 2: POST /oauth2/signup to complete registration
 	form := url.Values{}
 	form.Set("username", "promptcreateuser")
 	form.Set("password", "password123")
 	form.Set("confirm_password", "password123")
-	form.Set("redirect_uri", redirectURI)
-	form.Set("state", "create-state")
-	form.Set("client_id", "test-client")
+	form.Set("auth_request_id", authRequestID)
 	form.Set("gorilla.csrf.Token", csrfToken)
 
 	signupReq, err := http.NewRequest("POST", ts.BaseURL+"/oauth2/signup", strings.NewReader(form.Encode()))
 	require.NoError(t, err)
 	signupReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	signupReq.Header.Set("Referer", ts.BaseURL+"/oauth2/authorize")
+	signupReq.Header.Set("Referer", ts.BaseURL+"/oauth2/signup")
 
 	signupResp, err := ts.Client.Do(signupReq)
 	require.NoError(t, err)
@@ -267,12 +228,23 @@ func TestSelfSignup_PromptCreate_Disabled(t *testing.T) {
 		"code_challenge_method": {"S256"},
 	}.Encode()
 
+	// Authorize now redirects to /oauth2/login?auth_request_id=xxx&error=Self-registration+is+not+enabled
 	resp, err := ts.Client.Get(authorizeURL)
 	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusFound, resp.StatusCode, "should redirect to login with error")
 
-	body, _ := io.ReadAll(resp.Body)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	loginLocation := resp.Header.Get("Location")
+	assert.Contains(t, loginLocation, "/oauth2/login", "should redirect to login page")
+	assert.Contains(t, loginLocation, "auth_request_id=", "should include auth_request_id")
+
+	// Follow redirect to login page and verify the error message is rendered
+	loginResp, err := ts.Client.Get(ts.BaseURL + loginLocation)
+	require.NoError(t, err)
+	defer func() { _ = loginResp.Body.Close() }()
+
+	body, _ := io.ReadAll(loginResp.Body)
+	assert.Equal(t, http.StatusOK, loginResp.StatusCode)
 	assert.Contains(t, string(body), "Self-registration is not enabled")
 }
 
@@ -282,27 +254,23 @@ func TestSelfSignup_PasswordMismatch(t *testing.T) {
 	config.Values.ProfileFieldEmail = "hidden"
 	redirectURI := "http://localhost:3000/callback"
 
-	// GET authorize?prompt=create for CSRF token
-	resp, err := ts.Client.Get(ts.BaseURL + "/oauth2/authorize?" + url.Values{
-		"response_type": {"code"}, "prompt": {"create"},
-		"redirect_uri": {redirectURI}, "state": {"s1"}, "client_id": {"test-client"},
-		"code_challenge": {testCodeChallenge}, "code_challenge_method": {"S256"},
-	}.Encode())
-	require.NoError(t, err)
-	body, _ := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
-	csrfToken := getCSRFToken(string(body))
-	require.NotEmpty(t, csrfToken)
+	params := url.Values{
+		"response_type":         {"code"},
+		"prompt":                {"create"},
+		"redirect_uri":          {redirectURI},
+		"state":                 {"s1"},
+		"client_id":             {"test-client"},
+		"code_challenge":        {testCodeChallenge},
+		"code_challenge_method": {"S256"},
+	}
+
+	authRequestID, csrfToken := authorizeAndGetSignupPage(t, ts, params)
 
 	form := url.Values{}
 	form.Set("username", "someuser")
 	form.Set("password", "password123")
 	form.Set("confirm_password", "different456")
-	form.Set("redirect_uri", redirectURI)
-	form.Set("state", "s1")
-	form.Set("client_id", "test-client")
-	form.Set("code_challenge", testCodeChallenge)
-	form.Set("code_challenge_method", "S256")
+	form.Set("auth_request_id", authRequestID)
 	form.Set("gorilla.csrf.Token", csrfToken)
 
 	req, err := http.NewRequest("POST", ts.BaseURL+"/oauth2/signup", strings.NewReader(form.Encode()))
@@ -310,14 +278,14 @@ func TestSelfSignup_PasswordMismatch(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Referer", ts.BaseURL+"/oauth2/signup")
 
-	// Signup errors now redirect to /oauth2/authorize?prompt=create&error=...
+	// Signup errors now redirect to /oauth2/signup?auth_request_id=xxx&error=...
 	postResp, err := ts.Client.Do(req)
 	require.NoError(t, err)
 	defer func() { _ = postResp.Body.Close() }()
 	require.Equal(t, http.StatusFound, postResp.StatusCode, "should redirect on signup error")
 
 	loc := postResp.Header.Get("Location")
-	require.Contains(t, loc, "prompt=create")
+	require.Contains(t, loc, "auth_request_id=")
 	require.Contains(t, loc, "error=")
 
 	// Follow the redirect to verify the error is rendered
@@ -342,27 +310,23 @@ func TestSelfSignup_DuplicateUser(t *testing.T) {
 	// Use a fresh client with a new cookie jar to avoid SSO auto-login
 	freshClient := newClientWithJar()
 
-	// GET authorize?prompt=create for a new CSRF token
-	resp, err := freshClient.Get(ts.BaseURL + "/oauth2/authorize?" + url.Values{
-		"response_type": {"code"}, "prompt": {"create"},
-		"redirect_uri": {redirectURI}, "state": {"s2"}, "client_id": {"test-client"},
-		"code_challenge": {testCodeChallenge}, "code_challenge_method": {"S256"},
-	}.Encode())
-	require.NoError(t, err)
-	body, _ := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
-	csrfToken := getCSRFToken(string(body))
-	require.NotEmpty(t, csrfToken)
+	params := url.Values{
+		"response_type":         {"code"},
+		"prompt":                {"create"},
+		"redirect_uri":          {redirectURI},
+		"state":                 {"s2"},
+		"client_id":             {"test-client"},
+		"code_challenge":        {testCodeChallenge},
+		"code_challenge_method": {"S256"},
+	}
+
+	authRequestID, csrfToken := authorizeAndGetSignupPageWithClient(t, ts, freshClient, params)
 
 	form := url.Values{}
 	form.Set("username", "dupuser")
 	form.Set("password", "password123")
 	form.Set("confirm_password", "password123")
-	form.Set("redirect_uri", redirectURI)
-	form.Set("state", "s2")
-	form.Set("client_id", "test-client")
-	form.Set("code_challenge", testCodeChallenge)
-	form.Set("code_challenge_method", "S256")
+	form.Set("auth_request_id", authRequestID)
 	form.Set("gorilla.csrf.Token", csrfToken)
 
 	req, err := http.NewRequest("POST", ts.BaseURL+"/oauth2/signup", strings.NewReader(form.Encode()))
@@ -370,14 +334,14 @@ func TestSelfSignup_DuplicateUser(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Referer", ts.BaseURL+"/oauth2/signup")
 
-	// Signup errors now redirect to /oauth2/authorize?prompt=create&error=...
+	// Signup errors now redirect to /oauth2/signup?auth_request_id=xxx&error=...
 	postResp, err := freshClient.Do(req)
 	require.NoError(t, err)
 	defer func() { _ = postResp.Body.Close() }()
 	require.Equal(t, http.StatusFound, postResp.StatusCode, "should redirect on signup error")
 
 	loc := postResp.Header.Get("Location")
-	require.Contains(t, loc, "prompt=create")
+	require.Contains(t, loc, "auth_request_id=")
 	require.Contains(t, loc, "error=")
 
 	// Follow the redirect to verify the error is rendered
@@ -405,7 +369,8 @@ func TestSelfSignup_UsernameIsEmail(t *testing.T) {
 
 	// Use a fresh client so the IdP session cookie doesn't cause auto-login
 	freshClient := newClientWithJar()
-	signupURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
+
+	params := url.Values{
 		"response_type":         {"code"},
 		"prompt":                {"create"},
 		"redirect_uri":          {redirectURI},
@@ -413,22 +378,16 @@ func TestSelfSignup_UsernameIsEmail(t *testing.T) {
 		"client_id":             {"test-client"},
 		"code_challenge":        {testCodeChallenge},
 		"code_challenge_method": {"S256"},
-	}.Encode()
-	resp, err := freshClient.Get(signupURL)
-	require.NoError(t, err)
-	body, _ := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
-	csrfToken := getCSRFToken(string(body))
-	require.NotEmpty(t, csrfToken)
+	}
+
+	authRequestID, csrfToken := authorizeAndGetSignupPageWithClient(t, ts, freshClient, params)
 
 	// Second signup with a different email — must succeed without hitting unique constraint
 	form := url.Values{}
 	form.Set("username", "bob@example.com")
 	form.Set("password", "password456")
 	form.Set("confirm_password", "password456")
-	form.Set("redirect_uri", redirectURI)
-	form.Set("state", "s2")
-	form.Set("client_id", "test-client")
+	form.Set("auth_request_id", authRequestID)
 	form.Set("gorilla.csrf.Token", csrfToken)
 
 	req, err := http.NewRequest("POST", ts.BaseURL+"/oauth2/signup", strings.NewReader(form.Encode()))

--- a/tests/e2e/test_helpers_test.go
+++ b/tests/e2e/test_helpers_test.go
@@ -108,7 +108,7 @@ func obtainTokensViaConfidentialClient(t *testing.T, ts *TestServer, username, p
 func performAuthorizationCodeFlow(t *testing.T, ts *TestServer, clientID, redirectURI, username, password, state string) string {
 	t.Helper()
 
-	// Step 1: GET /oauth2/authorize to get login page with CSRF token
+	// Step 1: GET /oauth2/authorize → 302 redirect to /oauth2/login?auth_request_id=xxx
 	authorizeURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
 		"response_type":        {"code"},
 		"client_id":            {clientID},
@@ -120,31 +120,40 @@ func performAuthorizationCodeFlow(t *testing.T, ts *TestServer, clientID, redire
 
 	resp, err := ts.Client.Get(authorizeURL)
 	require.NoError(t, err, "failed to GET /oauth2/authorize")
-	defer func() { _ = resp.Body.Close() }()
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusFound, resp.StatusCode, "authorize should redirect to login")
 
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err, "failed to read authorize response")
-	require.Equal(t, http.StatusOK, resp.StatusCode, "authorize page failed: %s", string(body))
+	loginLocation := resp.Header.Get("Location")
+	require.Contains(t, loginLocation, "auth_request_id=", "authorize redirect must contain auth_request_id")
 
-	// Step 2: Extract CSRF token from the HTML
+	// Step 2: Follow redirect to GET /oauth2/login to get CSRF token
+	loginPageResp, err := ts.Client.Get(ts.BaseURL + loginLocation)
+	require.NoError(t, err, "failed to GET login page")
+	defer func() { _ = loginPageResp.Body.Close() }()
+
+	body, err := io.ReadAll(loginPageResp.Body)
+	require.NoError(t, err, "failed to read login page")
+	require.Equal(t, http.StatusOK, loginPageResp.StatusCode, "login page failed: %s", string(body))
+
 	csrfToken := getCSRFToken(string(body))
-	require.NotEmpty(t, csrfToken, "CSRF token not found in authorize page")
+	require.NotEmpty(t, csrfToken, "CSRF token not found in login page")
 
-	// Step 3: POST /oauth2/login with credentials and CSRF token
+	// Extract auth_request_id from the login page URL
+	loginURL, _ := url.Parse(loginLocation)
+	authRequestID := loginURL.Query().Get("auth_request_id")
+	require.NotEmpty(t, authRequestID, "auth_request_id not found in login URL")
+
+	// Step 3: POST /oauth2/login with auth_request_id + credentials + CSRF
 	form := url.Values{}
 	form.Set("username", username)
 	form.Set("password", password)
-	form.Set("redirect_uri", redirectURI)
-	form.Set("state", state)
-	form.Set("client_id", clientID)
-	form.Set("code_challenge", testCodeChallenge)
-	form.Set("code_challenge_method", "S256")
+	form.Set("auth_request_id", authRequestID)
 	form.Set("gorilla.csrf.Token", csrfToken)
 
 	loginReq, err := http.NewRequest("POST", ts.BaseURL+"/oauth2/login", strings.NewReader(form.Encode()))
 	require.NoError(t, err, "failed to create login request")
 	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	loginReq.Header.Set("Referer", ts.BaseURL+"/oauth2/authorize")
+	loginReq.Header.Set("Referer", ts.BaseURL+"/oauth2/login")
 
 	loginResp, err := ts.Client.Do(loginReq)
 	require.NoError(t, err, "failed to POST /oauth2/login")
@@ -188,48 +197,46 @@ func performAuthorizationCodeFlowWithScope(t *testing.T, ts *TestServer, clientI
 		params.Set("nonce", nonce)
 	}
 
-	authorizeURL := ts.BaseURL + "/oauth2/authorize?" + params.Encode()
-
-	resp, err := ts.Client.Get(authorizeURL)
+	// Step 1: GET /oauth2/authorize → 302 to /oauth2/login?auth_request_id=xxx
+	resp, err := ts.Client.Get(ts.BaseURL + "/oauth2/authorize?" + params.Encode())
 	require.NoError(t, err, "failed to GET /oauth2/authorize")
-	defer func() { _ = resp.Body.Close() }()
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusFound, resp.StatusCode, "authorize should redirect to login")
 
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err, "failed to read authorize response")
-	require.Equal(t, http.StatusOK, resp.StatusCode, "authorize page failed: %s", string(body))
+	loginLocation := resp.Header.Get("Location")
+	loginURL, _ := url.Parse(loginLocation)
+	authRequestID := loginURL.Query().Get("auth_request_id")
+	require.NotEmpty(t, authRequestID, "auth_request_id not found")
+
+	// Step 2: GET login page for CSRF
+	loginPageResp, err := ts.Client.Get(ts.BaseURL + loginLocation)
+	require.NoError(t, err)
+	defer func() { _ = loginPageResp.Body.Close() }()
+	body, _ := io.ReadAll(loginPageResp.Body)
+	require.Equal(t, http.StatusOK, loginPageResp.StatusCode, "login page failed: %s", string(body))
 
 	csrfToken := getCSRFToken(string(body))
-	require.NotEmpty(t, csrfToken, "CSRF token not found in authorize page")
+	require.NotEmpty(t, csrfToken)
 
+	// Step 3: POST /oauth2/login
 	form := url.Values{}
 	form.Set("username", username)
 	form.Set("password", password)
-	form.Set("redirect_uri", redirectURI)
-	form.Set("state", state)
-	form.Set("client_id", clientID)
-	form.Set("scope", scope)
-	form.Set("nonce", nonce)
-	form.Set("code_challenge", testCodeChallenge)
-	form.Set("code_challenge_method", "S256")
+	form.Set("auth_request_id", authRequestID)
 	form.Set("gorilla.csrf.Token", csrfToken)
 
 	loginReq, err := http.NewRequest("POST", ts.BaseURL+"/oauth2/login", strings.NewReader(form.Encode()))
-	require.NoError(t, err, "failed to create login request")
+	require.NoError(t, err)
 	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	loginReq.Header.Set("Referer", ts.BaseURL+"/oauth2/authorize")
+	loginReq.Header.Set("Referer", ts.BaseURL+"/oauth2/login")
 
 	loginResp, err := ts.Client.Do(loginReq)
-	require.NoError(t, err, "failed to POST /oauth2/login")
+	require.NoError(t, err)
 	defer func() { _ = loginResp.Body.Close() }()
-
 	require.Equal(t, http.StatusFound, loginResp.StatusCode, "login should redirect with 302")
 
 	location := loginResp.Header.Get("Location")
-	require.NotEmpty(t, location, "missing Location header in login redirect")
-
-	redirectURL, err := url.Parse(location)
-	require.NoError(t, err, "failed to parse redirect URL")
-
+	redirectURL, _ := url.Parse(location)
 	code := redirectURL.Query().Get("code")
 	require.NotEmpty(t, code, "authorization code not found in redirect URL")
 
@@ -260,88 +267,99 @@ func performAuthorizationCodeFlowWithPKCE(t *testing.T, ts *TestServer, clientID
 		params.Set("code_challenge_method", codeChallengeMethod)
 	}
 
-	authorizeURL := ts.BaseURL + "/oauth2/authorize?" + params.Encode()
+	// Step 1: GET /oauth2/authorize → 302 to /oauth2/login?auth_request_id=xxx
+	resp, err := ts.Client.Get(ts.BaseURL + "/oauth2/authorize?" + params.Encode())
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusFound, resp.StatusCode, "authorize should redirect to login")
 
-	resp, err := ts.Client.Get(authorizeURL)
-	require.NoError(t, err, "failed to GET /oauth2/authorize")
-	defer func() { _ = resp.Body.Close() }()
+	loginLocation := resp.Header.Get("Location")
+	loginURL, _ := url.Parse(loginLocation)
+	authRequestID := loginURL.Query().Get("auth_request_id")
+	require.NotEmpty(t, authRequestID, "auth_request_id not found")
 
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err, "failed to read authorize response")
-	require.Equal(t, http.StatusOK, resp.StatusCode, "authorize page failed: %s", string(body))
+	// Step 2: GET login page for CSRF
+	loginPageResp, err := ts.Client.Get(ts.BaseURL + loginLocation)
+	require.NoError(t, err)
+	defer func() { _ = loginPageResp.Body.Close() }()
+	body, _ := io.ReadAll(loginPageResp.Body)
+	require.Equal(t, http.StatusOK, loginPageResp.StatusCode, "login page failed: %s", string(body))
 
 	csrfToken := getCSRFToken(string(body))
-	require.NotEmpty(t, csrfToken, "CSRF token not found in authorize page")
+	require.NotEmpty(t, csrfToken)
 
+	// Step 3: POST /oauth2/login
 	form := url.Values{}
 	form.Set("username", username)
 	form.Set("password", password)
-	form.Set("redirect_uri", redirectURI)
-	form.Set("state", state)
-	form.Set("client_id", clientID)
-	form.Set("scope", scope)
-	form.Set("nonce", nonce)
-	form.Set("code_challenge", codeChallenge)
-	form.Set("code_challenge_method", codeChallengeMethod)
+	form.Set("auth_request_id", authRequestID)
 	form.Set("gorilla.csrf.Token", csrfToken)
 
 	loginReq, err := http.NewRequest("POST", ts.BaseURL+"/oauth2/login", strings.NewReader(form.Encode()))
-	require.NoError(t, err, "failed to create login request")
+	require.NoError(t, err)
 	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	loginReq.Header.Set("Referer", ts.BaseURL+"/oauth2/authorize")
+	loginReq.Header.Set("Referer", ts.BaseURL+"/oauth2/login")
 
 	loginResp, err := ts.Client.Do(loginReq)
-	require.NoError(t, err, "failed to POST /oauth2/login")
+	require.NoError(t, err)
 	defer func() { _ = loginResp.Body.Close() }()
-
 	require.Equal(t, http.StatusFound, loginResp.StatusCode, "login should redirect with 302")
 
 	location := loginResp.Header.Get("Location")
-	require.NotEmpty(t, location, "missing Location header in login redirect")
-
-	redirectURL, err := url.Parse(location)
-	require.NoError(t, err, "failed to parse redirect URL")
-
+	redirectURL, _ := url.Parse(location)
 	code := redirectURL.Query().Get("code")
 	require.NotEmpty(t, code, "authorization code not found in redirect URL")
 
 	return code
 }
 
-// performSignupFlow drives the authorize?prompt=create → POST signup → extract code chain.
+// performSignupFlow drives the authorize?prompt=create → signup page → POST signup → extract code chain.
 func performSignupFlow(t *testing.T, ts *TestServer, username, password, redirectURI, state string) string {
 	t.Helper()
 
-	// Step 1: GET /oauth2/authorize?prompt=create to obtain a CSRF token
+	// Step 1: GET /oauth2/authorize?prompt=create → 302 to /oauth2/signup?auth_request_id=xxx
 	signupURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
-		"response_type":        {"code"},
-		"prompt":               {"create"},
-		"redirect_uri":         {redirectURI},
-		"state":                {state},
-		"client_id":            {"test-client"},
-		"code_challenge":       {testCodeChallenge},
+		"response_type":         {"code"},
+		"prompt":                {"create"},
+		"redirect_uri":          {redirectURI},
+		"state":                 {state},
+		"client_id":             {"test-client"},
+		"code_challenge":        {testCodeChallenge},
 		"code_challenge_method": {"S256"},
 	}.Encode()
 
 	resp, err := ts.Client.Get(signupURL)
 	require.NoError(t, err, "failed to GET /oauth2/authorize?prompt=create")
-	defer func() { _ = resp.Body.Close() }()
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusFound, resp.StatusCode, "authorize?prompt=create should redirect to signup")
 
-	body, err := io.ReadAll(resp.Body)
+	signupLocation := resp.Header.Get("Location")
+	require.Contains(t, signupLocation, "/oauth2/signup", "should redirect to signup page")
+	require.Contains(t, signupLocation, "auth_request_id=", "should include auth_request_id")
+
+	// Extract auth_request_id from the redirect URL
+	signupRedirectURL, _ := url.Parse(signupLocation)
+	authRequestID := signupRedirectURL.Query().Get("auth_request_id")
+	require.NotEmpty(t, authRequestID, "auth_request_id not found in signup redirect")
+
+	// Step 2: GET /oauth2/signup?auth_request_id=xxx to get CSRF token
+	signupPageResp, err := ts.Client.Get(ts.BaseURL + signupLocation)
+	require.NoError(t, err, "failed to GET signup page")
+	defer func() { _ = signupPageResp.Body.Close() }()
+
+	body, err := io.ReadAll(signupPageResp.Body)
 	require.NoError(t, err, "failed to read signup page")
-	require.Equal(t, http.StatusOK, resp.StatusCode, "signup page failed: %s", string(body))
+	require.Equal(t, http.StatusOK, signupPageResp.StatusCode, "signup page failed: %s", string(body))
 
 	csrfToken := getCSRFToken(string(body))
 	require.NotEmpty(t, csrfToken, "CSRF token not found in signup page")
 
-	// Step 2: POST /oauth2/signup with credentials
+	// Step 3: POST /oauth2/signup with auth_request_id + credentials
 	form := url.Values{}
 	form.Set("username", username)
 	form.Set("password", password)
 	form.Set("confirm_password", password)
-	form.Set("redirect_uri", redirectURI)
-	form.Set("state", state)
-	form.Set("client_id", "test-client")
+	form.Set("auth_request_id", authRequestID)
 	form.Set("gorilla.csrf.Token", csrfToken)
 
 	signupReq, err := http.NewRequest("POST", ts.BaseURL+"/oauth2/signup", strings.NewReader(form.Encode()))
@@ -408,4 +426,95 @@ func createTestClient(t *testing.T, ts *TestServer, adminToken string, reqBody i
 	require.NoError(t, err)
 
 	return result
+}
+
+// authorizeAndGetSignupPage performs GET /oauth2/authorize?prompt=create, follows the
+// redirect to the signup page, and returns (authRequestID, csrfToken). This is the
+// common setup step for tests that need to interact with the signup form.
+func authorizeAndGetSignupPage(t *testing.T, ts *TestServer, params url.Values) (authRequestID, csrfToken string) {
+	t.Helper()
+
+	resp, err := ts.Client.Get(ts.BaseURL + "/oauth2/authorize?" + params.Encode())
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusFound, resp.StatusCode, "authorize?prompt=create should redirect to signup")
+
+	signupLocation := resp.Header.Get("Location")
+	require.Contains(t, signupLocation, "/oauth2/signup", "should redirect to signup page")
+
+	signupURL, _ := url.Parse(signupLocation)
+	authRequestID = signupURL.Query().Get("auth_request_id")
+	require.NotEmpty(t, authRequestID)
+
+	signupPageResp, err := ts.Client.Get(ts.BaseURL + signupLocation)
+	require.NoError(t, err)
+	defer func() { _ = signupPageResp.Body.Close() }()
+
+	body, _ := io.ReadAll(signupPageResp.Body)
+	require.Equal(t, http.StatusOK, signupPageResp.StatusCode, "signup page failed: %s", string(body))
+
+	csrfToken = getCSRFToken(string(body))
+	require.NotEmpty(t, csrfToken)
+
+	return authRequestID, csrfToken
+}
+
+// authorizeAndGetSignupPageWithClient performs GET /oauth2/authorize?prompt=create using
+// the provided HTTP client (instead of ts.Client), follows the redirect to the signup page,
+// and returns (authRequestID, csrfToken).
+func authorizeAndGetSignupPageWithClient(t *testing.T, ts *TestServer, httpClient *http.Client, params url.Values) (authRequestID, csrfToken string) {
+	t.Helper()
+
+	resp, err := httpClient.Get(ts.BaseURL + "/oauth2/authorize?" + params.Encode())
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusFound, resp.StatusCode, "authorize?prompt=create should redirect to signup")
+
+	signupLocation := resp.Header.Get("Location")
+	require.Contains(t, signupLocation, "/oauth2/signup", "should redirect to signup page")
+
+	signupURL, _ := url.Parse(signupLocation)
+	authRequestID = signupURL.Query().Get("auth_request_id")
+	require.NotEmpty(t, authRequestID)
+
+	signupPageResp, err := httpClient.Get(ts.BaseURL + signupLocation)
+	require.NoError(t, err)
+	defer func() { _ = signupPageResp.Body.Close() }()
+
+	body, _ := io.ReadAll(signupPageResp.Body)
+	require.Equal(t, http.StatusOK, signupPageResp.StatusCode, "signup page failed: %s", string(body))
+
+	csrfToken = getCSRFToken(string(body))
+	require.NotEmpty(t, csrfToken)
+
+	return authRequestID, csrfToken
+}
+
+// authorizeAndGetLoginPage performs GET /oauth2/authorize, follows the redirect to
+// the login page, and returns (authRequestID, csrfToken). This is the common setup
+// step for tests that need to interact with the login form.
+func authorizeAndGetLoginPage(t *testing.T, ts *TestServer, params url.Values) (authRequestID, csrfToken string) {
+	t.Helper()
+
+	resp, err := ts.Client.Get(ts.BaseURL + "/oauth2/authorize?" + params.Encode())
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusFound, resp.StatusCode, "authorize should redirect to login")
+
+	loginLocation := resp.Header.Get("Location")
+	loginURL, _ := url.Parse(loginLocation)
+	authRequestID = loginURL.Query().Get("auth_request_id")
+	require.NotEmpty(t, authRequestID)
+
+	loginPageResp, err := ts.Client.Get(ts.BaseURL + loginLocation)
+	require.NoError(t, err)
+	defer func() { _ = loginPageResp.Body.Close() }()
+
+	body, _ := io.ReadAll(loginPageResp.Body)
+	require.Equal(t, http.StatusOK, loginPageResp.StatusCode, "login page failed: %s", string(body))
+
+	csrfToken = getCSRFToken(string(body))
+	require.NotEmpty(t, csrfToken)
+
+	return authRequestID, csrfToken
 }

--- a/tests/e2e/test_server_test.go
+++ b/tests/e2e/test_server_test.go
@@ -129,7 +129,9 @@ func startTestServer(t *testing.T) *TestServer {
 
 	// CSRF-protected routes (using plaintext wrapper for HTTP test server)
 	mux.Handle(oauth+"/authorize", plaintextCSRF(http.HandlerFunc(authorize.HandleAuthorize)))
-	mux.Handle(oauth+"/login", plaintextCSRF(http.HandlerFunc(login.HandleLoginUser)))
+	mux.Handle("GET "+oauth+"/login", plaintextCSRF(http.HandlerFunc(login.HandleLoginPage)))
+	mux.Handle("POST "+oauth+"/login", plaintextCSRF(http.HandlerFunc(login.HandleLoginUser)))
+	mux.Handle("GET "+oauth+"/signup", plaintextCSRF(http.HandlerFunc(signup.HandleSignupPage)))
 	mux.Handle(oauth+"/signup", plaintextCSRF(http.HandlerFunc(signup.HandleSignup)))
 
 	// OAuth2 client registration (admin-protected)

--- a/tests/functional/helpers.ts
+++ b/tests/functional/helpers.ts
@@ -89,7 +89,7 @@ export async function obtainTokenViaAuthCode(
   password: string,
   scope = 'openid profile email'
 ): Promise<{ access_token: string; refresh_token: string; id_token: string; token_type: string }> {
-  // Step 1: GET /authorize — renders login page with CSRF token
+  // Step 1: GET /authorize → 302 redirect to /login?auth_request_id=xxx
   const authorizeURL = new URL(`${OAUTH_URL}/authorize`);
   authorizeURL.searchParams.set('response_type', 'code');
   authorizeURL.searchParams.set('client_id', ADMIN_CLIENT_ID);
@@ -100,20 +100,34 @@ export async function obtainTokenViaAuthCode(
   authorizeURL.searchParams.set('code_challenge_method', 'S256');
 
   const authorizeResp = await fetch(authorizeURL.toString(), { redirect: 'manual' });
-  if (authorizeResp.status !== 200) {
-    throw new Error(`Authorize returned ${authorizeResp.status}`);
+  if (authorizeResp.status !== 302) {
+    throw new Error(`Authorize returned ${authorizeResp.status}, expected 302`);
   }
 
-  const html = await authorizeResp.text();
+  const loginRedirect = authorizeResp.headers.get('Location');
+  if (!loginRedirect) throw new Error('Authorize did not return Location header');
+
+  // Extract auth_request_id from redirect URL
+  const loginRedirectURL = new URL(loginRedirect, BASE_URL);
+  const authRequestId = loginRedirectURL.searchParams.get('auth_request_id');
+  if (!authRequestId) throw new Error('No auth_request_id in authorize redirect');
+
+  // Step 2: GET /login?auth_request_id=xxx — get login page with CSRF token
+  const loginPageResp = await fetch(`${BASE_URL}${loginRedirect}`, { redirect: 'manual' });
+  if (loginPageResp.status !== 200) {
+    throw new Error(`Login page returned ${loginPageResp.status}`);
+  }
+
+  const html = await loginPageResp.text();
   const csrfMatch = html.match(/name="gorilla\.csrf\.Token"\s+value="([^"]+)"/);
   if (!csrfMatch) throw new Error('Could not extract CSRF token from login page');
   const csrfToken = csrfMatch[1];
 
-  const cookies = authorizeResp.headers.getSetCookie();
+  const cookies = loginPageResp.headers.getSetCookie();
   const csrfCookie = cookies.find((c) => c.startsWith('_gorilla_csrf='));
   if (!csrfCookie) throw new Error('Could not extract CSRF cookie');
 
-  // Step 2: POST /login — submit credentials
+  // Step 3: POST /login — submit credentials with auth_request_id
   const loginResp = await fetch(`${OAUTH_URL}/login`, {
     method: 'POST',
     headers: {
@@ -125,13 +139,7 @@ export async function obtainTokenViaAuthCode(
       username,
       password,
       'gorilla.csrf.Token': csrfToken,
-      client_id: ADMIN_CLIENT_ID,
-      redirect_uri: ADMIN_REDIRECT_URI,
-      scope,
-      state: 'helper-state',
-      response_type: 'code',
-      code_challenge: TEST_CODE_CHALLENGE,
-      code_challenge_method: 'S256',
+      auth_request_id: authRequestId,
     }),
     redirect: 'manual',
   });
@@ -146,7 +154,7 @@ export async function obtainTokenViaAuthCode(
   const code = new URL(location).searchParams.get('code');
   if (!code) throw new Error('No code in redirect URL');
 
-  // Step 3: POST /token — exchange code
+  // Step 4: POST /token — exchange code
   const tokenResp = await postForm(`${OAUTH_URL}/token`, {
     grant_type: 'authorization_code',
     code,

--- a/tests/functional/tests/auth-flow.test.ts
+++ b/tests/functional/tests/auth-flow.test.ts
@@ -16,7 +16,7 @@ describe('Authorization Code Flow', () => {
   it('completes full flow: authorize → login → token exchange → userinfo', async () => {
     const state = 'test-state-abc';
 
-    // Step 1: GET /authorize — renders login page with CSRF token
+    // Step 1: GET /authorize → 302 redirect to /login?auth_request_id=xxx
     const authorizeURL = new URL(`${OAUTH_URL}/authorize`);
     authorizeURL.searchParams.set('response_type', 'code');
     authorizeURL.searchParams.set('client_id', ADMIN_CLIENT_ID);
@@ -27,21 +27,33 @@ describe('Authorization Code Flow', () => {
     authorizeURL.searchParams.set('code_challenge_method', 'S256');
 
     const authorizeResp = await fetch(authorizeURL.toString(), { redirect: 'manual' });
-    expect(authorizeResp.status).toBe(200);
+    expect(authorizeResp.status).toBe(302);
 
-    const html = await authorizeResp.text();
+    const loginRedirect = authorizeResp.headers.get('Location');
+    expect(loginRedirect).toBeTruthy();
+    expect(loginRedirect).toContain('auth_request_id=');
+
+    // Extract auth_request_id
+    const loginRedirectURL = new URL(loginRedirect!, BASE_URL);
+    const authRequestId = loginRedirectURL.searchParams.get('auth_request_id');
+    expect(authRequestId).toBeTruthy();
+
+    // Step 2: GET /login?auth_request_id=xxx — get login page with CSRF token
+    const loginPageResp = await fetch(`${BASE_URL}${loginRedirect}`, { redirect: 'manual' });
+    expect(loginPageResp.status).toBe(200);
+
+    const html = await loginPageResp.text();
     expect(html).toContain('<form');
 
-    // Extract CSRF token and cookie
     const csrfMatch = html.match(/name="gorilla\.csrf\.Token"\s+value="([^"]+)"/);
     expect(csrfMatch).toBeTruthy();
     const csrfToken = csrfMatch![1];
 
-    const cookies = authorizeResp.headers.getSetCookie();
+    const cookies = loginPageResp.headers.getSetCookie();
     const csrfCookie = cookies.find((c) => c.startsWith('_gorilla_csrf='));
     expect(csrfCookie).toBeTruthy();
 
-    // Step 2: POST /login — submit credentials
+    // Step 3: POST /login — submit credentials with auth_request_id
     const loginResp = await fetch(`${OAUTH_URL}/login`, {
       method: 'POST',
       headers: {
@@ -53,13 +65,7 @@ describe('Authorization Code Flow', () => {
         username: ADMIN_USERNAME,
         password: ADMIN_PASSWORD,
         'gorilla.csrf.Token': csrfToken,
-        client_id: ADMIN_CLIENT_ID,
-        redirect_uri: ADMIN_REDIRECT_URI,
-        scope: 'openid profile email',
-        state,
-        response_type: 'code',
-        code_challenge: TEST_CODE_CHALLENGE,
-        code_challenge_method: 'S256',
+        auth_request_id: authRequestId!,
       }),
       redirect: 'manual',
     });
@@ -75,7 +81,7 @@ describe('Authorization Code Flow', () => {
     expect(code).toBeTruthy();
     expect(returnedState).toBe(state);
 
-    // Step 3: POST /token — exchange code for tokens
+    // Step 4: POST /token — exchange code for tokens
     const tokenResp = await postForm(`${OAUTH_URL}/token`, {
       grant_type: 'authorization_code',
       code: code!,
@@ -91,7 +97,7 @@ describe('Authorization Code Flow', () => {
     expect(tokens.id_token).toBeTruthy();
     expect(tokens.token_type).toBe('Bearer');
 
-    // Step 4: GET /userinfo — verify token works
+    // Step 5: GET /userinfo — verify token works
     const userinfoResp = await fetch(`${OAUTH_URL}/userinfo`, {
       headers: { Authorization: `Bearer ${tokens.access_token}` },
     });

--- a/view/login.html
+++ b/view/login.html
@@ -3,13 +3,7 @@
   {{template "logo" .}}
   <h1 class="auth-title">{{.ThemeTitle}}</h1>
   {{ .csrfField }}
-  <input type="hidden" name="state" value="{{.State}}" />
-  <input type="hidden" name="redirect_uri" value="{{.RedirectURI}}" />
-  <input type="hidden" name="client_id" value="{{.ClientID}}" />
-  <input type="hidden" name="scope" value="{{.Scope}}" />
-  <input type="hidden" name="nonce" value="{{.Nonce}}" />
-  <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}" />
-  <input type="hidden" name="code_challenge_method" value="{{.CodeChallengeMethod}}" />
+  <input type="hidden" name="auth_request_id" value="{{.AuthRequestID}}" />
   <div class="auth-field">
     {{if eq .ProfileFieldEmail "is_username"}}
     <label class="auth-label" for="username">Email</label>
@@ -47,17 +41,17 @@
   {{if or .AllowSelfSignup (and .SmtpConfigured (ne .AuthMode "passkey_only"))}}
   <div class="auth-links">
     {{if and .SmtpConfigured (ne .AuthMode "passkey_only")}}
-    <div class="auth-link"><a href="{{authURL "/forgot-password"}}?client_id={{.ClientID}}&redirect_uri={{.RedirectURI}}&state={{.State}}&scope={{.Scope}}&nonce={{.Nonce}}&code_challenge={{.CodeChallenge}}&code_challenge_method={{.CodeChallengeMethod}}">Forgot password?</a></div>
+    <div class="auth-link"><a href="{{authURL "/forgot-password"}}?auth_request_id={{.AuthRequestID}}">Forgot password?</a></div>
     {{end}}
     {{if .AllowSelfSignup}}
-    <div class="auth-link" style="margin-left:auto;"><a href="{{authURL "/authorize"}}?response_type=code&prompt=create&state={{.State}}&redirect_uri={{.RedirectURI}}&client_id={{.ClientID}}&scope={{.Scope}}&nonce={{.Nonce}}&code_challenge={{.CodeChallenge}}&code_challenge_method={{.CodeChallengeMethod}}">Create account</a></div>
+    <div class="auth-link" style="margin-left:auto;"><a href="{{authURL "/signup"}}?auth_request_id={{.AuthRequestID}}">Create account</a></div>
     {{end}}
   </div>
   {{end}}
   {{if .FederatedProviders}}
   <div class="auth-divider">or</div>
   {{range .FederatedProviders}}
-  <a href="{{authURL "/federation/"}}{{.ID}}?state={{$.State}}&redirect_uri={{$.RedirectURI}}&client_id={{$.ClientID}}&scope={{$.Scope}}&nonce={{$.Nonce}}&code_challenge={{$.CodeChallenge}}&code_challenge_method={{$.CodeChallengeMethod}}" class="auth-btn-secondary">
+  <a href="{{authURL "/federation/"}}{{.ID}}?auth_request_id={{$.AuthRequestID}}" class="auth-btn-secondary">
     {{if .IconSVG}}{{safeHTML .IconSVG}}{{end}}
     Sign in with {{.Name}}
   </a>
@@ -79,13 +73,7 @@
     if (!username) { showPasskeyError('Please enter your {{if eq .ProfileFieldEmail "is_username"}}email{{else}}username{{end}} first.'); return; }
     const params = new URLSearchParams({
       username,
-      redirect_uri: document.querySelector('[name=redirect_uri]').value,
-      state: document.querySelector('[name=state]').value,
-      client_id: document.querySelector('[name=client_id]').value,
-      scope: document.querySelector('[name=scope]').value,
-      nonce: document.querySelector('[name=nonce]').value,
-      code_challenge: document.querySelector('[name=code_challenge]').value,
-      code_challenge_method: document.querySelector('[name=code_challenge_method]').value,
+      auth_request_id: document.querySelector('[name=auth_request_id]').value,
     });
     try {
       const beginResp = await fetch('{{authURL "/passkey/login/begin"}}?' + params.toString());

--- a/view/signup.html
+++ b/view/signup.html
@@ -3,13 +3,7 @@
   {{template "logo" .}}
   <h1 class="auth-title">{{.ThemeTitle}}</h1>
   {{ .csrfField }}
-  <input type="hidden" name="state" value="{{.State}}" />
-  <input type="hidden" name="redirect_uri" value="{{.RedirectURI}}" />
-  <input type="hidden" name="client_id" value="{{.ClientID}}" />
-  <input type="hidden" name="scope" value="{{.Scope}}" />
-  <input type="hidden" name="nonce" value="{{.Nonce}}" />
-  <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}" />
-  <input type="hidden" name="code_challenge_method" value="{{.CodeChallengeMethod}}" />
+  <input type="hidden" name="auth_request_id" value="{{.AuthRequestID}}" />
   <div class="auth-field">
     {{if eq .ProfileFieldEmail "is_username"}}
     <label class="auth-label" for="username">Email</label>
@@ -97,7 +91,7 @@
   <button class="auth-btn" type="submit" id="signup-btn">
     {{if eq .AuthMode "passkey_only"}}Create Account with Passkey{{else}}Create Account{{end}}
   </button>
-  <div class="auth-link">Already have an account? <a href="{{authURL "/authorize"}}?response_type=code&client_id={{.ClientID}}&redirect_uri={{.RedirectURI}}&state={{.State}}&scope={{.Scope}}&nonce={{.Nonce}}&code_challenge={{.CodeChallenge}}&code_challenge_method={{.CodeChallengeMethod}}">Log in</a></div>
+  <div class="auth-link">Already have an account? <a href="{{authURL "/login"}}?auth_request_id={{.AuthRequestID}}">Log in</a></div>
 </form>
 {{end}}
 
@@ -134,13 +128,7 @@
     const params = new URLSearchParams({
       username,
       email,
-      redirect_uri: document.querySelector('[name=redirect_uri]').value,
-      state: document.querySelector('[name=state]').value,
-      client_id: document.querySelector('[name=client_id]').value,
-      scope: document.querySelector('[name=scope]').value,
-      nonce: document.querySelector('[name=nonce]').value,
-      code_challenge: document.querySelector('[name=code_challenge]').value,
-      code_challenge_method: document.querySelector('[name=code_challenge_method]').value,
+      auth_request_id: document.querySelector('[name=auth_request_id]').value,
     });
     try {
       const beginResp = await fetch('{{authURL "/passkey/register/begin"}}?' + params.toString());


### PR DESCRIPTION
## Summary
- Authorize endpoint now stores OAuth parameters (scope, nonce, PKCE, state) in a new `authorize_requests` table and redirects to `/oauth2/login?auth_request_id=<xid>`
- Login and signup handlers read parameters from the server-side record, not from the POST body
- Templates reduced from 7 hidden fields to 1 (`auth_request_id`)
- Prevents PKCE downgrade, scope escalation, and nonce injection via form tampering
- New `pkg/authrequest` package with CRUD operations
- Cleanup goroutine purges expired authorize requests
- New migration (v6) for `authorize_requests` table

Closes #184, closes #186

## Test plan
- [x] All 37 package unit tests pass
- [x] All E2E tests pass (updated for new authorize→redirect→login flow)
- [x] Authorize handler tests verify 302 redirect with `auth_request_id`
- [x] Login handler tests verify missing/expired auth request rejection
- [x] Signup, passkey, federation handler tests updated for `auth_request_id`
- [x] Full test suite: `go test -p 1 ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)