### PR TITLE
ui: refactor account-ui components and improve UX

### DIFF
--- a/account-ui/src/components/AccountDeletion.tsx
+++ b/account-ui/src/components/AccountDeletion.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '../api';
+import Modal from './Modal';
+import Button from './Button';
+import Alert from './Alert';
+import { useSettings } from '../context/SettingsContext';
+import { useAuth } from '../AuthContext';
+import { extractError } from '../lib/utils';
+
+interface AccountDeletionModalProps {
+  onClose: () => void;
+}
+
+const AccountDeletionModal: React.FC<AccountDeletionModalProps> = ({ onClose }) => {
+  const settings = useSettings();
+  const { logout, user } = useAuth();
+  const queryClient = useQueryClient();
+  const [confirmUsername, setConfirmUsername] = useState('');
+  const [reason, setReason] = useState('');
+  const [error, setError] = useState('');
+
+  const username = user?.profile?.preferred_username ?? '';
+  const usernameMatches = confirmUsername === username;
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      api.post('/deletion-request', reason.trim() ? { reason: reason.trim() } : {}),
+    onSuccess: () => {
+      if (settings.allow_self_service_deletion) {
+        logout();
+        return;
+      }
+      queryClient.invalidateQueries({ queryKey: ['deletion-request'] });
+      onClose();
+    },
+    onError: (err: unknown) => {
+      setError(extractError(err, 'Failed to submit request.'));
+    },
+  });
+
+  return (
+    <Modal
+      title={settings.allow_self_service_deletion ? 'Delete Account' : 'Request Account Deletion'}
+      onClose={onClose}
+    >
+      <div className="space-y-4">
+        <p className="text-sm text-theme-muted">
+          {settings.allow_self_service_deletion
+            ? 'Are you sure you want to permanently delete your account? This cannot be undone.'
+            : 'A deletion request will be submitted for admin review.'}
+        </p>
+        <div>
+          <label>
+            Type <span className="font-bold">{username}</span> to confirm
+          </label>
+          <input
+            type="text"
+            value={confirmUsername}
+            onChange={(e) => setConfirmUsername(e.target.value)}
+            placeholder={username}
+            autoFocus
+          />
+        </div>
+        <div>
+          <label>
+            Reason <span className="text-theme-muted font-normal">(optional)</span>
+          </label>
+          <textarea
+            className="w-full rounded-xl border border-theme-fg/20 px-3 py-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-theme-highlight bg-theme-bg text-theme-fg"
+            rows={3}
+            placeholder="Tell us why you want to delete your account…"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+          />
+        </div>
+        {error && <Alert type="danger" message={error} />}
+        <div className="flex gap-2">
+          <Button type="button" variant="ghost" onClick={onClose} className="flex-1">
+            Cancel
+          </Button>
+          <Button
+            variant="danger"
+            onClick={() => mutation.mutate()}
+            disabled={!usernameMatches || mutation.isPending}
+            className="flex-1"
+          >
+            {mutation.isPending
+              ? 'Submitting…'
+              : settings.allow_self_service_deletion
+                ? 'Delete Account'
+                : 'Submit Request'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default AccountDeletionModal;

--- a/account-ui/src/components/Alert.tsx
+++ b/account-ui/src/components/Alert.tsx
@@ -15,7 +15,7 @@ const config = {
   },
   success: {
     icon: IconCircleCheck,
-    className: 'bg-theme-highlight border border-theme-highlight text-theme-accent-fg',
+    className: 'bg-theme-success-bg border border-theme-success-bg text-theme-success-fg',
   },
 };
 

--- a/account-ui/src/components/Card.tsx
+++ b/account-ui/src/components/Card.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 interface CardProps {
   title: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   description?: string;
   action?: React.ReactNode;
 }
@@ -16,7 +16,7 @@ const Card: React.FC<CardProps> = ({ title, children, description, action }) => 
       </div>
       {action && <div className="flex-shrink-0 mt-0.5">{action}</div>}
     </div>
-    <div className="px-7 pb-7">{children}</div>
+    {children && <div className="px-7 pb-7">{children}</div>}
   </div>
 );
 

--- a/account-ui/src/components/DangerZoneCard.tsx
+++ b/account-ui/src/components/DangerZoneCard.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '../api';
+import { extractError } from '../lib/utils';
+import { useSettings } from '../context/SettingsContext';
+import Card from './Card';
+import Button from './Button';
+import Alert from './Alert';
+import AccountDeletionModal from './AccountDeletion';
+
+interface DeletionRequest {
+  id: string;
+  user_id: string;
+  reason?: string;
+  requested_at: string;
+}
+
+const DangerZoneCard: React.FC = () => {
+  const settings = useSettings();
+  const queryClient = useQueryClient();
+
+  const { data: deletionRequest } = useQuery<DeletionRequest | null>({
+    queryKey: ['deletion-request'],
+    queryFn: () => api.get('/deletion-request').then((res) => res.data.data ?? null),
+  });
+
+  const [showModal, setShowModal] = useState(false);
+  const [cancelError, setCancelError] = useState('');
+
+  const cancelMutation = useMutation({
+    mutationFn: () => api.delete('/deletion-request'),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['deletion-request'] });
+      setCancelError('');
+    },
+    onError: (err: unknown) => {
+      setCancelError(extractError(err, 'Failed to cancel request.'));
+    },
+  });
+
+  return (
+    <>
+      {showModal && <AccountDeletionModal onClose={() => setShowModal(false)} />}
+      <Card
+        title="Danger Zone"
+        description={
+          settings.allow_self_service_deletion
+            ? 'Permanently delete your account. This action cannot be undone.'
+            : 'Request account deletion. An admin will review and process your request.'
+        }
+        action={
+          !deletionRequest ? (
+            <Button variant="danger" onClick={() => setShowModal(true)}>
+              Delete Account
+            </Button>
+          ) : undefined
+        }
+      >
+        {deletionRequest && (
+          <div className="space-y-4">
+            <div className="rounded-xl bg-theme-danger-bg border border-theme-danger-bg px-4 py-3 text-sm text-theme-danger-fg">
+              A deletion request was submitted on{' '}
+              <strong>{new Date(deletionRequest.requested_at).toLocaleDateString()}</strong>.
+              {settings.allow_self_service_deletion
+                ? ' Your account has been deleted.'
+                : ' An admin will review and process your request. Your account remains active until then.'}
+            </div>
+            {deletionRequest.reason && (
+              <p className="text-sm text-theme-muted">
+                <span className="font-medium">Reason:</span> {deletionRequest.reason}
+              </p>
+            )}
+            {cancelError && <Alert type="danger" message={cancelError} />}
+            {!settings.allow_self_service_deletion && (
+              <Button
+                variant="ghost"
+                onClick={() => cancelMutation.mutate()}
+                disabled={cancelMutation.isPending}
+              >
+                {cancelMutation.isPending ? 'Cancelling…' : 'Cancel Deletion Request'}
+              </Button>
+            )}
+          </div>
+        )}
+      </Card>
+    </>
+  );
+};
+
+export default DangerZoneCard;

--- a/account-ui/src/components/Layout.tsx
+++ b/account-ui/src/components/Layout.tsx
@@ -7,11 +7,11 @@ import AppHeader from './AppHeader';
 import Spinner from './Spinner';
 
 const Dashboard = React.lazy(() => import('../pages/Dashboard'));
-const ProfilePage = React.lazy(() => import('../pages/ProfilePage'));
-const SecurityPage = React.lazy(() => import('../pages/SecurityPage'));
-const SessionsPage = React.lazy(() => import('../pages/SessionsPage'));
-const TrustedDevicesPage = React.lazy(() => import('../pages/TrustedDevicesPage'));
-const ConnectedProvidersPage = React.lazy(() => import('../pages/ConnectedProvidersPage'));
+const ProfilePage = React.lazy(() => import('../pages/Profile'));
+const SecurityPage = React.lazy(() => import('../pages/Security'));
+const SessionsPage = React.lazy(() => import('../pages/Sessions'));
+const TrustedDevicesPage = React.lazy(() => import('../pages/TrustedDevices'));
+const ConnectedProvidersPage = React.lazy(() => import('../pages/ConnectedProviders'));
 
 const pageTitles: Record<string, string> = {
   '/': 'Overview',

--- a/account-ui/src/components/Modal.tsx
+++ b/account-ui/src/components/Modal.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { IconX } from '@tabler/icons-react';
+
+interface ModalProps {
+  title: string;
+  children: React.ReactNode;
+  onClose: () => void;
+}
+
+const Modal: React.FC<ModalProps> = ({ title, children, onClose }) => (
+  <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
+    <div className="bg-theme-bg rounded-2xl shadow-xl w-full max-w-sm">
+      <div className="flex items-center justify-between px-6 py-4 border-b border-theme-fg/10">
+        <h2 className="text-base font-semibold">{title}</h2>
+        <button onClick={onClose} className="text-theme-muted hover:text-theme-fg transition-colors">
+          <IconX size={18} />
+        </button>
+      </div>
+      <div className="px-6 py-5">{children}</div>
+    </div>
+  </div>
+);
+
+export default Modal;

--- a/account-ui/src/components/PasskeyCard.tsx
+++ b/account-ui/src/components/PasskeyCard.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { IconKey } from '@tabler/icons-react';
+import api from '../api';
+import { performPasskeyRegistration } from '../lib/passkey';
+import { extractError } from '../lib/utils';
+import Card from './Card';
+import Button from './Button';
+import Alert from './Alert';
+import StatusDot from './StatusDot';
+
+const PasskeyCard: React.FC = () => {
+  const { data: passkeys, refetch } = useQuery({
+    queryKey: ['passkeys'],
+    queryFn: () => api.get('/passkeys').then((res) => res.data.data),
+  });
+
+  const [addError, setAddError] = useState('');
+  const [deleteError, setDeleteError] = useState('');
+  const [isAdding, setIsAdding] = useState(false);
+
+  const handleAdd = async () => {
+    setAddError('');
+    setIsAdding(true);
+    try {
+      const beginRes = await api.post('/passkeys/register/begin');
+      const data = beginRes.data.data;
+      const credential = await performPasskeyRegistration(data);
+      await api.post(`/passkeys/register/finish?challenge_id=${data.challenge_id}`, credential);
+      refetch();
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message.includes('cancel')) {
+        setAddError('Passkey registration was cancelled.');
+      } else {
+        setAddError(extractError(err, 'Failed to add passkey.'));
+      }
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setDeleteError('');
+    try {
+      await api.delete(`/passkeys/${id}`);
+      refetch();
+    } catch (err: unknown) {
+      setDeleteError(extractError(err, 'Failed to delete passkey.'));
+    }
+  };
+
+  return (
+    <Card
+      title="Passkeys"
+      description="Biometrics or security keys for passwordless login."
+      action={
+        <Button onClick={handleAdd} disabled={isAdding}>
+          {isAdding ? 'Registering…' : 'Add Passkey'}
+        </Button>
+      }
+    >
+      {addError && <Alert type="danger" message={addError} className="mb-2" />}
+      {deleteError && <Alert type="danger" message={deleteError} className="mb-2" />}
+      {passkeys && passkeys.length > 0 ? (
+        <div className="divide-y divide-theme-fg/10 mt-1">
+          {passkeys.map((pk: { id: string; name: string; created_at: string }) => (
+            <div key={pk.id} className="py-3.5 flex items-center justify-between gap-4">
+              <div className="flex items-center gap-3 min-w-0">
+                <div className="w-8 h-8 rounded-full bg-theme-body flex items-center justify-center flex-shrink-0">
+                  <IconKey size={14} className="text-theme-fg" />
+                </div>
+                <div>
+                  <p className="text-sm font-semibold">{pk.name || 'Unnamed Passkey'}</p>
+                  <p className="text-xs text-theme-muted">
+                    Added {new Date(pk.created_at).toLocaleDateString()}
+                  </p>
+                </div>
+              </div>
+              <Button
+                variant="danger"
+                onClick={() => handleDelete(pk.id)}
+                className="flex-shrink-0"
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 mt-1">
+          <StatusDot active={false} />
+          <span className="text-sm text-theme-fg">No passkeys registered</span>
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export default PasskeyCard;

--- a/account-ui/src/components/PasswordCard.tsx
+++ b/account-ui/src/components/PasswordCard.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import Card from './Card';
+import Button from './Button';
+import PasswordChangeModal from './PasswordChange';
+
+const PasswordCard: React.FC = () => {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <>
+      {showModal && <PasswordChangeModal onClose={() => setShowModal(false)} />}
+      <Card
+        title="Password"
+        description="Change your password to keep your account secure."
+        action={
+          <Button onClick={() => setShowModal(true)}>
+            Change Password
+          </Button>
+        }
+      />
+    </>
+  );
+};
+
+export default PasswordCard;

--- a/account-ui/src/components/PasswordChange.tsx
+++ b/account-ui/src/components/PasswordChange.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import api from '../api';
+import Modal from './Modal';
+import Button from './Button';
+import Alert from './Alert';
+import { extractError } from '../lib/utils';
+
+interface PasswordChangeModalProps {
+  onClose: () => void;
+}
+
+const PasswordChangeModal: React.FC<PasswordChangeModalProps> = ({ onClose }) => {
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setIsSubmitting(true);
+    try {
+      await api.post('/password', { current_password: currentPassword, new_password: newPassword });
+      setSuccess(true);
+    } catch (err: unknown) {
+      setError(extractError(err, 'Failed to update password.'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <Modal title="Change Password" onClose={onClose}>
+        <div className="space-y-4">
+          <Alert type="success" message="Password updated successfully." />
+          <Button className="w-full" onClick={onClose}>
+            Done
+          </Button>
+        </div>
+      </Modal>
+    );
+  }
+
+  return (
+    <Modal title="Change Password" onClose={onClose}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label>Current Password</label>
+          <input
+            type="password"
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            autoFocus
+          />
+        </div>
+        <div>
+          <label>New Password</label>
+          <input
+            type="password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+          />
+        </div>
+        {error && <Alert type="danger" message={error} />}
+        <div className="flex gap-2">
+          <Button type="button" variant="ghost" onClick={onClose} className="flex-1">
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSubmitting || !currentPassword || !newPassword} className="flex-1">
+            {isSubmitting ? 'Updating…' : 'Update Password'}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default PasswordChangeModal;

--- a/account-ui/src/components/Sidebar.tsx
+++ b/account-ui/src/components/Sidebar.tsx
@@ -81,7 +81,7 @@ const Sidebar: React.FC<SidebarProps> = ({ open, onClose, username, initials, on
         <button
           onClick={onLogout}
           data-testid="sign-out"
-          className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-theme-accent-fg/70 hover:text-theme-primary-fg hover:bg-theme-primary-bg rounded-brand transition-colors"
+          className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-theme-accent-fg/70 hover:text-theme-accent-fg hover:bg-theme-accent-fg/10 rounded-brand transition-colors"
         >
           <IconLogout size={15} />
           Sign out

--- a/account-ui/src/components/StatusDot.tsx
+++ b/account-ui/src/components/StatusDot.tsx
@@ -4,7 +4,7 @@ const StatusDot = ({ active }: { active: boolean }) => (
   <span
     className={cn(
       'inline-block w-2 h-2 rounded-full flex-shrink-0',
-      active ? 'bg-theme-highlight' : 'bg-theme-muted'
+      active ? 'bg-theme-success' : 'bg-theme-muted'
     )}
   />
 );

--- a/account-ui/src/components/TotpCard.tsx
+++ b/account-ui/src/components/TotpCard.tsx
@@ -4,7 +4,8 @@ import Card from './Card';
 import Button from './Button';
 import Alert from './Alert';
 import StatusDot from './StatusDot';
-import TotpSetupModal from './TotpSetupModal';
+import TotpSetupModal from './TotpSetup';
+import { extractError } from '../lib/utils';
 
 interface TotpCardProps {
   totpEnabled: boolean;
@@ -27,8 +28,7 @@ const TotpCard: React.FC<TotpCardProps> = ({ totpEnabled, preferredLabel, onChan
       setPassword('');
       onChanged();
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { error_description?: string } } };
-      setError(axiosErr.response?.data?.error_description || 'Failed to disable 2FA.');
+      setError(extractError(err, 'Failed to disable 2FA.'));
     }
   };
 
@@ -48,12 +48,11 @@ const TotpCard: React.FC<TotpCardProps> = ({ totpEnabled, preferredLabel, onChan
             <Button
               variant="danger"
               onClick={() => { setShowDisable(!showDisable); setError(''); }}
-              className="text-xs px-3 py-1.5"
             >
               Disable
             </Button>
           ) : (
-            <Button onClick={() => setShowModal(true)} className="text-xs px-3 py-1.5">
+            <Button onClick={() => setShowModal(true)}>
               Set Up
             </Button>
           )

--- a/account-ui/src/components/TotpSetup.tsx
+++ b/account-ui/src/components/TotpSetup.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
-import { IconX, IconCopy, IconCheck } from '@tabler/icons-react';
+import { IconCopy, IconCheck } from '@tabler/icons-react';
 import api from '../api';
+import Modal from './Modal';
 import Button from './Button';
 import Alert from './Alert';
+import { extractError } from '../lib/utils';
 
 interface TotpSetupModalProps {
   onClose: () => void;
@@ -48,24 +50,14 @@ const TotpSetupModal: React.FC<TotpSetupModalProps> = ({ onClose, onSuccess }) =
       onSuccess();
       onClose();
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { error_description?: string } } };
-      setError(axiosErr.response?.data?.error_description || 'Invalid code. Please try again.');
+      setError(extractError(err, 'Invalid code. Please try again.'));
     } finally {
       setIsVerifying(false);
     }
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
-      <div className="bg-theme-bg rounded-2xl shadow-xl w-full max-w-sm">
-        <div className="flex items-center justify-between px-6 py-4 border-b border-theme-fg/10">
-          <h2 className="text-base font-semibold">Set Up Authenticator</h2>
-          <button onClick={onClose} className="text-theme-muted hover:text-theme-fg transition-colors">
-            <IconX size={18} />
-          </button>
-        </div>
-
-        <div className="px-6 py-5">
+    <Modal title="Set Up Authenticator" onClose={onClose}>
           {step === 'loading' && (
             <div className="flex justify-center py-8">
               <div className="w-6 h-6 border-2 border-theme-fg/20 border-t-theme-fg rounded-full animate-spin" />
@@ -87,7 +79,7 @@ const TotpSetupModal: React.FC<TotpSetupModalProps> = ({ onClose, onSuccess }) =
                 <div className="flex items-center gap-2 px-3 py-2 bg-theme-body rounded-lg border border-theme-fg/15">
                   <code className="flex-1 text-xs font-mono text-theme-fg break-all">{secret}</code>
                   <button onClick={handleCopy} className="flex-shrink-0 text-theme-muted hover:text-theme-fg transition-colors">
-                    {copied ? <IconCheck size={15} className="text-theme-highlight" /> : <IconCopy size={15} />}
+                    {copied ? <IconCheck size={15} className="text-theme-success" /> : <IconCopy size={15} />}
                   </button>
                 </div>
               </div>
@@ -126,9 +118,7 @@ const TotpSetupModal: React.FC<TotpSetupModalProps> = ({ onClose, onSuccess }) =
               </div>
             </form>
           )}
-        </div>
-      </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/account-ui/src/index.css
+++ b/account-ui/src/index.css
@@ -2,22 +2,26 @@
 @import "tailwindcss";
 
 @theme inline {
-  --radius-brand:              var(--radius);
-  --color-theme-bg:            var(--color-bg);
-  --color-theme-body:          var(--color-body);
-  --color-theme-fg:            var(--color-fg);
-  --color-theme-muted:         var(--color-muted);
-  --color-theme-primary-bg:    var(--color-primary-bg);
-  --color-theme-primary-fg:    var(--color-primary-fg);
-  --color-theme-accent-bg:     var(--color-accent-bg);
-  --color-theme-accent-fg:     var(--color-accent-fg);
-  --color-theme-danger-bg:     var(--color-danger-bg);
-  --color-theme-danger-fg:     var(--color-danger-fg);
-  --color-theme-highlight:     var(--color-highlight);
+  --radius-brand: var(--radius);
+  --color-theme-bg: var(--color-bg);
+  --color-theme-body: var(--color-body);
+  --color-theme-fg: var(--color-fg);
+  --color-theme-muted: var(--color-muted);
+  --color-theme-primary-bg: var(--color-primary-bg);
+  --color-theme-primary-fg: var(--color-primary-fg);
+  --color-theme-accent-bg: var(--color-accent-bg);
+  --color-theme-accent-fg: var(--color-accent-fg);
+  --color-theme-danger-bg: var(--color-danger-bg);
+  --color-theme-danger-fg: var(--color-danger-fg);
+  --color-theme-success-bg: var(--color-success-bg);
+  --color-theme-success-fg: var(--color-success-fg);
+  --color-theme-highlight: var(--color-highlight);
 }
 
 @layer base {
-  a, button {
+
+  a,
+  button {
     cursor: pointer;
   }
 

--- a/account-ui/src/lib/utils.ts
+++ b/account-ui/src/lib/utils.ts
@@ -4,3 +4,8 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function extractError(err: unknown, fallback: string): string {
+  const res = (err as { response?: { data?: { error_description?: string } } })?.response;
+  return res?.data?.error_description || fallback;
+}

--- a/account-ui/src/pages/Callback.tsx
+++ b/account-ui/src/pages/Callback.tsx
@@ -1,18 +1,40 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
 import Spinner from '../components/Spinner';
+import Alert from '../components/Alert';
 
 const Callback: React.FC = () => {
   const { signinCallback, isLoading } = useAuth();
   const navigate = useNavigate();
   const called = React.useRef(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (isLoading || called.current) return;
     called.current = true;
-    signinCallback().then(() => navigate('/')).catch(() => navigate('/'));
+    signinCallback()
+      .then(() => navigate('/'))
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : 'Authentication failed. Please try again.');
+      });
   }, [signinCallback, navigate, isLoading]);
+
+  if (error) {
+    return (
+      <div className="min-h-dvh flex items-center justify-center bg-theme-body p-4">
+        <div className="bg-theme-bg rounded-2xl shadow-sm p-8 max-w-sm w-full space-y-4">
+          <Alert type="danger" message={error} />
+          <button
+            onClick={() => window.location.href = '/account'}
+            className="w-full inline-flex items-center justify-center px-4 py-2.5 rounded-brand text-sm font-medium bg-theme-primary-bg text-theme-primary-fg hover:opacity-90 transition-all"
+          >
+            Try Again
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-dvh flex items-center justify-center bg-theme-accent-bg">

--- a/account-ui/src/pages/ConnectedProviders.tsx
+++ b/account-ui/src/pages/ConnectedProviders.tsx
@@ -5,6 +5,7 @@ import api from '../api';
 import Card from '../components/Card';
 import Alert from '../components/Alert';
 import Button from '../components/Button';
+import { extractError } from '../lib/utils';
 
 interface ConnectedProvider {
   id: string;
@@ -27,8 +28,7 @@ const ConnectedProvidersPage: React.FC = () => {
       await api.delete(`/connected-providers/${id}`);
       refetch();
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { error_description?: string } } };
-      setError(axiosErr.response?.data?.error_description || 'Failed to disconnect provider.');
+      setError(extractError(err, 'Failed to disconnect provider.'));
     }
   };
 
@@ -56,7 +56,7 @@ const ConnectedProvidersPage: React.FC = () => {
             <Button
               variant="ghost"
               onClick={() => handleDisconnect(p.id)}
-              className="flex-shrink-0 text-xs px-3 py-1.5"
+              className="flex-shrink-0"
             >
               Disconnect
             </Button>

--- a/account-ui/src/pages/Dashboard.tsx
+++ b/account-ui/src/pages/Dashboard.tsx
@@ -23,7 +23,7 @@ const Dashboard: React.FC = () => {
         title="Account Security"
         action={
           <Link to="/security">
-            <Button variant="primary" className="text-xs px-3 py-1.5">
+            <Button variant="primary">
               Manage <IconChevronRight size={13} />
             </Button>
           </Link>
@@ -33,14 +33,23 @@ const Dashboard: React.FC = () => {
           <StatusDot active={!!mfa?.totp_enabled} />
           <span className="text-sm">
             Two-factor authentication{' '}
-            <span className={cn('font-semibold', mfa?.totp_enabled ? 'text-theme-highlight' : 'text-theme-muted')}>
+            <span className={cn('font-semibold', mfa?.totp_enabled ? 'text-theme-success' : 'text-theme-muted')}>
               {mfa?.totp_enabled ? 'enabled' : 'not configured'}
             </span>
           </span>
         </div>
       </Card>
 
-      <Card title="Profile">
+      <Card
+        title="Profile"
+        action={
+          <Link to="/profile">
+            <Button variant="primary">
+              Update <IconChevronRight size={13} />
+            </Button>
+          </Link>
+        }
+      >
         <dl className="space-y-3 mt-1">
           {[
             { label: 'Username', value: profile?.username },

--- a/account-ui/src/pages/Profile.tsx
+++ b/account-ui/src/pages/Profile.tsx
@@ -5,6 +5,7 @@ import Card from '../components/Card';
 import Button from '../components/Button';
 import Alert from '../components/Alert';
 import { useSettings } from '../context/SettingsContext';
+import { extractError } from '../lib/utils';
 
 interface ProfileForm {
   username: string;
@@ -108,8 +109,7 @@ const ProfilePage: React.FC = () => {
       setSuccess('Profile updated successfully.');
       refetch();
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { error_description?: string } } };
-      setError(axiosErr.response?.data?.error_description || 'Failed to update profile.');
+      setError(extractError(err, 'Failed to update profile.'));
     } finally {
       setIsUpdating(false);
     }

--- a/account-ui/src/pages/Security.tsx
+++ b/account-ui/src/pages/Security.tsx
@@ -8,8 +8,11 @@ import Button from '../components/Button';
 import Alert from '../components/Alert';
 import TotpCard from '../components/TotpCard';
 import EmailOtpCard from '../components/EmailOtpCard';
+import StatusDot from '../components/StatusDot';
+import PasswordChangeModal from '../components/PasswordChange';
+import AccountDeletionModal from '../components/AccountDeletion';
+import { extractError } from '../lib/utils';
 import { useSettings } from '../context/SettingsContext';
-import { useAuth } from '../AuthContext';
 
 interface DeletionRequest {
   id: string;
@@ -20,7 +23,6 @@ interface DeletionRequest {
 
 const SecurityPage: React.FC = () => {
   const settings = useSettings();
-  const { logout } = useAuth();
   const queryClient = useQueryClient();
 
   const { data: mfa, refetch: refetchMfa } = useQuery({
@@ -32,12 +34,7 @@ const SecurityPage: React.FC = () => {
     queryFn: () => api.get('/passkeys').then((res) => res.data.data),
   });
 
-  const [currentPassword, setCurrentPassword] = useState('');
-  const [newPassword, setNewPassword] = useState('');
-  const [isChangingPass, setIsChangingPass] = useState(false);
-  const [passwordError, setPasswordError] = useState('');
-  const [passwordSuccess, setPasswordSuccess] = useState('');
-
+  const [showPasswordModal, setShowPasswordModal] = useState(false);
 
   const [addPasskeyError, setAddPasskeyError] = useState('');
   const [isAddingPasskey, setIsAddingPasskey] = useState(false);
@@ -47,29 +44,8 @@ const SecurityPage: React.FC = () => {
     queryKey: ['deletion-request'],
     queryFn: () => api.get('/deletion-request').then((res) => res.data.data ?? null),
   });
-  const [deletionReason, setDeletionReason] = useState('');
-  const [showDeletionConfirm, setShowDeletionConfirm] = useState(false);
-  const [deletionSubmitError, setDeletionSubmitError] = useState('');
+  const [showDeletionModal, setShowDeletionModal] = useState(false);
   const [deletionCancelError, setDeletionCancelError] = useState('');
-
-  const submitDeletionMutation = useMutation({
-    mutationFn: () =>
-      api.post('/deletion-request', deletionReason.trim() ? { reason: deletionReason.trim() } : {}),
-    onSuccess: () => {
-      if (settings.allow_self_service_deletion) {
-        logout();
-        return;
-      }
-      queryClient.invalidateQueries({ queryKey: ['deletion-request'] });
-      setDeletionReason('');
-      setShowDeletionConfirm(false);
-      setDeletionSubmitError('');
-    },
-    onError: (err: unknown) => {
-      const axiosErr = err as { response?: { data?: { error_description?: string } } };
-      setDeletionSubmitError(axiosErr.response?.data?.error_description || 'Failed to submit request.');
-    },
-  });
 
   const cancelDeletionMutation = useMutation({
     mutationFn: () => api.delete('/deletion-request'),
@@ -78,28 +54,9 @@ const SecurityPage: React.FC = () => {
       setDeletionCancelError('');
     },
     onError: (err: unknown) => {
-      const axiosErr = err as { response?: { data?: { error_description?: string } } };
-      setDeletionCancelError(axiosErr.response?.data?.error_description || 'Failed to cancel request.');
+      setDeletionCancelError(extractError(err, 'Failed to cancel request.'));
     },
   });
-
-  const handleChangePassword = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setPasswordError('');
-    setPasswordSuccess('');
-    setIsChangingPass(true);
-    try {
-      await api.post('/password', { current_password: currentPassword, new_password: newPassword });
-      setCurrentPassword('');
-      setNewPassword('');
-      setPasswordSuccess('Password updated successfully.');
-    } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { error_description?: string } } };
-      setPasswordError(axiosErr.response?.data?.error_description || 'Failed to update password.');
-    } finally {
-      setIsChangingPass(false);
-    }
-  };
 
   const handleDeletePasskey = async (id: string) => {
     setDeletePasskeyError('');
@@ -107,8 +64,7 @@ const SecurityPage: React.FC = () => {
       await api.delete(`/passkeys/${id}`);
       refetchPasskeys();
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { error_description?: string } } };
-      setDeletePasskeyError(axiosErr.response?.data?.error_description || 'Failed to delete passkey.');
+      setDeletePasskeyError(extractError(err, 'Failed to delete passkey.'));
     }
   };
 
@@ -125,8 +81,7 @@ const SecurityPage: React.FC = () => {
       if (err instanceof Error && err.message.includes('cancel')) {
         setAddPasskeyError('Passkey registration was cancelled.');
       } else {
-        const axiosErr = err as { response?: { data?: { error_description?: string } } };
-        setAddPasskeyError(axiosErr.response?.data?.error_description || 'Failed to add passkey.');
+        setAddPasskeyError(extractError(err, 'Failed to add passkey.'));
       }
     } finally {
       setIsAddingPasskey(false);
@@ -135,33 +90,16 @@ const SecurityPage: React.FC = () => {
 
   return (
     <div className="space-y-4">
-      <Card title="Password" description="Change your password to keep your account secure.">
-        <form onSubmit={handleChangePassword} className="space-y-5 mt-2">
-          <div>
-            <label>Current Password</label>
-            <input
-              type="password"
-              value={currentPassword}
-              onChange={(e) => setCurrentPassword(e.target.value)}
-            />
-          </div>
-          <div>
-            <label>New Password</label>
-            <input
-              type="password"
-              value={newPassword}
-              onChange={(e) => setNewPassword(e.target.value)}
-            />
-          </div>
-          {passwordError && <Alert type="danger" message={passwordError} />}
-          {passwordSuccess && <Alert type="success" message={passwordSuccess} />}
-          <div className="flex justify-end">
-            <Button type="submit" disabled={isChangingPass || !currentPassword || !newPassword}>
-              Update Password
-            </Button>
-          </div>
-        </form>
-      </Card>
+      {showPasswordModal && <PasswordChangeModal onClose={() => setShowPasswordModal(false)} />}
+      <Card
+        title="Password"
+        description="Change your password to keep your account secure."
+        action={
+          <Button onClick={() => setShowPasswordModal(true)}>
+            Change Password
+          </Button>
+        }
+      />
 
       {(settings.mfa_method === 'totp' || settings.mfa_method === 'both') && (
         <TotpCard
@@ -179,7 +117,7 @@ const SecurityPage: React.FC = () => {
         title="Passkeys"
         description="Biometrics or security keys for passwordless login."
         action={
-          <Button onClick={handleAddPasskey} disabled={isAddingPasskey} className="text-xs px-3 py-1.5">
+          <Button onClick={handleAddPasskey} disabled={isAddingPasskey}>
             {isAddingPasskey ? 'Registering…' : 'Add Passkey'}
           </Button>
         }
@@ -204,7 +142,7 @@ const SecurityPage: React.FC = () => {
                 <Button
                   variant="danger"
                   onClick={() => handleDeletePasskey(pk.id)}
-                  className="text-xs px-3 py-1.5 flex-shrink-0"
+                  className="flex-shrink-0"
                 >
                   Remove
                 </Button>
@@ -212,10 +150,14 @@ const SecurityPage: React.FC = () => {
             ))}
           </div>
         ) : (
-          <p className="text-sm text-theme-muted mt-1">No passkeys registered yet.</p>
+          <div className="flex items-center gap-2 mt-1">
+            <StatusDot active={false} />
+            <span className="text-sm text-theme-fg">No passkeys registered</span>
+          </div>
         )}
       </Card>
 
+      {showDeletionModal && <AccountDeletionModal onClose={() => setShowDeletionModal(false)} />}
       <Card
         title="Danger Zone"
         description={
@@ -223,9 +165,16 @@ const SecurityPage: React.FC = () => {
             ? 'Permanently delete your account. This action cannot be undone.'
             : 'Request account deletion. An admin will review and process your request.'
         }
+        action={
+          !deletionRequest ? (
+            <Button variant="danger" onClick={() => setShowDeletionModal(true)}>
+              Delete Account
+            </Button>
+          ) : undefined
+        }
       >
-        {deletionRequest ? (
-          <div className="mt-2 space-y-4">
+        {deletionRequest && (
+          <div className="space-y-4">
             <div className="rounded-xl bg-theme-danger-bg border border-theme-danger-bg px-4 py-3 text-sm text-theme-danger-fg">
               A deletion request was submitted on{' '}
               <strong>{new Date(deletionRequest.requested_at).toLocaleDateString()}</strong>.
@@ -248,54 +197,6 @@ const SecurityPage: React.FC = () => {
                 {cancelDeletionMutation.isPending ? 'Cancelling…' : 'Cancel Deletion Request'}
               </Button>
             )}
-          </div>
-        ) : !showDeletionConfirm ? (
-          <div className="mt-2">
-            <Button variant="danger" onClick={() => setShowDeletionConfirm(true)}>
-              {settings.allow_self_service_deletion ? 'Delete My Account' : 'Request Account Deletion'}
-            </Button>
-          </div>
-        ) : (
-          <div className="mt-2 space-y-4 border-t border-theme-fg/10 pt-4">
-            <p className="text-sm text-theme-fg font-medium">
-              {settings.allow_self_service_deletion
-                ? 'Are you sure you want to permanently delete your account? This cannot be undone.'
-                : 'A deletion request will be submitted for admin review.'}
-            </p>
-            <div>
-              <label className="block text-sm font-medium mb-1">
-                Reason <span className="text-theme-muted font-normal">(optional)</span>
-              </label>
-              <textarea
-                className="w-full rounded-xl border border-theme-fg/20 px-3 py-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-theme-highlight bg-theme-bg text-theme-fg"
-                rows={3}
-                placeholder="Tell us why you want to delete your account…"
-                value={deletionReason}
-                onChange={(e) => setDeletionReason(e.target.value)}
-              />
-            </div>
-            {deletionSubmitError && <Alert type="danger" message={deletionSubmitError} />}
-            <div className="flex gap-2">
-              <Button
-                variant="ghost"
-                onClick={() => { setShowDeletionConfirm(false); setDeletionSubmitError(''); }}
-                className="flex-1"
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="danger"
-                onClick={() => submitDeletionMutation.mutate()}
-                disabled={submitDeletionMutation.isPending}
-                className="flex-1"
-              >
-                {submitDeletionMutation.isPending
-                  ? 'Submitting…'
-                  : settings.allow_self_service_deletion
-                  ? 'Delete Account'
-                  : 'Submit Request'}
-              </Button>
-            </div>
           </div>
         )}
       </Card>

--- a/account-ui/src/pages/Security.tsx
+++ b/account-ui/src/pages/Security.tsx
@@ -1,107 +1,29 @@
-import React, { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { IconKey } from '@tabler/icons-react';
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
 import api from '../api';
-import { performPasskeyRegistration } from '../lib/passkey';
-import Card from '../components/Card';
-import Button from '../components/Button';
-import Alert from '../components/Alert';
+import PasswordCard from '../components/PasswordCard';
 import TotpCard from '../components/TotpCard';
 import EmailOtpCard from '../components/EmailOtpCard';
-import StatusDot from '../components/StatusDot';
-import PasswordChangeModal from '../components/PasswordChange';
-import AccountDeletionModal from '../components/AccountDeletion';
-import { extractError } from '../lib/utils';
+import PasskeyCard from '../components/PasskeyCard';
+import DangerZoneCard from '../components/DangerZoneCard';
 import { useSettings } from '../context/SettingsContext';
-
-interface DeletionRequest {
-  id: string;
-  user_id: string;
-  reason?: string;
-  requested_at: string;
-}
 
 const SecurityPage: React.FC = () => {
   const settings = useSettings();
-  const queryClient = useQueryClient();
+
+  const showTotp = settings.mfa_method === 'totp' || settings.mfa_method === 'both';
+  const showEmailOtp = settings.mfa_method === 'email' || settings.mfa_method === 'both';
 
   const { data: mfa, refetch: refetchMfa } = useQuery({
     queryKey: ['mfa'],
     queryFn: () => api.get('/mfa').then((res) => res.data.data),
   });
-  const { data: passkeys, refetch: refetchPasskeys } = useQuery({
-    queryKey: ['passkeys'],
-    queryFn: () => api.get('/passkeys').then((res) => res.data.data),
-  });
-
-  const [showPasswordModal, setShowPasswordModal] = useState(false);
-
-  const [addPasskeyError, setAddPasskeyError] = useState('');
-  const [isAddingPasskey, setIsAddingPasskey] = useState(false);
-  const [deletePasskeyError, setDeletePasskeyError] = useState('');
-
-  const { data: deletionRequest } = useQuery<DeletionRequest | null>({
-    queryKey: ['deletion-request'],
-    queryFn: () => api.get('/deletion-request').then((res) => res.data.data ?? null),
-  });
-  const [showDeletionModal, setShowDeletionModal] = useState(false);
-  const [deletionCancelError, setDeletionCancelError] = useState('');
-
-  const cancelDeletionMutation = useMutation({
-    mutationFn: () => api.delete('/deletion-request'),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['deletion-request'] });
-      setDeletionCancelError('');
-    },
-    onError: (err: unknown) => {
-      setDeletionCancelError(extractError(err, 'Failed to cancel request.'));
-    },
-  });
-
-  const handleDeletePasskey = async (id: string) => {
-    setDeletePasskeyError('');
-    try {
-      await api.delete(`/passkeys/${id}`);
-      refetchPasskeys();
-    } catch (err: unknown) {
-      setDeletePasskeyError(extractError(err, 'Failed to delete passkey.'));
-    }
-  };
-
-  const handleAddPasskey = async () => {
-    setAddPasskeyError('');
-    setIsAddingPasskey(true);
-    try {
-      const beginRes = await api.post('/passkeys/register/begin');
-      const data = beginRes.data.data;
-      const credential = await performPasskeyRegistration(data);
-      await api.post(`/passkeys/register/finish?challenge_id=${data.challenge_id}`, credential);
-      refetchPasskeys();
-    } catch (err: unknown) {
-      if (err instanceof Error && err.message.includes('cancel')) {
-        setAddPasskeyError('Passkey registration was cancelled.');
-      } else {
-        setAddPasskeyError(extractError(err, 'Failed to add passkey.'));
-      }
-    } finally {
-      setIsAddingPasskey(false);
-    }
-  };
 
   return (
     <div className="space-y-4">
-      {showPasswordModal && <PasswordChangeModal onClose={() => setShowPasswordModal(false)} />}
-      <Card
-        title="Password"
-        description="Change your password to keep your account secure."
-        action={
-          <Button onClick={() => setShowPasswordModal(true)}>
-            Change Password
-          </Button>
-        }
-      />
+      <PasswordCard />
 
-      {(settings.mfa_method === 'totp' || settings.mfa_method === 'both') && (
+      {showTotp && (
         <TotpCard
           totpEnabled={!!mfa?.totp_enabled}
           preferredLabel={settings.mfa_method === 'both'}
@@ -109,97 +31,12 @@ const SecurityPage: React.FC = () => {
         />
       )}
 
-      {(settings.mfa_method === 'email' || settings.mfa_method === 'both') && (
+      {showEmailOtp && (
         <EmailOtpCard fallbackLabel={settings.mfa_method === 'both'} />
       )}
 
-      <Card
-        title="Passkeys"
-        description="Biometrics or security keys for passwordless login."
-        action={
-          <Button onClick={handleAddPasskey} disabled={isAddingPasskey}>
-            {isAddingPasskey ? 'Registering…' : 'Add Passkey'}
-          </Button>
-        }
-      >
-        {addPasskeyError && <Alert type="danger" message={addPasskeyError} className="mb-2" />}
-        {deletePasskeyError && <Alert type="danger" message={deletePasskeyError} className="mb-2" />}
-        {passkeys && passkeys.length > 0 ? (
-          <div className="divide-y divide-theme-fg/10 mt-1">
-            {passkeys.map((pk: { id: string; name: string; created_at: string }) => (
-              <div key={pk.id} className="py-3.5 flex items-center justify-between gap-4">
-                <div className="flex items-center gap-3 min-w-0">
-                  <div className="w-8 h-8 rounded-full bg-theme-body flex items-center justify-center flex-shrink-0">
-                    <IconKey size={14} className="text-theme-fg" />
-                  </div>
-                  <div>
-                    <p className="text-sm font-semibold">{pk.name || 'Unnamed Passkey'}</p>
-                    <p className="text-xs text-theme-muted">
-                      Added {new Date(pk.created_at).toLocaleDateString()}
-                    </p>
-                  </div>
-                </div>
-                <Button
-                  variant="danger"
-                  onClick={() => handleDeletePasskey(pk.id)}
-                  className="flex-shrink-0"
-                >
-                  Remove
-                </Button>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="flex items-center gap-2 mt-1">
-            <StatusDot active={false} />
-            <span className="text-sm text-theme-fg">No passkeys registered</span>
-          </div>
-        )}
-      </Card>
-
-      {showDeletionModal && <AccountDeletionModal onClose={() => setShowDeletionModal(false)} />}
-      <Card
-        title="Danger Zone"
-        description={
-          settings.allow_self_service_deletion
-            ? 'Permanently delete your account. This action cannot be undone.'
-            : 'Request account deletion. An admin will review and process your request.'
-        }
-        action={
-          !deletionRequest ? (
-            <Button variant="danger" onClick={() => setShowDeletionModal(true)}>
-              Delete Account
-            </Button>
-          ) : undefined
-        }
-      >
-        {deletionRequest && (
-          <div className="space-y-4">
-            <div className="rounded-xl bg-theme-danger-bg border border-theme-danger-bg px-4 py-3 text-sm text-theme-danger-fg">
-              A deletion request was submitted on{' '}
-              <strong>{new Date(deletionRequest.requested_at).toLocaleDateString()}</strong>.
-              {settings.allow_self_service_deletion
-                ? ' Your account has been deleted.'
-                : ' An admin will review and process your request. Your account remains active until then.'}
-            </div>
-            {deletionRequest.reason && (
-              <p className="text-sm text-theme-muted">
-                <span className="font-medium">Reason:</span> {deletionRequest.reason}
-              </p>
-            )}
-            {deletionCancelError && <Alert type="danger" message={deletionCancelError} />}
-            {!settings.allow_self_service_deletion && (
-              <Button
-                variant="ghost"
-                onClick={() => cancelDeletionMutation.mutate()}
-                disabled={cancelDeletionMutation.isPending}
-              >
-                {cancelDeletionMutation.isPending ? 'Cancelling…' : 'Cancel Deletion Request'}
-              </Button>
-            )}
-          </div>
-        )}
-      </Card>
+      <PasskeyCard />
+      <DangerZoneCard />
     </div>
   );
 };

--- a/account-ui/src/pages/Sessions.tsx
+++ b/account-ui/src/pages/Sessions.tsx
@@ -5,6 +5,7 @@ import api from '../api';
 import Card from '../components/Card';
 import Alert from '../components/Alert';
 import Button from '../components/Button';
+import { extractError } from '../lib/utils';
 
 interface Session {
   id: string;
@@ -28,8 +29,7 @@ const SessionsPage: React.FC = () => {
       await api.delete(`/sessions/${id}`);
       refetch();
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { error_description?: string } } };
-      setError(axiosErr.response?.data?.error_description || 'Failed to revoke session.');
+      setError(extractError(err, 'Failed to revoke session.'));
     }
   };
 

--- a/account-ui/src/pages/TrustedDevices.tsx
+++ b/account-ui/src/pages/TrustedDevices.tsx
@@ -5,6 +5,7 @@ import api from '../api';
 import Card from '../components/Card';
 import Alert from '../components/Alert';
 import Button from '../components/Button';
+import { extractError } from '../lib/utils';
 
 interface TrustedDevice {
   id: string;
@@ -27,8 +28,7 @@ const TrustedDevicesPage: React.FC = () => {
       await api.delete(`/trusted-devices/${id}`);
       refetch();
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { error_description?: string } } };
-      setError(axiosErr.response?.data?.error_description || 'Failed to revoke trusted device.');
+      setError(extractError(err, 'Failed to revoke trusted device.'));
     }
   };
 
@@ -55,7 +55,7 @@ const TrustedDevicesPage: React.FC = () => {
                 </p>
               </div>
             </div>
-            <Button variant="danger" onClick={() => handleRevoke(d.id)} className="flex-shrink-0 text-xs px-3 py-1.5">
+            <Button variant="danger" onClick={() => handleRevoke(d.id)} className="flex-shrink-0">
               Revoke
             </Button>
           </div>

--- a/account-ui/src/theme.css
+++ b/account-ui/src/theme.css
@@ -16,6 +16,8 @@
  *   --color-accent-fg    Text on --color-accent-bg
  *   --color-danger-bg    Errors, destructive actions surface
  *   --color-danger-fg    Text on --color-danger-bg
+ *   --color-success-bg   Confirmations, positive actions surface
+ *   --color-success-fg   Text on --color-success-bg
  *   --color-highlight    Links, focus rings, info states (no surface use)
  */
 
@@ -39,6 +41,8 @@
   --color-accent-fg:    #fafafa;
   --color-danger-bg:    #b91313;
   --color-danger-fg:    #ffffff;
+  --color-success-bg:   #15803d;
+  --color-success-fg:   #ffffff;
   --color-highlight:    #4779a1;
 }
 
@@ -58,6 +62,8 @@
     --color-accent-fg:    #ffffff;
     --color-danger-bg:    #d42f2f;
     --color-danger-fg:    #ffffff;
+    --color-success-bg:   #22c55e;
+    --color-success-fg:   #111111;
     --color-highlight:    #4779a1;
   }
 }
@@ -77,6 +83,8 @@
   --color-accent-fg:    #fafafa;
   --color-danger-bg:    #b91313;
   --color-danger-fg:    #ffffff;
+  --color-success-bg:   #15803d;
+  --color-success-fg:   #ffffff;
   --color-highlight:    #4779a1;
 }
 
@@ -94,6 +102,8 @@
   --color-accent-fg:    #ffffff;
   --color-danger-bg:    #d42f2f;
   --color-danger-fg:    #ffffff;
+  --color-success-bg:   #22c55e;
+  --color-success-fg:   #111111;
   --color-highlight:    #4779a1;
 }
 
@@ -111,6 +121,8 @@
   --color-accent-fg:    #ffffff;
   --color-danger-bg:    #d60b0b;
   --color-danger-fg:    #ffffff;
+  --color-success-bg:   #16a34a;
+  --color-success-fg:   #ffffff;
   --color-highlight:    #0b66d6;
 }
 
@@ -128,6 +140,8 @@
   --color-accent-fg:    #efefef;
   --color-danger-bg:    #d60b0b;
   --color-danger-fg:    #ffffff;
+  --color-success-bg:   #22c55e;
+  --color-success-fg:   #1a1a2a;
   --color-highlight:    #0b66d6;
 }
 
@@ -145,6 +159,8 @@
   --color-accent-fg:    #fdf6e3;
   --color-danger-bg:    #dc322f;
   --color-danger-fg:    #fdf6e3;
+  --color-success-bg:   #859900;
+  --color-success-fg:   #fdf6e3;
   --color-highlight:    #6c71c4;
 }
 
@@ -162,6 +178,8 @@
   --color-accent-fg:    #fafafa;
   --color-danger-bg:    #b91313;
   --color-danger-fg:    #ffffff;
+  --color-success-bg:   #15803d;
+  --color-success-fg:   #ffffff;
   --color-highlight:    #4779a1;
 }
 
@@ -179,6 +197,8 @@
   --color-accent-fg:    #ffffff;
   --color-danger-bg:    #d42f2f;
   --color-danger-fg:    #ffffff;
+  --color-success-bg:   #22c55e;
+  --color-success-fg:   #111111;
   --color-highlight:    #4779a1;
 }
 
@@ -196,6 +216,8 @@
   --color-accent-fg:    #fbf7ff;
   --color-danger-bg:    #e63946;
   --color-danger-fg:    #ffffff;
+  --color-success-bg:   #16a34a;
+  --color-success-fg:   #ffffff;
   --color-highlight:    #705ea4;
 }
 
@@ -213,6 +235,8 @@
   --color-accent-fg:    #fbf7ff;
   --color-danger-bg:    #e63946;
   --color-danger-fg:    #ffffff;
+  --color-success-bg:   #22c55e;
+  --color-success-fg:   #201b3e;
   --color-highlight:    #564787;
 }
 
@@ -230,6 +254,8 @@
   --color-accent-fg:    #ffeef6;
   --color-danger-bg:    #c2185b;
   --color-danger-fg:    #ffeef6;
+  --color-success-bg:   #4caf50;
+  --color-success-fg:   #1e0f1b;
   --color-highlight:    #f78da7;
 }
 
@@ -247,6 +273,8 @@
   --color-accent-fg:    #ffffff;
   --color-danger-bg:    #770000;
   --color-danger-fg:    #ffffff;
+  --color-success-bg:   #006600;
+  --color-success-fg:   #ffffff;
   --color-highlight:    #0000aa;
 }
 
@@ -264,6 +292,8 @@
   --color-accent-fg:    #ffffff;
   --color-danger-bg:    #ff4444;
   --color-danger-fg:    #000000;
+  --color-success-bg:   #00cc00;
+  --color-success-fg:   #000000;
   --color-highlight:    #ffff00;
 }
 
@@ -281,6 +311,8 @@
   --color-accent-fg:    #ffffff;
   --color-danger-bg:    #ff2400;
   --color-danger-fg:    #3b1d1d;
+  --color-success-bg:   #2e7d32;
+  --color-success-fg:   #ffffff;
   --color-highlight:    #ff7e67;
 }
 
@@ -298,6 +330,8 @@
   --color-accent-fg:    #e8f7fe;
   --color-danger-bg:    #ff4d4d;
   --color-danger-fg:    #ffffff;
+  --color-success-bg:   #00897b;
+  --color-success-fg:   #e8f7fe;
   --color-highlight:    #1ecbe1;
 }
 
@@ -315,6 +349,8 @@
   --color-accent-fg:    #e2e7e9;
   --color-danger-bg:    #e63946;
   --color-danger-fg:    #ffffff;
+  --color-success-bg:   #2a9d8f;
+  --color-success-fg:   #e2e7e9;
   --color-highlight:    #a8dadc;
 }
 
@@ -332,6 +368,8 @@
   --color-accent-fg:    #000000;
   --color-danger-bg:    #d12f1d;
   --color-danger-fg:    #ffffff;
+  --color-success-bg:   #27ae60;
+  --color-success-fg:   #000000;
   --color-highlight:    #f5b041;
 }
 
@@ -349,6 +387,8 @@
   --color-accent-fg:    #f5e8d0;
   --color-danger-bg:    #b22222;
   --color-danger-fg:    #f5e8d0;
+  --color-success-bg:   #558b2f;
+  --color-success-fg:   #f5e8d0;
   --color-highlight:    #9e7145;
 }
 
@@ -366,6 +406,8 @@
   --color-accent-fg:    #ffffff;
   --color-danger-bg:    #e60000;
   --color-danger-fg:    #ffffff;
+  --color-success-bg:   #1b5e20;
+  --color-success-fg:   #ffffff;
   --color-highlight:    #4169e1;
 }
 
@@ -383,5 +425,7 @@
   --color-accent-fg:    #f2f4f7;
   --color-danger-bg:    #b22222;
   --color-danger-fg:    #f2f4f7;
+  --color-success-bg:   #4caf50;
+  --color-success-fg:   #f2f4f7;
   --color-highlight:    #3b82f6;
 }


### PR DESCRIPTION
## Summary
- Add reusable `Modal` component, refactor TotpSetup and create PasswordChange + AccountDeletion modals
- Add `extractError()` utility replacing 11 duplicated error extraction patterns
- Add `--color-success-bg`/`--color-success-fg` design tokens to all 18 themes
- Fix Callback infinite redirect loop on login failure — shows error with retry button instead
- Fix success Alert using wrong CSS variables
- Consistent card pattern across Security page (StatusDot on passkeys, action buttons in card headers)
- Add "Update >" action to Dashboard profile card linking to /profile
- Remove `Page` suffix from page filenames
- Remove hardcoded small button overrides — use default Button size
- Account deletion now requires typing username to confirm

## Test plan
- [ ] Verify all themes render success alerts with correct colors
- [ ] Verify password change modal opens, submits, shows success/error
- [ ] Verify TOTP setup modal still works end-to-end
- [ ] Verify account deletion modal requires username match before submit
- [ ] Verify login callback failure shows error instead of infinite redirect
- [ ] Verify all page routes still work after filename renames

🤖 Generated with [Claude Code](https://claude.com/claude-code)