### PR TITLE
docs: lead quickstart with Docker and simplify installation

### DIFF
--- a/docs-web/src/content/docs/getting-started/installation.mdx
+++ b/docs-web/src/content/docs/getting-started/installation.mdx
@@ -3,12 +3,46 @@ title: Installation
 description: How to install Autentico — binary download, Docker image, or build from source.
 ---
 
-import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
 
 Autentico ships as a single self-contained binary with no runtime dependencies. Choose the method that fits your environment.
 
-<Tabs>
-<TabItem label="Binary">
+## Install with Docker
+
+<Steps>
+1. Generate a `.env` file with all required secrets:
+   ```bash
+   docker run --rm -v $(pwd):/output ghcr.io/eugenioenko/autentico:latest \
+     init --output /output --url http://localhost:9999
+   ```
+
+2. Start the server:
+   ```bash
+   docker run -d \
+     --name autentico \
+     -p 9999:9999 \
+     -v autentico-data:/data \
+     --env-file .env \
+     --restart unless-stopped \
+     ghcr.io/eugenioenko/autentico:latest \
+     start --auto-migrate
+   ```
+</Steps>
+
+See [Bootstrap Settings](/configuration/bootstrap/) for all available environment variables. For production setups with Docker Compose, see [Docker Compose](/deployment/docker-compose/).
+
+:::tip[URL mismatch after restart]
+If you restart the container with a different `AUTENTICO_APP_URL` or port, the persisted database still has the admin UI OAuth2 client registered with the old callback URL. Login will fail with a "Redirect URI not allowed" error.
+
+To fix it, delete the volume and start fresh (this wipes all data):
+```bash
+docker stop autentico && docker rm autentico
+docker volume rm autentico-data
+```
+Then re-run with the new URL. This applies to local testing only — in production, `AUTENTICO_APP_URL` should be stable and the client redirect URIs are updated automatically on restart.
+:::
+
+## Install from Binary
 
 Pre-built binaries for Linux, macOS, and Windows are available on the [GitHub Releases page](https://github.com/eugenioenko/autentico/releases).
 
@@ -35,49 +69,7 @@ Pre-built binaries for Linux, macOS, and Windows are available on the [GitHub Re
 
 Once installed, follow the [Quickstart](/getting-started/quickstart/) to initialize and run your instance.
 
-</TabItem>
-<TabItem label="Docker">
-
-<Steps>
-1. Generate a `.env` file with all required secrets:
-   ```bash
-   docker run --rm -v $(pwd):/output ghcr.io/eugenioenko/autentico:latest \
-     init --output /output --url http://localhost:9999
-   ```
-
-2. Start the server:
-   ```bash
-   docker run -d \
-     --name autentico \
-     -p 9999:9999 \
-     -v autentico-data:/data \
-     --env-file .env \
-     --restart unless-stopped \
-     ghcr.io/eugenioenko/autentico:latest \
-     start --auto-migrate
-   ```
-</Steps>
-
-See [Bootstrap Settings](/configuration/bootstrap/) for all available environment variables.
-
-:::tip[URL mismatch after restart]
-If you restart the container with a different `AUTENTICO_APP_URL` or port, the persisted database still has the admin UI OAuth2 client registered with the old callback URL. Login will fail with a "Redirect URI not allowed" error.
-
-To fix it, delete the volume and start fresh (this wipes all data):
-```bash
-docker stop autentico && docker rm autentico
-docker volume rm autentico-data
-```
-Then re-run with the new URL. This applies to local testing only — in production, `AUTENTICO_APP_URL` should be stable and the client redirect URIs are updated automatically on restart.
-:::
-
-</TabItem>
-<TabItem label="Docker Compose">
-
-See [Docker Compose](/deployment/docker-compose/) for a full annotated `docker-compose.yml` that mounts persistent storage, configures SMTP, and sits behind a reverse proxy.
-
-</TabItem>
-<TabItem label="From Source">
+## Build from Source
 
 Requires Go 1.22 or later.
 
@@ -95,9 +87,6 @@ Requires Go 1.22 or later.
 
 3. The compiled binary is at `./autentico`. Follow the [Quickstart](/getting-started/quickstart/) to initialize and run your instance.
 </Steps>
-
-</TabItem>
-</Tabs>
 
 ## CLI commands
 

--- a/docs-web/src/content/docs/getting-started/installation.mdx
+++ b/docs-web/src/content/docs/getting-started/installation.mdx
@@ -3,46 +3,12 @@ title: Installation
 description: How to install Autentico — binary download, Docker image, or build from source.
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
 Autentico ships as a single self-contained binary with no runtime dependencies. Choose the method that fits your environment.
 
-## Install with Docker
-
-<Steps>
-1. Generate a `.env` file with all required secrets:
-   ```bash
-   docker run --rm -v $(pwd):/output ghcr.io/eugenioenko/autentico:latest \
-     init --output /output --url http://localhost:9999
-   ```
-
-2. Start the server:
-   ```bash
-   docker run -d \
-     --name autentico \
-     -p 9999:9999 \
-     -v autentico-data:/data \
-     --env-file .env \
-     --restart unless-stopped \
-     ghcr.io/eugenioenko/autentico:latest \
-     start --auto-migrate
-   ```
-</Steps>
-
-See [Bootstrap Settings](/configuration/bootstrap/) for all available environment variables. For production setups with Docker Compose, see [Docker Compose](/deployment/docker-compose/).
-
-:::tip[URL mismatch after restart]
-If you restart the container with a different `AUTENTICO_APP_URL` or port, the persisted database still has the admin UI OAuth2 client registered with the old callback URL. Login will fail with a "Redirect URI not allowed" error.
-
-To fix it, delete the volume and start fresh (this wipes all data):
-```bash
-docker stop autentico && docker rm autentico
-docker volume rm autentico-data
-```
-Then re-run with the new URL. This applies to local testing only — in production, `AUTENTICO_APP_URL` should be stable and the client redirect URIs are updated automatically on restart.
-:::
-
-## Install from Binary
+<Tabs>
+<TabItem label="Binary">
 
 Pre-built binaries for Linux, macOS, and Windows are available on the [GitHub Releases page](https://github.com/eugenioenko/autentico/releases).
 
@@ -69,7 +35,52 @@ Pre-built binaries for Linux, macOS, and Windows are available on the [GitHub Re
 
 Once installed, follow the [Quickstart](/getting-started/quickstart/) to initialize and run your instance.
 
-## Build from Source
+</TabItem>
+<TabItem label="Docker">
+
+Pull the latest image:
+
+```bash
+docker pull ghcr.io/eugenioenko/autentico:latest
+```
+
+Run with environment variables:
+
+```bash
+docker run \
+  --name autentico \
+  -p 9999:9999 \
+  -v autentico-data:/data \
+  -e AUTENTICO_APP_URL=http://localhost:9999\
+  -e AUTENTICO_LISTEN_PORT=9999 \
+  -e AUTENTICO_DB_FILE_PATH=/data/autentico.db \
+  -e AUTENTICO_PRIVATE_KEY=base64-encoded-pem-string \
+  -e AUTENTICO_CSRF_SECRET_KEY=changeme-at-least-32-chars \
+  -e AUTENTICO_ACCESS_TOKEN_SECRET=changeme-at-least-32-chars \
+  -e AUTENTICO_REFRESH_TOKEN_SECRET=changeme-at-least-32-chars \
+  ghcr.io/eugenioenko/autentico:latest
+```
+
+See [Bootstrap Settings](/configuration/bootstrap/) for all available environment variables.
+
+:::tip[URL mismatch after restart]
+If you restart the container with a different `AUTENTICO_APP_URL` or port, the persisted database still has the admin UI OAuth2 client registered with the old callback URL. Login will fail with a "Redirect URI not allowed" error.
+
+To fix it, delete the volume and start fresh (this wipes all data):
+```bash
+docker stop autentico && docker rm autentico
+docker volume rm autentico-data
+```
+Then re-run with the new URL. This applies to local testing only — in production, `AUTENTICO_APP_URL` should be stable and the client redirect URIs are updated automatically on restart.
+:::
+
+</TabItem>
+<TabItem label="Docker Compose">
+
+See [Docker Compose](/deployment/docker-compose/) for a full annotated `docker-compose.yml` that mounts persistent storage, configures SMTP, and sits behind a reverse proxy.
+
+</TabItem>
+<TabItem label="From Source">
 
 Requires Go 1.22 or later.
 
@@ -87,6 +98,9 @@ Requires Go 1.22 or later.
 
 3. The compiled binary is at `./autentico`. Follow the [Quickstart](/getting-started/quickstart/) to initialize and run your instance.
 </Steps>
+
+</TabItem>
+</Tabs>
 
 ## CLI commands
 

--- a/docs-web/src/content/docs/getting-started/installation.mdx
+++ b/docs-web/src/content/docs/getting-started/installation.mdx
@@ -38,28 +38,25 @@ Once installed, follow the [Quickstart](/getting-started/quickstart/) to initial
 </TabItem>
 <TabItem label="Docker">
 
-Pull the latest image:
+<Steps>
+1. Generate a `.env` file with all required secrets:
+   ```bash
+   docker run --rm -v $(pwd):/output ghcr.io/eugenioenko/autentico:latest \
+     init --output /output --url http://localhost:9999
+   ```
 
-```bash
-docker pull ghcr.io/eugenioenko/autentico:latest
-```
-
-Run with environment variables:
-
-```bash
-docker run \
-  --name autentico \
-  -p 9999:9999 \
-  -v autentico-data:/data \
-  -e AUTENTICO_APP_URL=http://localhost:9999\
-  -e AUTENTICO_LISTEN_PORT=9999 \
-  -e AUTENTICO_DB_FILE_PATH=/data/autentico.db \
-  -e AUTENTICO_PRIVATE_KEY=base64-encoded-pem-string \
-  -e AUTENTICO_CSRF_SECRET_KEY=changeme-at-least-32-chars \
-  -e AUTENTICO_ACCESS_TOKEN_SECRET=changeme-at-least-32-chars \
-  -e AUTENTICO_REFRESH_TOKEN_SECRET=changeme-at-least-32-chars \
-  ghcr.io/eugenioenko/autentico:latest
-```
+2. Start the server:
+   ```bash
+   docker run -d \
+     --name autentico \
+     -p 9999:9999 \
+     -v autentico-data:/data \
+     --env-file .env \
+     --restart unless-stopped \
+     ghcr.io/eugenioenko/autentico:latest \
+     start --auto-migrate
+   ```
+</Steps>
 
 See [Bootstrap Settings](/configuration/bootstrap/) for all available environment variables.
 

--- a/docs-web/src/content/docs/getting-started/quickstart.mdx
+++ b/docs-web/src/content/docs/getting-started/quickstart.mdx
@@ -5,9 +5,49 @@ description: Get Autentico running and serving tokens in under five minutes.
 
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
-Autentico is a single binary. There is no database to provision, no external services to start, and no multi-step infrastructure setup. The full process is: download, generate a `.env`, start the server, and complete onboarding in the browser.
+Autentico is a single binary. There is no database to provision, no external services to start, and no multi-step infrastructure setup. The full process is: generate a `.env`, start the server, and complete onboarding in the browser.
 
-This guide takes you from zero to a running Autentico instance with a registered OAuth2 client. It assumes you want to run the binary directly. For Docker, see [Docker deployment](/deployment/docker/).
+<Tabs>
+<TabItem label="Docker">
+
+<Steps>
+
+1. **Generate your configuration**
+
+   ```bash
+   docker run --rm -v $(pwd):/output ghcr.io/eugenioenko/autentico:latest \
+     init --output /output --url http://localhost:9999
+   ```
+
+   This creates a `.env` file in the current directory with a freshly generated RSA key, CSRF secret, and token signing secrets.
+
+2. **Start the server**
+
+   ```bash
+   docker run -d \
+     --name autentico \
+     -p 9999:9999 \
+     -v autentico-data:/data \
+     --env-file .env \
+     --restart unless-stopped \
+     ghcr.io/eugenioenko/autentico:latest \
+     start --auto-migrate
+   ```
+
+3. **Complete onboarding**
+
+   Open `http://localhost:9999/onboard` in your browser. Create the first administrator account. Once complete, you are redirected to the Admin UI.
+
+4. **Done**
+
+   Autentico is running. From the Admin UI you can manage users, register OAuth2 clients, and configure settings.
+
+</Steps>
+
+For production, replace `http://localhost:9999` with your public URL (e.g. `https://auth.example.com`). See [Docker deployment](/deployment/docker/) and [Docker Compose](/deployment/docker-compose/) for full production setups.
+
+</TabItem>
+<TabItem label="Binary">
 
 <Steps>
 
@@ -54,21 +94,11 @@ This guide takes you from zero to a running Autentico instance with a registered
 
 2. **Generate your configuration**
 
-   <Tabs>
-     <TabItem label="Development">
-     ```bash
-     ./autentico init --url http://localhost:9999
-     ```
-     </TabItem>
-     <TabItem label="Production">
-     ```bash
-     ./autentico init --url https://auth.example.com
-     ```
-     </TabItem>
-   </Tabs>
+   ```bash
+   ./autentico init --url http://localhost:9999
+   ```
 
-   This creates a `.env` file in the current directory containing a freshly generated RSA private key (base64-encoded), CSRF secret, and token signing secrets. You do not need a separate key file — everything is in `.env`.
-
+   This creates a `.env` file in the current directory with a freshly generated RSA key, CSRF secret, and token signing secrets.
 
 3. **Start the server**
 
@@ -96,7 +126,7 @@ This guide takes you from zero to a running Autentico instance with a registered
 
    <Tabs>
      <TabItem label="Browser">
-     Open `http://localhost:9999/onboard` in your browser. Fill in your administrator credentials to create the first account. Once complete, you are redirected to the Admin UI.
+     Open `http://localhost:9999/onboard` in your browser. Create the first administrator account. Once complete, you are redirected to the Admin UI.
      </TabItem>
      <TabItem label="CLI (CI/CD)">
      For automated deployments, create the admin account headlessly before starting the server:
@@ -112,9 +142,16 @@ This guide takes you from zero to a running Autentico instance with a registered
 
 5. **Done**
 
-   Autentico is running. From the Admin UI you can manage users, register OAuth2 clients, and configure settings. When you're ready to integrate, see [Registering clients](/clients/registering/) and the [Authorization Code + PKCE](/protocol/authorization-code/) flow.
+   Autentico is running. From the Admin UI you can manage users, register OAuth2 clients, and configure settings.
 
 </Steps>
+
+For production, replace `http://localhost:9999` with your public URL (e.g. `https://auth.example.com`).
+
+</TabItem>
+</Tabs>
+
+When you're ready to integrate, see [Registering clients](/clients/registering/) and the [Authorization Code + PKCE](/protocol/authorization-code/) flow.
 
 ## What's next?
 

--- a/docs-web/src/content/docs/getting-started/quickstart.mdx
+++ b/docs-web/src/content/docs/getting-started/quickstart.mdx
@@ -7,47 +7,7 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 Autentico is a single binary. There is no database to provision, no external services to start, and no multi-step infrastructure setup. The full process is: generate a `.env`, start the server, and complete onboarding in the browser.
 
-<Tabs>
-<TabItem label="Docker">
-
-<Steps>
-
-1. **Generate your configuration**
-
-   ```bash
-   docker run --rm -v $(pwd):/output ghcr.io/eugenioenko/autentico:latest \
-     init --output /output --url http://localhost:9999
-   ```
-
-   This creates a `.env` file in the current directory with a freshly generated RSA key, CSRF secret, and token signing secrets.
-
-2. **Start the server**
-
-   ```bash
-   docker run -d \
-     --name autentico \
-     -p 9999:9999 \
-     -v autentico-data:/data \
-     --env-file .env \
-     --restart unless-stopped \
-     ghcr.io/eugenioenko/autentico:latest \
-     start --auto-migrate
-   ```
-
-3. **Complete onboarding**
-
-   Open `http://localhost:9999/onboard` in your browser. Create the first administrator account. Once complete, you are redirected to the Admin UI.
-
-4. **Done**
-
-   Autentico is running. From the Admin UI you can manage users, register OAuth2 clients, and configure settings.
-
-</Steps>
-
-For production, replace `http://localhost:9999` with your public URL (e.g. `https://auth.example.com`). See [Docker deployment](/deployment/docker/) and [Docker Compose](/deployment/docker-compose/) for full production setups.
-
-</TabItem>
-<TabItem label="Binary">
+## Quickstart with Binary
 
 <Steps>
 
@@ -148,13 +108,47 @@ For production, replace `http://localhost:9999` with your public URL (e.g. `http
 
 For production, replace `http://localhost:9999` with your public URL (e.g. `https://auth.example.com`).
 
-</TabItem>
-</Tabs>
+## Quickstart with Docker
 
-When you're ready to integrate, see [Registering clients](/clients/registering/) and the [Authorization Code + PKCE](/protocol/authorization-code/) flow.
+<Steps>
+
+1. **Generate your configuration**
+
+   ```bash
+   docker run --rm -v $(pwd):/output ghcr.io/eugenioenko/autentico:latest \
+     init --output /output --url http://localhost:9999
+   ```
+
+   This creates a `.env` file in the current directory with a freshly generated RSA key, CSRF secret, and token signing secrets.
+
+2. **Start the server**
+
+   ```bash
+   docker run -d \
+     --name autentico \
+     -p 9999:9999 \
+     -v autentico-data:/data \
+     --env-file .env \
+     --restart unless-stopped \
+     ghcr.io/eugenioenko/autentico:latest \
+     start --auto-migrate
+   ```
+
+3. **Complete onboarding**
+
+   Open `http://localhost:9999/onboard` in your browser. Create the first administrator account. Once complete, you are redirected to the Admin UI.
+
+4. **Done**
+
+   Autentico is running. From the Admin UI you can manage users, register OAuth2 clients, and configure settings.
+
+</Steps>
+
+For production, replace `http://localhost:9999` with your public URL (e.g. `https://auth.example.com`). See [Docker deployment](/deployment/docker/) and [Docker Compose](/deployment/docker-compose/) for full production setups.
 
 ## What's next?
 
+- [Registering clients](/clients/registering/) — all registration options
+- [Authorization Code + PKCE](/protocol/authorization-code/) — integrate with your app
 - [Configuration reference](/configuration/overview/) — understand the three-layer config system
 - [Authentication modes](/authentication/overview/) — password, passkeys, MFA
-- [Registering clients](/clients/registering/) — all registration options


### PR DESCRIPTION
## Summary

- Restructured the quickstart page to show Docker first (two commands: `init` + `start`) instead of binary-only
- Replaced the verbose `docker run` example in the installation page (which required manually setting all env vars) with the simpler `init --output` + `--env-file` approach

## Test plan

- [ ] Verify quickstart page renders correctly with Docker/Binary tabs
- [ ] Verify installation page Docker tab renders correctly with Steps
- [ ] Test the Docker commands work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)