### PR TITLE
fix: redirect GET /oauth2/signup to /authorize?prompt=create (#201)

### DIFF
--- a/pkg/signup/handler.go
+++ b/pkg/signup/handler.go
@@ -46,6 +46,13 @@ func HandleSignup(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPost:
 		handleSignupPost(w, r)
+	case http.MethodGet:
+		// Back-compat: GET /oauth2/signup used to render the signup page directly.
+		// It was removed in favor of OIDC Core §3.1.2.1 prompt=create on /oauth2/authorize.
+		// Redirect with all query params preserved so existing client links keep working.
+		q := r.URL.Query()
+		q.Set("prompt", "create")
+		http.Redirect(w, r, config.GetBootstrap().AppOAuthPath+"/authorize?"+q.Encode(), http.StatusFound)
 	default:
 		utils.WriteErrorResponse(w, http.StatusMethodNotAllowed, "invalid_request", "Method not allowed")
 	}

--- a/pkg/signup/handler_test.go
+++ b/pkg/signup/handler_test.go
@@ -46,6 +46,28 @@ func TestHandleSignup_WrongMethod(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
 }
 
+func TestHandleSignup_Get_RedirectsToAuthorizePromptCreate(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Values.AuthAllowSelfSignup = true
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/signup?client_id=abc&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&state=xyz&code_challenge=c&code_challenge_method=S256", nil)
+	rr := httptest.NewRecorder()
+
+	HandleSignup(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+	loc := rr.Header().Get("Location")
+	assert.Contains(t, loc, "/oauth2/authorize?")
+	assert.Contains(t, loc, "prompt=create")
+	assert.Contains(t, loc, "client_id=abc")
+	assert.Contains(t, loc, "redirect_uri=http%3A%2F%2Flocalhost%2Fcb")
+	assert.Contains(t, loc, "state=xyz")
+	assert.Contains(t, loc, "code_challenge=c")
+	assert.Contains(t, loc, "code_challenge_method=S256")
+}
+
 func TestHandleSignup_Post_InvalidRedirectURI(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.WithConfigOverride(t, func() {


### PR DESCRIPTION
## Summary
- Redirects `GET /oauth2/signup` to `/oauth2/authorize?prompt=create`, preserving all query params (`client_id`, `redirect_uri`, `state`, `code_challenge`, etc.)
- Back-compat for early-adopter client apps with hardcoded links to the old GET route that was removed in 7429731 in favor of OIDC Core §3.1.2.1 `prompt=create`
- `allow_self_signup=false` still returns 404 (config gate runs before method switch); PUT/other methods still return 405

Fixes #201

## Test plan
- [x] `go test ./pkg/signup/...` — new `TestHandleSignup_Get_RedirectsToAuthorizePromptCreate` passes
- [x] Existing `TestHandleSignup_DisabledReturns404` (GET + disabled → 404) still passes
- [x] Existing `TestHandleSignup_WrongMethod` (PUT → 405) still passes
- [ ] Manual: `curl -i http://localhost:9999/oauth2/signup?client_id=test&redirect_uri=...` → 302 to `/oauth2/authorize?...&prompt=create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)