### PR TITLE
feat: expose post_logout_redirect_uris in admin UI client form (#197)

### DIFF
--- a/admin-ui/src/components/clients/ClientCreateForm.tsx
+++ b/admin-ui/src/components/clients/ClientCreateForm.tsx
@@ -128,6 +128,7 @@ export default function ClientCreateForm({
             token_endpoint_auth_method: "client_secret_basic",
             scopes: ["openid", "profile", "email", "offline_access"],
             redirect_uris: [""],
+            post_logout_redirect_uris: [],
           }}
         >
           <Form.Item
@@ -223,6 +224,53 @@ export default function ClientCreateForm({
                     Add Redirect URI
                   </Button>
                   <Form.ErrorList errors={errors} />
+                </Form.Item>
+              </>
+            )}
+          </Form.List>
+
+          <Form.List name="post_logout_redirect_uris">
+            {(fields, { add, remove }) => (
+              <>
+                {fields.map((field) => (
+                  <Form.Item
+                    key={field.key}
+                    label={field.name === 0 ? "Post-Logout Redirect URIs" : undefined}
+                    tooltip={field.name === 0 ? { title: tip("post_logout_redirect_uris"), icon: <ExclamationCircleOutlined /> } : undefined}
+                  >
+                    <Space.Compact style={{ width: "100%" }}>
+                      <Form.Item
+                        {...field}
+                        noStyle
+                        rules={[
+                          { required: true, message: "URI is required" },
+                          { type: "url", message: "Must be a valid URL" },
+                        ]}
+                      >
+                        <Input
+                          placeholder="https://example.com/logout-callback"
+                          style={{ width: "100%" }}
+                        />
+                      </Form.Item>
+                      <Button
+                        icon={<MinusCircleOutlined />}
+                        onClick={() => remove(field.name)}
+                      />
+                    </Space.Compact>
+                  </Form.Item>
+                ))}
+                <Form.Item
+                  label={fields.length === 0 ? "Post-Logout Redirect URIs" : undefined}
+                  tooltip={fields.length === 0 ? { title: tip("post_logout_redirect_uris"), icon: <ExclamationCircleOutlined /> } : undefined}
+                >
+                  <Button
+                    type="dashed"
+                    onClick={() => add()}
+                    block
+                    icon={<PlusOutlined />}
+                  >
+                    Add Post-Logout Redirect URI
+                  </Button>
                 </Form.Item>
               </>
             )}

--- a/admin-ui/src/components/clients/ClientDetail.tsx
+++ b/admin-ui/src/components/clients/ClientDetail.tsx
@@ -45,6 +45,17 @@ export default function ClientDetail({
             ))}
           </Space>
         </Descriptions.Item>
+        <Descriptions.Item label="Post-Logout Redirect URIs">
+          {client.post_logout_redirect_uris && client.post_logout_redirect_uris.length > 0 ? (
+            <Space direction="vertical" size={4}>
+              {client.post_logout_redirect_uris.map((uri) => (
+                <span key={uri}>{uri}</span>
+              ))}
+            </Space>
+          ) : (
+            <span style={{ color: "#999" }}>None</span>
+          )}
+        </Descriptions.Item>
         <Descriptions.Item label="Grant Types">
           <Space size={[0, 4]} wrap>
             {client.grant_types?.map((gt) => (

--- a/admin-ui/src/components/clients/ClientEditForm.tsx
+++ b/admin-ui/src/components/clients/ClientEditForm.tsx
@@ -68,6 +68,7 @@ export default function ClientEditForm({
       form.setFieldsValue({
         client_name: client.client_name,
         redirect_uris: client.redirect_uris,
+        post_logout_redirect_uris: client.post_logout_redirect_uris ?? [],
         grant_types: client.grant_types,
         response_types: client.response_types,
         scopes: client.scopes?.split(" ").filter(Boolean) ?? [],
@@ -176,6 +177,50 @@ export default function ClientEditForm({
                   Add Redirect URI
                 </Button>
                 <Form.ErrorList errors={errors} />
+              </Form.Item>
+            </>
+          )}
+        </Form.List>
+
+        <Form.List name="post_logout_redirect_uris">
+          {(fields, { add, remove }) => (
+            <>
+              {fields.map((field) => (
+                <Form.Item
+                  key={field.key}
+                  label={field.name === 0 ? "Post-Logout Redirect URIs" : undefined}
+                  tooltip={field.name === 0 ? { title: tip("post_logout_redirect_uris"), icon: <ExclamationCircleOutlined /> } : undefined}
+                >
+                  <Space.Compact style={{ width: "100%" }}>
+                    <Form.Item
+                      {...field}
+                      noStyle
+                      rules={[
+                        { required: true, message: "URI is required" },
+                        { type: "url", message: "Must be a valid URL" },
+                      ]}
+                    >
+                      <Input style={{ width: "100%" }} />
+                    </Form.Item>
+                    <Button
+                      icon={<MinusCircleOutlined />}
+                      onClick={() => remove(field.name)}
+                    />
+                  </Space.Compact>
+                </Form.Item>
+              ))}
+              <Form.Item
+                label={fields.length === 0 ? "Post-Logout Redirect URIs" : undefined}
+                tooltip={fields.length === 0 ? { title: tip("post_logout_redirect_uris"), icon: <ExclamationCircleOutlined /> } : undefined}
+              >
+                <Button
+                  type="dashed"
+                  onClick={() => add()}
+                  block
+                  icon={<PlusOutlined />}
+                >
+                  Add Post-Logout Redirect URI
+                </Button>
               </Form.Item>
             </>
           )}

--- a/admin-ui/src/components/clients/clientTips.ts
+++ b/admin-ui/src/components/clients/clientTips.ts
@@ -7,6 +7,7 @@ export const tip = makeTip({
   client_type: "Confidential: server-side apps that can keep a secret. Public: browser or mobile apps that cannot — no secret is issued, use PKCE instead.",
   client_secret: "Optional. If left empty, a secret is auto-generated. Only shown once after creation.",
   redirect_uris: "Allowed callback URLs. The redirect_uri in each authorization request must exactly match one of these. No wildcards, max 10.",
+  post_logout_redirect_uris: "Allowed URLs for OIDC RP-initiated logout. The post_logout_redirect_uri in a logout request must exactly match one of these. Optional — leave empty to disable RP-initiated logout redirects.",
   grant_types: "OAuth2 flows this client is permitted to use.",
   response_types: "What the authorization endpoint returns. Use [code] for the standard Authorization Code flow.",
   scopes: "Scopes the client is allowed to request. Standard: openid, profile, email, address, phone, offline_access.",


### PR DESCRIPTION
## Summary
- Adds `post_logout_redirect_uris` as an optional dynamic list in `ClientCreateForm` and `ClientEditForm` (same pattern as `redirect_uris`)
- Renders the field in `ClientDetail` (shows "None" when empty)
- Adds a tooltip entry in `clientTips.ts`

Backend, DB, and generated types already supported `post_logout_redirect_uris` — this wires up the admin UI so clients can be configured without hitting the API directly.

Fixes #197

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Create a new client with 0, 1, and 2 post-logout URIs — verify they round-trip
- [ ] Edit an existing client to add/remove URIs — verify update persists
- [ ] Detail drawer shows "None" for clients with no URIs and a list otherwise
- [ ] RP-initiated logout with a matching `post_logout_redirect_uri` still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)