### PR TITLE
fix: validate duration settings on save (#126)

### DIFF
--- a/pkg/appsettings/handler.go
+++ b/pkg/appsettings/handler.go
@@ -2,7 +2,9 @@ package appsettings
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/eugenioenko/autentico/pkg/audit"
@@ -10,6 +12,43 @@ import (
 	"github.com/eugenioenko/autentico/pkg/user"
 	"github.com/eugenioenko/autentico/pkg/utils"
 )
+
+// durationSettings lists keys whose values must parse as Go durations
+// (time.ParseDuration). Values in the slice are non-duration strings that
+// are also accepted — e.g. "0" and "-1" on audit_log_retention mean
+// "disabled" and "keep forever" respectively.
+var durationSettings = map[string][]string{
+	"access_token_expiration":       nil,
+	"refresh_token_expiration":      nil,
+	"authorization_code_expiration": nil,
+	"sso_session_idle_timeout":      {"", "0"},
+	"account_lockout_duration":      nil,
+	"trust_device_expiration":       nil,
+	"cleanup_interval":              nil,
+	"cleanup_retention":             nil,
+	"email_verification_expiration": nil,
+	"password_reset_expiration":     nil,
+	"audit_log_retention":           {"", "0", "-1"},
+}
+
+// validateDurationSettings returns an error if any duration-typed setting
+// in updates has a value that neither parses as a Go duration nor matches
+// one of its allowed special values.
+func validateDurationSettings(updates map[string]string) error {
+	for k, allowed := range durationSettings {
+		v, ok := updates[k]
+		if !ok {
+			continue
+		}
+		if slices.Contains(allowed, v) {
+			continue
+		}
+		if _, err := time.ParseDuration(v); err != nil {
+			return fmt.Errorf("setting %q has invalid duration %q (expected a Go duration like 15m, 1h, 24h)", k, v)
+		}
+	}
+	return nil
+}
 
 // HandleGetSettings godoc
 // @Summary Get system settings
@@ -53,6 +92,11 @@ func HandlePutSettings(w http.ResponseWriter, r *http.Request) {
 		if protected[k] {
 			delete(updates, k)
 		}
+	}
+
+	if err := validateDurationSettings(updates); err != nil {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
 	}
 
 	for k, v := range updates {
@@ -169,6 +213,11 @@ func HandleImportApply(w http.ResponseWriter, r *http.Request) {
 	}
 
 	protected := map[string]bool{"onboarded": true, "private_key": true}
+
+	if err := validateDurationSettings(payload.Settings); err != nil {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
 
 	for k, v := range payload.Settings {
 		if protected[k] {

--- a/pkg/appsettings/handler_test.go
+++ b/pkg/appsettings/handler_test.go
@@ -50,6 +50,32 @@ func TestHandlePutSettings(t *testing.T) {
 	})
 }
 
+func TestHandlePutSettings_InvalidDuration(t *testing.T) {
+	testutils.WithTestDB(t)
+	body := `{"access_token_expiration": "30d"}`
+	req := httptest.NewRequest(http.MethodPut, "/admin/api/settings", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	HandlePutSettings(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "access_token_expiration")
+
+	// The invalid value must not have been persisted.
+	val, _ := GetSetting("access_token_expiration")
+	assert.NotEqual(t, "30d", val)
+}
+
+func TestHandlePutSettings_AuditLogRetentionSpecialValues(t *testing.T) {
+	testutils.WithTestDB(t)
+	for _, v := range []string{"0", "-1", "168h"} {
+		body := `{"audit_log_retention": "` + v + `"}`
+		req := httptest.NewRequest(http.MethodPut, "/admin/api/settings", strings.NewReader(body))
+		rr := httptest.NewRecorder()
+		HandlePutSettings(rr, req)
+		assert.Equal(t, http.StatusNoContent, rr.Code, "value %q should be accepted", v)
+	}
+}
+
 func TestHandlePutSettings_InvalidJSON(t *testing.T) {
 	testutils.WithTestDB(t)
 	req := httptest.NewRequest(http.MethodPut, "/admin/api/settings", bytes.NewBufferString("{invalid"))


### PR DESCRIPTION
## Summary
- Adds \`validateDurationSettings()\` to \`pkg/appsettings/handler.go\` that rejects invalid Go durations before they are persisted
- Wires it into both \`HandlePutSettings\` and \`HandleImportApply\`, returning 400 with a message naming the offending key and value
- \`audit_log_retention\` still accepts \`"0"\` (disabled) and \`"-1"\` (keep forever); \`sso_session_idle_timeout\` still accepts \`""\` and \`"0"\`
- Tests for invalid duration (rejected), special values (accepted), and the existing happy-path

## Why
Previously, invalid values like \`30d\` (not a valid Go duration — Go only goes up to \`h\`) were silently accepted, then swallowed by \`config.ParseDuration\`'s fallback behavior. This broke audit log retention: the setting turned logging on but the cleanup goroutine couldn't parse the duration, so nothing was ever purged.

Fixes #126

## Test plan
- [x] \`go test ./pkg/appsettings/...\` passes
- [x] New \`TestHandlePutSettings_InvalidDuration\` — \`30d\` rejected with 400, value not persisted
- [x] New \`TestHandlePutSettings_AuditLogRetentionSpecialValues\` — \`0\`, \`-1\`, \`168h\` all accepted
- [x] Existing \`TestHandlePutSettings\` (valid \`60m\`) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)