### PR TITLE
feat: password validation hints and regex pattern support (#159)

### DIFF
--- a/admin-ui/src/pages/SettingsPage.tsx
+++ b/admin-ui/src/pages/SettingsPage.tsx
@@ -61,6 +61,8 @@ const tip = makeTip({
   validation_max_username_length: "Maximum length for usernames.",
   validation_min_password_length: "Minimum length for passwords.",
   validation_max_password_length: "Maximum length for passwords.",
+  validation_password_pattern: "Optional regex pattern (Go syntax) that passwords must match. Example: ^(?=.*[A-Z])(?=.*\\d).+$ requires at least one uppercase letter and one digit. Leave empty to disable.",
+  validation_password_hint: "Human-readable hint shown as a browser tooltip when the password regex fails. Example: 'Must contain an uppercase letter and a digit.' Ignored if pattern is empty.",
   account_lockout_max_attempts: "Maximum number of failed login attempts before account lockout. 0 to disable.",
   account_lockout_duration: "Duration of account lockout (e.g. 15m).",
   audit_log_retention: "How long audit events are kept. 0 = disabled, -1 = keep forever, or a duration (e.g. 720h for 30 days).",
@@ -437,6 +439,20 @@ export default function SettingsPage() {
                       <InputNumber min={1} />
                     </Form.Item>
                   </Space>
+                  <Form.Item
+                    label="Password Pattern (regex)"
+                    name="validation_password_pattern"
+                    tooltip={{ title: tip("validation_password_pattern"), icon: <ExclamationCircleOutlined /> }}
+                  >
+                    <Input placeholder="^(?=.*[A-Z])(?=.*\d).+$" />
+                  </Form.Item>
+                  <Form.Item
+                    label="Password Hint"
+                    name="validation_password_hint"
+                    tooltip={{ title: tip("validation_password_hint"), icon: <ExclamationCircleOutlined /> }}
+                  >
+                    <Input placeholder="Must contain an uppercase letter and a digit." />
+                  </Form.Item>
 
                   <Divider />
 

--- a/pkg/appsettings/handler.go
+++ b/pkg/appsettings/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"slices"
 	"time"
 
@@ -29,6 +30,19 @@ var durationSettings = map[string][]string{
 	"email_verification_expiration": nil,
 	"password_reset_expiration":     nil,
 	"audit_log_retention":           {"", "0", "-1"},
+}
+
+// validatePasswordPattern returns an error if validation_password_pattern is
+// present in updates and is not a valid Go regexp.
+func validatePasswordPattern(updates map[string]string) error {
+	v, ok := updates["validation_password_pattern"]
+	if !ok || v == "" {
+		return nil
+	}
+	if _, err := regexp.Compile(v); err != nil {
+		return fmt.Errorf("setting \"validation_password_pattern\" is not a valid regex: %v", err)
+	}
+	return nil
 }
 
 // validateDurationSettings returns an error if any duration-typed setting
@@ -95,6 +109,10 @@ func HandlePutSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := validateDurationSettings(updates); err != nil {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if err := validatePasswordPattern(updates); err != nil {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
 	}
@@ -215,6 +233,10 @@ func HandleImportApply(w http.ResponseWriter, r *http.Request) {
 	protected := map[string]bool{"onboarded": true, "private_key": true}
 
 	if err := validateDurationSettings(payload.Settings); err != nil {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if err := validatePasswordPattern(payload.Settings); err != nil {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
 	}

--- a/pkg/appsettings/load.go
+++ b/pkg/appsettings/load.go
@@ -21,6 +21,8 @@ var defaults = map[string]string{
 	"validation_max_username_length": "64",
 	"validation_min_password_length": "6",
 	"validation_max_password_length": "64",
+	"validation_password_pattern":    "",
+	"validation_password_hint":       "",
 	"account_lockout_max_attempts":   "5",
 	"account_lockout_duration":       "15m",
 	"auth_mode":                      "password",
@@ -132,6 +134,12 @@ func LoadIntoConfig() error {
 		if n, err := strconv.Atoi(v); err == nil {
 			cfg.ValidationMaxPasswordLength = n
 		}
+	}
+	if v, ok := all["validation_password_pattern"]; ok {
+		cfg.ValidationPasswordPattern = v
+	}
+	if v, ok := all["validation_password_hint"]; ok {
+		cfg.ValidationPasswordHint = v
 	}
 	if v, ok := all["allow_self_service_deletion"]; ok {
 		cfg.AllowSelfServiceDeletion = parseBool(v, false)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -101,6 +101,8 @@ type Config struct {
 	ValidationMaxUsernameLength        int
 	ValidationMinPasswordLength        int
 	ValidationMaxPasswordLength        int
+	ValidationPasswordPattern          string // optional regex; if non-empty, password must match
+	ValidationPasswordHint             string // human-readable hint shown in browser validation tooltip
 	Theme                              ThemeConfig
 	ThemeCssResolved                   string
 	// When true, users can delete their own account immediately without admin approval.
@@ -168,6 +170,8 @@ var defaultConfig = Config{
 	ValidationMaxUsernameLength:        64,
 	ValidationMinPasswordLength:        6,
 	ValidationMaxPasswordLength:        64,
+	ValidationPasswordPattern:          "",
+	ValidationPasswordHint:             "",
 	Theme:                              ThemeConfig{Title: "Autentico"},
 	AllowSelfServiceDeletion:           false,
 	AllowUsernameChange:                false,

--- a/pkg/onboarding/handler.go
+++ b/pkg/onboarding/handler.go
@@ -117,13 +117,17 @@ func renderOnboard(w http.ResponseWriter, r *http.Request, params onboardParams,
 	}
 
 	data := map[string]any{
-		"FormAction":        params.FormAction,
-		"Error":             errMsg,
-		"ProfileFieldEmail": cfg.ProfileFieldEmail,
-		csrf.TemplateTag:    csrf.TemplateField(r),
-		"ThemeTitle":        cfg.Theme.Title,
-		"ThemeLogoUrl":      cfg.Theme.LogoUrl,
-		"ThemeCssResolved":  template.CSS(cfg.ThemeCssResolved),
+		"FormAction":            params.FormAction,
+		"Error":                 errMsg,
+		"ProfileFieldEmail":     cfg.ProfileFieldEmail,
+		csrf.TemplateTag:        csrf.TemplateField(r),
+		"ThemeTitle":            cfg.Theme.Title,
+		"ThemeLogoUrl":          cfg.Theme.LogoUrl,
+		"ThemeCssResolved":      template.CSS(cfg.ThemeCssResolved),
+		"PasswordMinLength":     cfg.ValidationMinPasswordLength,
+		"PasswordMaxLength":     cfg.ValidationMaxPasswordLength,
+		"PasswordPattern":       cfg.ValidationPasswordPattern,
+		"PasswordHint":          cfg.ValidationPasswordHint,
 	}
 
 	if err = tmpl.ExecuteTemplate(w, "layout", data); err != nil {

--- a/pkg/passwordreset/handler.go
+++ b/pkg/passwordreset/handler.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"regexp"
 	"time"
 
 	"github.com/eugenioenko/autentico/pkg/audit"
@@ -94,6 +95,10 @@ func renderResetPassword(w http.ResponseWriter, r *http.Request, mode, token str
 		"ThemeLogoUrl":        cfg.Theme.LogoUrl,
 		"ThemeCssResolved":    template.CSS(cfg.ThemeCssResolved),
 		csrf.TemplateTag:      csrf.TemplateField(r),
+		"PasswordMinLength":   cfg.ValidationMinPasswordLength,
+		"PasswordMaxLength":   cfg.ValidationMaxPasswordLength,
+		"PasswordPattern":     cfg.ValidationPasswordPattern,
+		"PasswordHint":        cfg.ValidationPasswordHint,
 	}
 	if err = tmpl.ExecuteTemplate(w, "layout", data); err != nil {
 		http.Error(w, "Template Execution Error", http.StatusInternalServerError)
@@ -230,6 +235,16 @@ func HandleResetPassword(w http.ResponseWriter, r *http.Request) {
 	if len(password) > cfg.ValidationMaxPasswordLength {
 		renderResetPassword(w, r, "form", rawToken, params, "Password is too long.")
 		return
+	}
+	if cfg.ValidationPasswordPattern != "" {
+		if re, err := regexp.Compile(cfg.ValidationPasswordPattern); err == nil && !re.MatchString(password) {
+			hint := cfg.ValidationPasswordHint
+			if hint == "" {
+				hint = "Password does not meet the required format."
+			}
+			renderResetPassword(w, r, "form", rawToken, params, hint)
+			return
+		}
 	}
 
 	// Look up and validate the token

--- a/pkg/signup/handler.go
+++ b/pkg/signup/handler.go
@@ -292,6 +292,10 @@ func RenderSignup(w http.ResponseWriter, r *http.Request, params SignupParams, e
 		"ProfileFieldPicture":    cfg.ProfileFieldPicture,
 		"ProfileFieldLocale":     cfg.ProfileFieldLocale,
 		"ProfileFieldAddress":    cfg.ProfileFieldAddress,
+		"PasswordMinLength":      cfg.ValidationMinPasswordLength,
+		"PasswordMaxLength":      cfg.ValidationMaxPasswordLength,
+		"PasswordPattern":        cfg.ValidationPasswordPattern,
+		"PasswordHint":           cfg.ValidationPasswordHint,
 	}
 
 	if err = tmpl.ExecuteTemplate(w, "layout", data); err != nil {

--- a/pkg/user/model.go
+++ b/pkg/user/model.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/eugenioenko/autentico/pkg/config"
@@ -10,6 +11,30 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation"
 	"github.com/go-ozzo/ozzo-validation/is"
 )
+
+// validatePasswordPattern enforces the configured regex (if any) on a password.
+// The hint is returned in the error so the caller can surface exactly what the
+// browser-side tooltip also says.
+func validatePasswordPattern(password string) error {
+	pattern := config.Get().ValidationPasswordPattern
+	if pattern == "" {
+		return nil
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		// Settings validation should have caught this; ignore silently
+		// to avoid blocking login-adjacent flows on a bad config.
+		return nil
+	}
+	if !re.MatchString(password) {
+		hint := config.Get().ValidationPasswordHint
+		if hint == "" {
+			hint = "password does not meet the required format"
+		}
+		return fmt.Errorf("password is invalid: %s", hint)
+	}
+	return nil
+}
 
 type User struct {
 	ID                  string
@@ -200,6 +225,9 @@ func ValidateUserUpdateRequest(input UserUpdateRequest) error {
 		if err := validation.Validate(input.Password, validation.Length(config.Get().ValidationMinPasswordLength, config.Get().ValidationMaxPasswordLength)); err != nil {
 			return fmt.Errorf("password is invalid: %w", err)
 		}
+		if err := validatePasswordPattern(input.Password); err != nil {
+			return err
+		}
 	}
 	if input.Email != "" {
 		if err := validation.Validate(input.Email, is.Email); err != nil {
@@ -247,6 +275,9 @@ func ValidateUserCreateRequest(input UserCreateRequest) error {
 	)
 	if err != nil {
 		return fmt.Errorf("password is invalid: %w", err)
+	}
+	if err := validatePasswordPattern(input.Password); err != nil {
+		return err
 	}
 
 	if config.Get().ProfileFieldEmail == "required" || input.Email != "" {

--- a/view/onboard.html
+++ b/view/onboard.html
@@ -28,11 +28,11 @@
   {{end}}
   <div class="auth-field">
     <label class="auth-label" for="password">Administrator Password</label>
-    <input class="auth-input" type="password" id="password" name="password" required autocomplete="new-password" minlength="6" maxlength="64" />
+    <input class="auth-input" type="password" id="password" name="password" required autocomplete="new-password" minlength="{{.PasswordMinLength}}" maxlength="{{.PasswordMaxLength}}"{{if .PasswordPattern}} pattern="{{.PasswordPattern}}"{{end}}{{if .PasswordHint}} title="{{.PasswordHint}}"{{end}} />
   </div>
   <div class="auth-field">
     <label class="auth-label" for="confirm_password">Confirm Password</label>
-    <input class="auth-input" type="password" id="confirm_password" name="confirm_password" required autocomplete="new-password" />
+    <input class="auth-input" type="password" id="confirm_password" name="confirm_password" required autocomplete="new-password" minlength="{{.PasswordMinLength}}" maxlength="{{.PasswordMaxLength}}" />
   </div>
   {{if .Error}}
   <div class="auth-error" role="alert">{{.Error}}</div>

--- a/view/reset_password.html
+++ b/view/reset_password.html
@@ -36,11 +36,11 @@
   <input type="hidden" name="code_challenge_method" value="{{.CodeChallengeMethod}}" />
   <div class="auth-field">
     <label class="auth-label" for="password">New Password</label>
-    <input class="auth-input" type="password" id="password" name="password" required autocomplete="new-password" />
+    <input class="auth-input" type="password" id="password" name="password" required autocomplete="new-password" minlength="{{.PasswordMinLength}}" maxlength="{{.PasswordMaxLength}}"{{if .PasswordPattern}} pattern="{{.PasswordPattern}}"{{end}}{{if .PasswordHint}} title="{{.PasswordHint}}"{{end}} />
   </div>
   <div class="auth-field">
     <label class="auth-label" for="confirm_password">Confirm Password</label>
-    <input class="auth-input" type="password" id="confirm_password" name="confirm_password" required autocomplete="new-password" />
+    <input class="auth-input" type="password" id="confirm_password" name="confirm_password" required autocomplete="new-password" minlength="{{.PasswordMinLength}}" maxlength="{{.PasswordMaxLength}}" />
   </div>
   <button class="auth-btn" type="submit">Reset password</button>
 </form>

--- a/view/signup.html
+++ b/view/signup.html
@@ -76,11 +76,11 @@
   <div id="password-fields">
     <div class="auth-field">
       <label class="auth-label" for="password">Password</label>
-      <input class="auth-input" type="password" id="password" name="password" required autocomplete="new-password" />
+      <input class="auth-input" type="password" id="password" name="password" required autocomplete="new-password" minlength="{{.PasswordMinLength}}" maxlength="{{.PasswordMaxLength}}"{{if .PasswordPattern}} pattern="{{.PasswordPattern}}"{{end}}{{if .PasswordHint}} title="{{.PasswordHint}}"{{end}} />
     </div>
     <div class="auth-field">
       <label class="auth-label" for="confirm_password">Confirm Password</label>
-      <input class="auth-input" type="password" id="confirm_password" name="confirm_password" required autocomplete="new-password" />
+      <input class="auth-input" type="password" id="confirm_password" name="confirm_password" required autocomplete="new-password" minlength="{{.PasswordMinLength}}" maxlength="{{.PasswordMaxLength}}" />
     </div>
   </div>
   {{end}}


### PR DESCRIPTION
## Summary
- New settings \`validation_password_pattern\` (Go regexp) and \`validation_password_hint\` (human-readable tooltip text), exposed in the admin UI Settings page
- On signup / onboard / password reset forms, the password \`<input>\` now gets HTML5 \`minlength\`, \`maxlength\`, \`pattern\`, and \`title\` attributes — browser shows a native tooltip on invalid submit, no JS
- Server-side validation enforces the same rules as defense in depth (\`pkg/user/model.go\`, \`pkg/passwordreset/handler.go\`)
- Admin settings save rejects an invalid regex with 400 so a typo can't lock users out

## Base branch
Depends on #204 (duration validator refactor) — stacked on \`fix/validate-duration-settings\`. Rebase to \`main\` after that lands.

Fixes #159

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/{user,appsettings,passwordreset,onboarding,signup}/...\` passes
- [x] \`tsc --noEmit\` clean on admin-ui
- [ ] Manual: set pattern \`^(?=.*[A-Z])(?=.*\\d).+$\` + hint, sign up with a weak password → browser tooltip appears
- [ ] Manual: submit an invalid regex via settings → 400 with clear error
- [ ] Manual: with no pattern set, signup behaves as today

🤖 Generated with [Claude Code](https://claude.com/claude-code)