### PR TITLE
fix: load .env from db directory when not found in CWD

### DIFF
--- a/docs-web/src/content/docs/configuration/bootstrap.mdx
+++ b/docs-web/src/content/docs/configuration/bootstrap.mdx
@@ -7,6 +7,8 @@ import { Aside } from '@astrojs/starlight/components';
 
 Bootstrap settings are loaded once at startup from the `.env` file (or OS environment variables if no `.env` is present). Changing any of these requires restarting the server.
 
+Autentico looks for `.env` in the current working directory first, then falls back to `./db/.env` (where `--auto-setup` writes it for Docker volume persistence).
+
 Generate a `.env` with secure defaults:
 
 ```bash

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"net/url"
 	"os"
-	"path/filepath"
 	"strconv"
 	"time"
 
@@ -237,16 +236,11 @@ func ParseDuration(s string, fallback time.Duration) time.Duration {
 func InitBootstrap() {
 	_ = godotenv.Load() // silent if no .env file in CWD
 
-	// Fallback: check for .env next to the database file (e.g. ./db/.env),
-	// which is where --auto-setup writes it for Docker volume persistence.
+	// Fallback: check for .env in ./db/, which is where --auto-setup
+	// writes it for Docker volume persistence.
 	if _, err := os.Stat(".env"); err != nil {
-		dbFilePath := os.Getenv("AUTENTICO_DB_FILE_PATH")
-		if dbFilePath == "" {
-			dbFilePath = "./db/autentico.db"
-		}
-		dbEnv := filepath.Join(filepath.Dir(dbFilePath), ".env")
-		if _, err := os.Stat(dbEnv); err == nil {
-			_ = godotenv.Load(dbEnv)
+		if _, err := os.Stat("./db/.env"); err == nil {
+			_ = godotenv.Load("./db/.env")
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -234,7 +235,20 @@ func ParseDuration(s string, fallback time.Duration) time.Duration {
 // OS env) and populates Bootstrap. AppDomain, AppHost, AppPort and AppAuthIssuer
 // are derived from AppURL — they do not need to be set manually.
 func InitBootstrap() {
-	_ = godotenv.Load() // silent if no .env file
+	_ = godotenv.Load() // silent if no .env file in CWD
+
+	// Fallback: check for .env next to the database file (e.g. ./db/.env),
+	// which is where --auto-setup writes it for Docker volume persistence.
+	if _, err := os.Stat(".env"); err != nil {
+		dbFilePath := os.Getenv("AUTENTICO_DB_FILE_PATH")
+		if dbFilePath == "" {
+			dbFilePath = "./db/autentico.db"
+		}
+		dbEnv := filepath.Join(filepath.Dir(dbFilePath), ".env")
+		if _, err := os.Stat(dbEnv); err == nil {
+			_ = godotenv.Load(dbEnv)
+		}
+	}
 
 	appURL := getEnv("AUTENTICO_APP_URL", "http://localhost:9999")
 	oauthPath := getEnv("AUTENTICO_APP_OAUTH_PATH", "/oauth2")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -234,14 +234,11 @@ func ParseDuration(s string, fallback time.Duration) time.Duration {
 // OS env) and populates Bootstrap. AppDomain, AppHost, AppPort and AppAuthIssuer
 // are derived from AppURL — they do not need to be set manually.
 func InitBootstrap() {
-	_ = godotenv.Load() // silent if no .env file in CWD
-
-	// Fallback: check for .env in ./db/, which is where --auto-setup
-	// writes it for Docker volume persistence.
-	if _, err := os.Stat(".env"); err != nil {
-		if _, err := os.Stat("./db/.env"); err == nil {
-			_ = godotenv.Load("./db/.env")
-		}
+	// Load .env: prefer CWD, fall back to ./db/.env (where --auto-setup writes it).
+	if _, err := os.Stat(".env"); err == nil {
+		_ = godotenv.Load(".env")
+	} else if _, err := os.Stat("./db/.env"); err == nil {
+		_ = godotenv.Load("./db/.env")
 	}
 
 	appURL := getEnv("AUTENTICO_APP_URL", "http://localhost:9999")


### PR DESCRIPTION
## Summary
- Fix `--auto-setup` generating `.env` in `./db/` but subsequent runs without `--auto-setup` not finding it
- `InitBootstrap` now falls back to checking for `.env` next to the database file when none exists in CWD
- Works for both Docker (where `./db/` is a persistent volume) and local development

## Context
`--auto-setup` intentionally writes `.env` to the database directory (`./db/.env`) so it persists in Docker volumes. But `godotenv.Load()` only looks in CWD, so running `autentico start` (without `--auto-setup`) couldn't find the config.

## Test plan
- [ ] `./autentico start --auto-setup` — generates `./db/.env`, starts successfully
- [ ] `./autentico start` (second run, no flag) — loads `./db/.env`, starts successfully
- [ ] With `.env` in CWD — still takes precedence over `./db/.env`
- [ ] Docker: `docker run` with volume on `/app/db` — config persists across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)