### PR TITLE
docs: run Docker in foreground for quickstart examples

### DIFF
--- a/docs-web/public/llms.txt
+++ b/docs-web/public/llms.txt
@@ -557,11 +557,9 @@ WantedBy=multi-user.target
 ### Docker
 
 ```bash
-docker run -d \
-  --name autentico \
+docker run --rm \
   -p 9999:9999 \
   -v autentico-data:/app/data \
-  --restart unless-stopped \
   ghcr.io/eugenioenko/autentico:latest \
   start --auto-setup
 ```

--- a/docs-web/public/llms.txt
+++ b/docs-web/public/llms.txt
@@ -557,11 +557,8 @@ WantedBy=multi-user.target
 ### Docker
 
 ```bash
-docker run --rm \
-  -p 9999:9999 \
-  -v autentico-data:/app/data \
-  ghcr.io/eugenioenko/autentico:latest \
-  start --auto-setup
+docker run -p 9999:9999 -v autentico-data:/app/data \
+  ghcr.io/eugenioenko/autentico:latest start --auto-setup
 ```
 
 For a custom URL: add `-e AUTENTICO_APP_URL=https://auth.example.com`.

--- a/docs-web/src/content/docs/getting-started/installation.mdx
+++ b/docs-web/src/content/docs/getting-started/installation.mdx
@@ -68,11 +68,9 @@ autentico start
 ## Docker
 
 ```bash
-docker run -d \
-  --name autentico \
+docker run --rm \
   -p 9999:9999 \
   -v autentico-data:/app/data \
-  --restart unless-stopped \
   ghcr.io/eugenioenko/autentico:latest \
   start --auto-setup
 ```
@@ -82,12 +80,10 @@ The `--auto-setup` flag generates a `.env` with fresh secrets on first run and r
 For a custom URL, pass it via environment variable:
 
 ```bash
-docker run -d \
-  --name autentico \
+docker run --rm \
   -p 9999:9999 \
   -v autentico-data:/app/data \
   -e AUTENTICO_APP_URL=https://auth.example.com \
-  --restart unless-stopped \
   ghcr.io/eugenioenko/autentico:latest \
   start --auto-setup
 ```

--- a/docs-web/src/content/docs/getting-started/installation.mdx
+++ b/docs-web/src/content/docs/getting-started/installation.mdx
@@ -68,11 +68,8 @@ autentico start
 ## Docker
 
 ```bash
-docker run --rm \
-  -p 9999:9999 \
-  -v autentico-data:/app/data \
-  ghcr.io/eugenioenko/autentico:latest \
-  start --auto-setup
+docker run -p 9999:9999 -v autentico-data:/app/data \
+  ghcr.io/eugenioenko/autentico:latest start --auto-setup
 ```
 
 The `--auto-setup` flag generates a `.env` with fresh secrets on first run and reuses it on restarts. The volume at `/app/data` persists both the database and the generated configuration.
@@ -80,12 +77,9 @@ The `--auto-setup` flag generates a `.env` with fresh secrets on first run and r
 For a custom URL, pass it via environment variable:
 
 ```bash
-docker run --rm \
-  -p 9999:9999 \
-  -v autentico-data:/app/data \
+docker run -p 9999:9999 -v autentico-data:/app/data \
   -e AUTENTICO_APP_URL=https://auth.example.com \
-  ghcr.io/eugenioenko/autentico:latest \
-  start --auto-setup
+  ghcr.io/eugenioenko/autentico:latest start --auto-setup
 ```
 
 See [Docker Compose](/deployment/docker-compose/) for production setups with reverse proxy and SMTP.

--- a/docs-web/src/content/docs/getting-started/quickstart.mdx
+++ b/docs-web/src/content/docs/getting-started/quickstart.mdx
@@ -21,11 +21,8 @@ chmod +x autentico
 <TabItem label="Docker">
 
 ```bash
-docker run --rm \
-  -p 9999:9999 \
-  -v autentico-data:/app/data \
-  ghcr.io/eugenioenko/autentico:latest \
-  start --auto-setup
+docker run -p 9999:9999 -v autentico-data:/app/data \
+  ghcr.io/eugenioenko/autentico:latest start --auto-setup
 ```
 
 </TabItem>

--- a/docs-web/src/content/docs/getting-started/quickstart.mdx
+++ b/docs-web/src/content/docs/getting-started/quickstart.mdx
@@ -21,11 +21,9 @@ chmod +x autentico
 <TabItem label="Docker">
 
 ```bash
-docker run -d \
-  --name autentico \
+docker run --rm \
   -p 9999:9999 \
   -v autentico-data:/app/data \
-  --restart unless-stopped \
   ghcr.io/eugenioenko/autentico:latest \
   start --auto-setup
 ```


### PR DESCRIPTION
## Summary
- Remove `-d` from quickstart and installation Docker examples so users see startup output
- Use `--rm` instead of `--name`/`--restart` for quickstart simplicity
- Production `deployment/docker.mdx` keeps `-d` (expected for production)

## Test plan
- [ ] Verify quickstart Docker command shows server output in terminal
- [ ] Ctrl+C stops the container cleanly