### PR TITLE
feat: include email claims in ID token when email scope is requested

### DIFF
--- a/pkg/token/generate.go
+++ b/pkg/token/generate.go
@@ -176,9 +176,13 @@ func GenerateIDToken(user user.User, sessionID string, nonce string, scope strin
 		}
 	}
 
-	// Email claims are intentionally excluded from the id_token.
-	// Per OIDC Core §5.4, scope=email grants access to email via the userinfo endpoint;
-	// it does not require email to be present in the id_token.
+	// OIDC Core §5.4: the AS MAY return email claims in the ID token when the
+	// "email" scope was requested, even if they are also available via UserInfo.
+	// Many RPs rely on ID token claims without calling UserInfo, so we include them here.
+	if containsScope(scope, "email") {
+		claims["email"] = user.Email
+		claims["email_verified"] = user.IsEmailVerified
+	}
 
 	idToken := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	idToken.Header["kid"] = bs.AuthJwkCertKeyID

--- a/pkg/token/generate_test.go
+++ b/pkg/token/generate_test.go
@@ -41,9 +41,10 @@ func TestGenerateIDToken_WithNonce(t *testing.T) {
 	config.Bootstrap.AppAuthIssuer = "http://localhost/oauth2"
 
 	testUser := user.User{
-		ID:       "user-1",
-		Username: "testuser",
-		Email:    "testuser@example.com",
+		ID:              "user-1",
+		Username:        "testuser",
+		Email:           "testuser@example.com",
+		IsEmailVerified: true,
 	}
 
 	idToken, err := GenerateIDToken(testUser, "session-1", "test-nonce-123", "openid profile email", "my-client", time.Now(), "fake-access-token")
@@ -60,8 +61,8 @@ func TestGenerateIDToken_WithNonce(t *testing.T) {
 	assert.Equal(t, "session-1", claims["sid"])
 	assert.Equal(t, "testuser", claims["name"])
 	assert.Equal(t, "testuser", claims["preferred_username"])
-	assert.Nil(t, claims["email"], "email must not be in id_token per OIDC §5.4")
-	assert.Nil(t, claims["email_verified"], "email_verified must not be in id_token")
+	assert.Equal(t, "testuser@example.com", claims["email"], "email must be in id_token when email scope requested")
+	assert.Equal(t, true, claims["email_verified"], "email_verified must be in id_token when email scope requested")
 	assert.NotNil(t, claims["exp"])
 	assert.NotNil(t, claims["iat"])
 	assert.NotNil(t, claims["auth_time"])
@@ -91,9 +92,10 @@ func TestGenerateIDToken_ScopeBasedClaims(t *testing.T) {
 	config.Bootstrap.AppAuthIssuer = "http://localhost/oauth2"
 
 	testUser := user.User{
-		ID:       "user-1",
-		Username: "testuser",
-		Email:    "testuser@example.com",
+		ID:              "user-1",
+		Username:        "testuser",
+		Email:           "testuser@example.com",
+		IsEmailVerified: true,
 	}
 
 	// Only "openid" scope — profile and email claims must NOT be included
@@ -114,20 +116,21 @@ func TestGenerateIDToken_ScopeBasedClaims(t *testing.T) {
 	assert.Nil(t, claims["email"])
 	assert.Nil(t, claims["email_verified"])
 
-	// "openid email" — email is served via userinfo only, never in id_token
+	// "openid email" — email claims included in id_token per OIDC §5.4 MAY clause
 	idToken, err = GenerateIDToken(testUser, "session-1", "", "openid email", "my-client", time.Now(), "fake-access-token")
 	require.NoError(t, err)
 	claims = parseIDTokenClaims(t, idToken)
 	assert.Nil(t, claims["name"])
-	assert.Nil(t, claims["email"], "email must not be in id_token per OIDC §5.4")
-	assert.Nil(t, claims["email_verified"])
+	assert.Equal(t, "testuser@example.com", claims["email"])
+	assert.Equal(t, true, claims["email_verified"])
 
-	// "openid profile email" — profile claims in id_token, email only via userinfo
+	// "openid profile email" — both profile and email claims in id_token
 	idToken, err = GenerateIDToken(testUser, "session-1", "", "openid profile email", "my-client", time.Now(), "fake-access-token")
 	require.NoError(t, err)
 	claims = parseIDTokenClaims(t, idToken)
 	assert.Equal(t, "testuser", claims["name"])
-	assert.Nil(t, claims["email"], "email must not be in id_token per OIDC §5.4")
+	assert.Equal(t, "testuser@example.com", claims["email"])
+	assert.Equal(t, true, claims["email_verified"])
 }
 
 // Issue #9/#10: auth_time must reflect the original authentication time, not token issuance time

--- a/rfc/rfc.md
+++ b/rfc/rfc.md
@@ -364,6 +364,7 @@ At the end of each phase, verify that every endpoint or capability introduced by
 | §5.1 | UserInfo standard claims scope-filtered | `pkg/userinfo/handler.go` lines 102-145 |
 | §5.3 | UserInfo `sub` MUST match ID token `sub` | `pkg/userinfo/handler.go` — both use `user.ID` / `tok.UserID` |
 | §5.4 | Claims in access token must respect scope | `pkg/token/generate.go` — ✅ Fixed (PR #108) |
+| §5.4 | MAY include email claims in ID token when `email` scope requested | `pkg/token/generate.go` `GenerateIDToken` — ✅ Added (issue #220) |
 | §11 | `offline_access` requires `prompt=consent` | ⏭ Skipped — refresh tokens always issued; `offline_access` is effectively always on |
 | §16.14 | `acr` value consistency | `pkg/token/generate.go` — consistently `"1"` in both access and ID tokens ✅ |
 
@@ -377,6 +378,7 @@ At the end of each phase, verify that every endpoint or capability introduced by
 | MUST | §3.1.3.3 | `aud` contains the client_id | ✅ Verified + annotated (2026-03-30) |
 | MUST | §5.3 | UserInfo `sub` matches ID token `sub` | ✅ Verified + annotated (2026-03-30) — both use same user ID |
 | MUST | §5.4 | Access token claims respect requested scope | ✅ Fixed (PR #108) |
+| MAY | §5.4 | Email claims returned in ID token when `email` scope requested | ✅ Added (issue #220) — mirrors Google/Auth0/Okta behavior |
 | SHOULD | §3.1.3.6 | `at_hash` in ID token from token endpoint | ✅ Implemented (2026-04-08) — PR #165 |
 | SHOULD | §3.1.3.7 | `azp` present in ID token | ✅ Verified + annotated (2026-03-30) |
 | SHOULD | §11 | `offline_access` only with `prompt=consent` | ⏭ Skipped — refresh tokens always issued by design |

--- a/tests/functional/tests/token.test.ts
+++ b/tests/functional/tests/token.test.ts
@@ -3,10 +3,19 @@ import {
   OAUTH_URL,
   ADMIN_USERNAME,
   ADMIN_PASSWORD,
+  ADMIN_EMAIL,
   obtainTokenViaROPC,
   postForm,
   getAdminToken,
 } from '../helpers';
+
+function decodeJwtPayload(jwt: string): Record<string, unknown> {
+  const parts = jwt.split('.');
+  if (parts.length !== 3) throw new Error('not a JWT');
+  const payload = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+  const padded = payload + '='.repeat((4 - (payload.length % 4)) % 4);
+  return JSON.parse(Buffer.from(padded, 'base64').toString('utf-8'));
+}
 
 describe('Token endpoint — ROPC', () => {
   it('returns access, refresh, and id tokens', async () => {
@@ -16,6 +25,27 @@ describe('Token endpoint — ROPC', () => {
     expect(tokens.refresh_token).toBeTruthy();
     expect(tokens.id_token).toBeTruthy();
     expect(tokens.token_type).toBe('Bearer');
+  });
+});
+
+// OIDC Core §5.4: the AS MAY include email/email_verified in the ID token when the
+// "email" scope is requested. Autentico includes them so RPs can auto-link accounts
+// without a separate UserInfo call. Issue #220.
+describe('ID token — email scope claims', () => {
+  it('includes email and email_verified when email scope is requested', async () => {
+    const tokens = await obtainTokenViaROPC(ADMIN_USERNAME, ADMIN_PASSWORD, 'openid email');
+
+    const claims = decodeJwtPayload(tokens.id_token);
+    expect(claims.email).toBe(ADMIN_EMAIL);
+    expect(typeof claims.email_verified).toBe('boolean');
+  });
+
+  it('omits email and email_verified when email scope is not requested', async () => {
+    const tokens = await obtainTokenViaROPC(ADMIN_USERNAME, ADMIN_PASSWORD, 'openid profile');
+
+    const claims = decodeJwtPayload(tokens.id_token);
+    expect(claims.email).toBeUndefined();
+    expect(claims.email_verified).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- Include `email` and `email_verified` in the ID token when the `email` scope is requested (in addition to the UserInfo endpoint and access token, where they already were).
- Lets Relying Parties auto-link accounts by email without a separate UserInfo call.
- OIDC Core §5.4 allows this via the MAY clause: *"The Authorization Server MAY return the Claims in the ID Token, even if the UserInfo Endpoint is used to return the Claims."* Matches Google / Auth0 / Okta behavior.

Closes #220.

## Changes

- `pkg/token/generate.go` — `GenerateIDToken` now emits `email` + `email_verified` when `scope` contains `email`, with an inline §5.4 annotation.
- `pkg/token/generate_test.go` — updated scope-matrix unit tests (openid only / +profile → absent; +email / +profile+email → present).
- `tests/functional/tests/token.test.ts` — new black-box tests that decode a real ID token obtained via ROPC: positive (email scope → claims present) + negative (no email scope → claims absent).
- `rfc/rfc.md` — added §5.4 MAY entry to the compliance table.

## Test plan

- [x] `go test ./...` — all Go unit + e2e tests pass
- [x] `make test-functional` — 154/154 passed, including 2 new ID-token email-claim tests
- [x] Manual curl verification: ROPC with `scope=openid email profile` → decoded ID token contains `email` + `email_verified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)