### PR TITLE
refactor: filter deactivated sessions and revoked tokens at the read layer

### DIFF
--- a/pkg/account/common_test.go
+++ b/pkg/account/common_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
+	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/jwtutil"
 	"github.com/eugenioenko/autentico/pkg/key"
 	"github.com/eugenioenko/autentico/pkg/session"
@@ -42,6 +43,16 @@ func setupTestUserAndSession(t *testing.T) (string, *user.User) {
 		ExpiresAt:    time.Now().Add(time.Hour),
 	}
 	err = session.CreateSession(sess)
+	assert.NoError(t, err)
+
+	// Persist the matching tokens row so bearer.ValidateBearer's
+	// revocation check sees an active row (not sql.ErrNoRows).
+	now := time.Now().UTC()
+	_, err = db.GetDB().Exec(`
+		INSERT INTO tokens (id, user_id, access_token, refresh_token, access_token_type,
+			refresh_token_expires_at, access_token_expires_at, issued_at, scope, grant_type)
+		VALUES (?, ?, ?, ?, 'Bearer', ?, ?, ?, 'openid', 'password')
+	`, "tok-"+sessionID[:8], usr.ID, tokenString, "refresh-"+sessionID[:8], now.Add(time.Hour), now.Add(time.Hour), now)
 	assert.NoError(t, err)
 
 	return tokenString, usr

--- a/pkg/bearer/user_from_request_test.go
+++ b/pkg/bearer/user_from_request_test.go
@@ -52,6 +52,13 @@ func setupAuthenticatedUser(t *testing.T) (string, string) {
 	`, sessionID, userID, signedToken, "refresh-token-placeholder", "", "", "", time.Now(), time.Now().Add(1*time.Hour))
 	assert.NoError(t, err)
 
+	_, err = db.GetDB().Exec(`
+		INSERT INTO tokens (id, user_id, access_token, refresh_token, access_token_type,
+			refresh_token_expires_at, access_token_expires_at, issued_at, scope, grant_type)
+		VALUES (?, ?, ?, ?, 'Bearer', ?, ?, ?, 'openid profile email', 'password')
+	`, "tok-"+sessionID[:6], userID, signedToken, "refresh-"+sessionID[:6], accessTokenExpiresAt, accessTokenExpiresAt, time.Now())
+	assert.NoError(t, err)
+
 	return signedToken, userID
 }
 
@@ -121,6 +128,8 @@ func TestUserFromRequest_Valid(t *testing.T) {
 
 // Regression for https://github.com/eugenioenko/autentico/issues/225:
 // a token whose session has been deactivated must not be accepted.
+// SessionByAccessToken filters deactivated rows at the read layer, so the
+// error surfaces as "session not found" rather than a per-field rejection.
 func TestUserFromRequest_DeactivatedSession(t *testing.T) {
 	testutils.WithTestDB(t)
 	token, _ := setupAuthenticatedUser(t)
@@ -134,20 +143,19 @@ func TestUserFromRequest_DeactivatedSession(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token)
 	_, err = bearer.UserFromRequest(req)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "deactivated")
 }
 
 // A token revoked via /oauth2/revoke (RFC 7009 — sets tokens.revoked_at)
 // must also be rejected. Same class as #225 but on the tokens table.
+// TokenByAccessToken filters revoked rows at the read layer; the caller
+// treats ErrNoRows as a rejection.
 func TestUserFromRequest_RevokedToken(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, userID := setupAuthenticatedUser(t)
-	now := time.Now().UTC()
-	_, err := db.GetDB().Exec(`
-		INSERT INTO tokens (id, user_id, access_token, refresh_token, access_token_type,
-			refresh_token_expires_at, access_token_expires_at, issued_at, scope, grant_type, revoked_at)
-		VALUES (?, ?, ?, 'refresh', 'Bearer', ?, ?, ?, 'openid', 'password', ?)
-	`, "tok-"+userID[:6], userID, token, now.Add(time.Hour), now.Add(time.Hour), now, now)
+	token, _ := setupAuthenticatedUser(t)
+	_, err := db.GetDB().Exec(
+		`UPDATE tokens SET revoked_at = CURRENT_TIMESTAMP WHERE access_token = ?`,
+		token,
+	)
 	assert.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/pkg/bearer/validate_bearer.go
+++ b/pkg/bearer/validate_bearer.go
@@ -1,7 +1,6 @@
 package bearer
 
 import (
-	"database/sql"
 	"fmt"
 	"net/http"
 
@@ -68,15 +67,8 @@ func ValidateBearer(r *http.Request) (*Validated, error) {
 	if sess.DeactivatedAt != nil {
 		return nil, fmt.Errorf("session has been deactivated")
 	}
-	// RFC 7009: tokens can be individually revoked via /oauth2/revoke,
-	// independent of session state. A missing row (sql.ErrNoRows) means
-	// the token was never persisted — valid (not every flow persists) and
-	// must not reject.
-	tkn, err := token.TokenByAccessToken(bearerToken)
-	if err != nil && err != sql.ErrNoRows {
-		return nil, fmt.Errorf("token lookup failed: %v", err)
-	}
-	if tkn != nil && tkn.RevokedAt != nil {
+	// TokenByAccessToken filters revoked rows; any error is a rejection.
+	if _, err := token.TokenByAccessToken(bearerToken); err != nil {
 		return nil, fmt.Errorf("token has been revoked")
 	}
 	return &Validated{Token: bearerToken, Claims: claims, Session: sess}, nil

--- a/pkg/deletion/handler_test.go
+++ b/pkg/deletion/handler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/jwtutil"
 	"github.com/eugenioenko/autentico/pkg/key"
 	"github.com/eugenioenko/autentico/pkg/model"
@@ -47,6 +48,16 @@ func setupTestUserAndSession(t *testing.T) (string, *user.User) {
 		ExpiresAt:    time.Now().Add(time.Hour),
 	}
 	require.NoError(t, session.CreateSession(sess))
+
+	// Persist matching tokens row (active) so the revocation read-layer
+	// filter sees an active record for this bearer.
+	now := time.Now().UTC()
+	_, err = db.GetDB().Exec(`
+		INSERT INTO tokens (id, user_id, access_token, refresh_token, access_token_type,
+			refresh_token_expires_at, access_token_expires_at, issued_at, scope, grant_type)
+		VALUES (?, ?, ?, ?, 'Bearer', ?, ?, ?, 'openid', 'password')
+	`, "tok-"+sessionID[:8], usr.ID, tokenString, "refresh-"+sessionID[:8], now.Add(time.Hour), now.Add(time.Hour), now)
+	require.NoError(t, err)
 
 	return tokenString, usr
 }

--- a/pkg/introspect/handler_test.go
+++ b/pkg/introspect/handler_test.go
@@ -550,7 +550,8 @@ func TestHandleIntrospect_InactiveToken_NoExtraFields(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // generateBearerJWT creates a signed JWT for the given userID and inserts a
-// matching active session row so that bearer-auth liveness checks pass.
+// matching active session and active tokens row so that bearer-auth
+// liveness checks pass.
 func generateBearerJWT(t *testing.T, userID string) string {
 	t.Helper()
 	sessionID := xid.New().String()
@@ -574,6 +575,13 @@ func generateBearerJWT(t *testing.T, userID string) string {
 		INSERT INTO sessions (id, user_id, access_token, refresh_token, user_agent, ip_address, location, created_at, expires_at)
 		VALUES (?, ?, ?, ?, '', '', '', CURRENT_TIMESTAMP, ?)
 	`, sessionID, userID, signed, "refresh-placeholder", accessTokenExpiresAt)
+	assert.NoError(t, err)
+
+	_, err = db.GetDB().Exec(`
+		INSERT INTO tokens (id, user_id, access_token, refresh_token, access_token_type,
+			refresh_token_expires_at, access_token_expires_at, issued_at, scope, grant_type)
+		VALUES (?, ?, ?, ?, 'Bearer', ?, ?, ?, 'openid', 'password')
+	`, "tok-"+sessionID[:6], userID, signed, "refresh-"+sessionID[:6], accessTokenExpiresAt, accessTokenExpiresAt, time.Now())
 	assert.NoError(t, err)
 	return signed
 }

--- a/pkg/middleware/admin_auth.go
+++ b/pkg/middleware/admin_auth.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"database/sql"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -76,18 +75,9 @@ func AdminAuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		// RFC 7009: tokens can be individually revoked via /oauth2/revoke,
-		// independent of session state. sql.ErrNoRows is not an error —
-		// not every flow persists a tokens row, and absence means
-		// "nothing to revoke," not "reject."
-		tkn, err := token.TokenByAccessToken(tokenString)
-		if err != nil && err != sql.ErrNoRows {
-			slog.Warn("admin_auth: token lookup failed", "user_id", claims.UserID, "error", err, "ip", utils.GetClientIP(r))
-			utils.WriteBearerUnauthorized(w, realm, "invalid_token", "Token lookup failed")
-			return
-		}
-		if tkn != nil && tkn.RevokedAt != nil {
-			slog.Warn("admin_auth: revoked token", "user_id", claims.UserID, "ip", utils.GetClientIP(r))
+		// TokenByAccessToken filters revoked rows; any error is a rejection.
+		if _, err := token.TokenByAccessToken(tokenString); err != nil {
+			slog.Warn("admin_auth: token lookup failed or revoked", "user_id", claims.UserID, "error", err, "ip", utils.GetClientIP(r))
 			utils.WriteBearerUnauthorized(w, realm, "invalid_token", "Token has been revoked")
 			return
 		}

--- a/pkg/middleware/admin_auth_test.go
+++ b/pkg/middleware/admin_auth_test.go
@@ -272,12 +272,20 @@ func TestAdminAuthMiddlewareAdminUser(t *testing.T) {
 	token, err := generateTestAccessToken(userID)
 	assert.NoError(t, err)
 
-	// Create a session for this token so the session check passes
+	// Create a session and tokens row so the liveness checks pass
 	sessionID := xid.New().String()
 	_, err = db.GetDB().Exec(`
 		INSERT INTO sessions (id, user_id, access_token, refresh_token, user_agent, ip_address, location, created_at, expires_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, datetime('now', '+1 hour'))
 	`, sessionID, userID, token, "", "", "", "")
+	assert.NoError(t, err)
+
+	now := time.Now().UTC()
+	_, err = db.GetDB().Exec(`
+		INSERT INTO tokens (id, user_id, access_token, refresh_token, access_token_type,
+			refresh_token_expires_at, access_token_expires_at, issued_at, scope, grant_type)
+		VALUES (?, ?, ?, ?, 'Bearer', ?, ?, ?, 'openid', 'password')
+	`, "tok-"+sessionID[:6], userID, token, "refresh-"+sessionID[:6], now.Add(time.Hour), now.Add(time.Hour), now)
 	assert.NoError(t, err)
 
 	handlerCalled := false
@@ -435,6 +443,12 @@ func TestAdminAuthMiddleware_CaseInsensitiveBearer(t *testing.T) {
 		INSERT INTO sessions (id, user_id, access_token, refresh_token, user_agent, ip_address, location, created_at, expires_at)
 		VALUES (?, ?, ?, ?, '', '', '', CURRENT_TIMESTAMP, datetime('now', '+1 hour'))
 	`, sessionID, userID, token, "")
+	now := time.Now().UTC()
+	_, _ = db.GetDB().Exec(`
+		INSERT INTO tokens (id, user_id, access_token, refresh_token, access_token_type,
+			refresh_token_expires_at, access_token_expires_at, issued_at, scope, grant_type)
+		VALUES (?, ?, ?, ?, 'Bearer', ?, ?, ?, 'openid', 'password')
+	`, "tok-"+sessionID[:6], userID, token, "refresh-"+sessionID[:6], now.Add(time.Hour), now.Add(time.Hour), now)
 
 	handlerCalled := false
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/session/read.go
+++ b/pkg/session/read.go
@@ -94,14 +94,16 @@ func SessionByID(sessionID string) (*Session, error) {
 	return &session, nil
 }
 
+// SessionByAccessToken returns the active session matching the access token.
+// Deactivated sessions are filtered at the read layer so callers can't
+// accidentally honor a revoked session.
 func SessionByAccessToken(accessToken string) (*Session, error) {
 	var session Session
-	query := `
+	row := db.GetDB().QueryRow(`
 		SELECT id, user_id, access_token, refresh_token, user_agent, ip_address, location, created_at, expires_at, deactivated_at
 		FROM sessions
-		WHERE access_token = ?
-	`
-	row := db.GetDB().QueryRow(query, accessToken)
+		WHERE access_token = ? AND deactivated_at IS NULL
+	`, accessToken)
 	err := row.Scan(
 		&session.ID,
 		&session.UserID,

--- a/pkg/token/read.go
+++ b/pkg/token/read.go
@@ -7,17 +7,24 @@ import (
 	"github.com/eugenioenko/autentico/pkg/db"
 )
 
-// TokenByAccessToken returns the token row matching the given access token
-// value. Returns sql.ErrNoRows when no row exists — not every flow persists
-// a tokens row (e.g. some short-lived paths), so callers should treat
-// "not found" as "nothing to check" rather than a rejection.
+// TokenByAccessToken returns the active token row matching the access token.
+// Revoked tokens are filtered at the read layer so callers can't accidentally
+// honor a revoked token.
+//
+// Returns sql.ErrNoRows when no active row exists. A JWT that validated
+// cryptographically but has no matching active row means either (a) the
+// token was revoked via /oauth2/revoke, (b) its tokens row was cleaned up
+// because the refresh token expired (only possible if refresh_token_expiration
+// is misconfigured shorter than access_token_expiration), or (c) the JWT was
+// forged (impossible with an uncompromised signing key). Callers should
+// treat this as a rejection, not a pass.
 func TokenByAccessToken(accessToken string) (*Token, error) {
 	var t Token
 	err := db.GetDB().QueryRow(`
 		SELECT id, user_id, access_token, refresh_token, access_token_type,
 			refresh_token_expires_at, refresh_token_last_used_at,
 			access_token_expires_at, issued_at, scope, grant_type, revoked_at
-		FROM tokens WHERE access_token = ?
+		FROM tokens WHERE access_token = ? AND revoked_at IS NULL
 	`, accessToken).Scan(
 		&t.ID, &t.UserID, &t.AccessToken, &t.RefreshToken, &t.AccessTokenType,
 		&t.RefreshTokenExpiresAt, &t.RefreshTokenLastUsedAt,


### PR DESCRIPTION
Partial implementation of #229 targeting the two tables whose revocation enforcement the recently-merged #227 relied on. Leaves the other tables from #229 (`idp_sessions`, `auth_codes`, `mfa_challenges`, `trusted_devices`, `passkey_challenges`, `deletion_requests`, `clients`) for follow-up work.

## Summary

- `pkg/session.SessionByAccessToken` filters `deactivated_at IS NULL` at the SQL layer. Matches the `user.UserByID` convention.
- `pkg/token.TokenByAccessToken` filters `revoked_at IS NULL` at the SQL layer. Any error = reject (every grant type persists a tokens row, so a valid unexpired JWT should always have one).
- `pkg/bearer.ValidateBearer` and `pkg/middleware.AdminAuthMiddleware` collapse their two-branch revocation logic into a single error-is-reject path. Removes the `sql.ErrNoRows` tolerance that was a latent footgun under certain misconfigurations.
- Test helpers in `pkg/account`, `pkg/bearer`, `pkg/deletion`, `pkg/introspect`, `pkg/middleware` now insert the matching tokens row — matches production reality (every `/oauth2/token` creates one) so tests exercise the full liveness check.

## What this doesn't change

- Behavior for shipped defaults. On `main`, revoked tokens were already rejected via the explicit `RevokedAt != nil` branch. This PR doesn't close an exploitable bug — it hardens the invariant so future callers can't accidentally skip the check, and kills the `ErrNoRows` tolerance that would have been load-bearing under misconfigured `refresh_token_expiration`.
- No `…IncludingDeactivated` / `…IncludingRevoked` variants. Nobody currently needs to see deactivated sessions or revoked tokens by access-token lookup (admin UI lists use `ListSessions`, not `SessionByAccessToken`). Adding speculative API surface would be YAGNI.

## Test plan

- [x] `make test` — full Go suite clean
- [x] `make lint` — 0 issues
- [x] `make test-functional` — 159/159 green

Related: #229 (the umbrella issue), #227 (the merged fix this hardens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
