### PR TITLE
fix: always create IdP sessions, treat idle timeout 0 as infinite

### DIFF
--- a/admin-ui/src/pages/SettingsPage.tsx
+++ b/admin-ui/src/pages/SettingsPage.tsx
@@ -54,6 +54,7 @@ const tip = makeTip({
   mfa_method: "Preferred second-factor authentication method.",
   require_email_verification: "Require users to verify their email address before they can log in. Admins are exempt. Requires SMTP to be configured.",
   email_verification_expiration: "How long a verification link remains valid (e.g. 24h, 48h).",
+  sso_enabled: "Enable Single Sign-On. When enabled, returning users with an active session are automatically re-authorized without entering credentials.",
   sso_session_idle_timeout: "Duration of inactivity before SSO session expires (e.g. 30m, 24h). 0 for no idle expiration.",
   trust_device_enabled: "Allow users to trust their current device for MFA.",
   trust_device_expiration: "How long a device remains trusted (e.g. 720h).",
@@ -371,6 +372,15 @@ export default function SettingsPage() {
                   <Divider />
 
                   <Title level={5}>Session Control</Title>
+                  <Form.Item
+                    label="SSO Enabled"
+                    name="sso_enabled"
+                    valuePropName="checked"
+                    getValueProps={boolProp}
+                    tooltip={{ title: tip("sso_enabled"), icon: <ExclamationCircleOutlined /> }}
+                  >
+                    <Switch />
+                  </Form.Item>
                   <Form.Item
                     label="SSO Session Idle Timeout"
                     name="sso_session_idle_timeout"

--- a/admin-ui/src/pages/SettingsPage.tsx
+++ b/admin-ui/src/pages/SettingsPage.tsx
@@ -54,7 +54,7 @@ const tip = makeTip({
   mfa_method: "Preferred second-factor authentication method.",
   require_email_verification: "Require users to verify their email address before they can log in. Admins are exempt. Requires SMTP to be configured.",
   email_verification_expiration: "How long a verification link remains valid (e.g. 24h, 48h).",
-  sso_session_idle_timeout: "Duration of inactivity before SSO session expires (e.g. 30m, 24h). 0 to disable.",
+  sso_session_idle_timeout: "Duration of inactivity before SSO session expires (e.g. 30m, 24h). 0 for no idle expiration.",
   trust_device_enabled: "Allow users to trust their current device for MFA.",
   trust_device_expiration: "How long a device remains trusted (e.g. 720h).",
   validation_min_username_length: "Minimum length for usernames.",

--- a/docs-web/src/content/docs/admin-ui/settings.mdx
+++ b/docs-web/src/content/docs/admin-ui/settings.mdx
@@ -15,7 +15,7 @@ Settings are grouped by category:
 |---|---|
 | **Authentication** | `auth_mode`, `mfa_enabled`, `mfa_method` |
 | **Token lifetimes** | `access_token_expiration`, `refresh_token_expiration` |
-| **SSO sessions** | `sso_session_idle_timeout` |
+| **SSO sessions** | `sso_enabled`, `sso_session_idle_timeout` |
 | **Account security** | `lockout_max_attempts`, `lockout_duration` |
 | **SMTP** | `smtp_host`, `smtp_port`, `smtp_username`, `smtp_from` |
 | **Trusted devices** | `trust_device_enabled`, `trust_device_expiration` |

--- a/docs-web/src/content/docs/admin-ui/settings.mdx
+++ b/docs-web/src/content/docs/admin-ui/settings.mdx
@@ -15,7 +15,7 @@ Settings are grouped by category:
 |---|---|
 | **Authentication** | `auth_mode`, `mfa_enabled`, `mfa_method` |
 | **Token lifetimes** | `access_token_expiration`, `refresh_token_expiration` |
-| **SSO sessions** | `sso_session_max_age`, `sso_session_idle_timeout` |
+| **SSO sessions** | `sso_session_idle_timeout` |
 | **Account security** | `lockout_max_attempts`, `lockout_duration` |
 | **SMTP** | `smtp_host`, `smtp_port`, `smtp_username`, `smtp_from` |
 | **Trusted devices** | `trust_device_enabled`, `trust_device_expiration` |

--- a/docs-web/src/content/docs/authentication/sso-sessions.mdx
+++ b/docs-web/src/content/docs/authentication/sso-sessions.mdx
@@ -21,14 +21,11 @@ On a new authorization request:
 
 ## Session lifetime and idle timeout
 
-Sessions have two separate lifetime controls:
-
 | Setting | Default | Description |
 |---|---|---|
-| `sso_session_max_age` | `720h` | Absolute maximum session duration — the session expires after this regardless of activity |
 | `sso_session_idle_timeout` | `4h` | If the user has no activity for this long, the session expires. `0` for no idle expiration |
 
-Both use Go duration format: `24h`, `168h`, `720h`, etc.
+Uses Go duration format: `24h`, `168h`, `720h`, etc.
 
 The idle timeout can be overridden per-client, so different clients can have stricter session requirements. See [Per-Client Overrides](/configuration/per-client-overrides/).
 
@@ -44,7 +41,7 @@ Sessions are stored in the `sessions` table with the following fields:
 | `ip_address` | Client IP at login time |
 | `last_activity_at` | Updated on each authorization request (used for idle timeout) |
 | `created_at` | Session creation time |
-| `expires_at` | Absolute expiry (`created_at` + `sso_session_max_age`) |
+| `expires_at` | Absolute expiry (not yet enforced — reserved for future `sso_session_max_age` setting) |
 | `deactivated_at` | Set when the session is explicitly logged out |
 
 ## Logout

--- a/docs-web/src/content/docs/authentication/sso-sessions.mdx
+++ b/docs-web/src/content/docs/authentication/sso-sessions.mdx
@@ -23,9 +23,10 @@ On a new authorization request:
 
 | Setting | Default | Description |
 |---|---|---|
+| `sso_enabled` | `true` | Enable SSO auto-login. When disabled, users must log in on every request. Device sessions are still tracked |
 | `sso_session_idle_timeout` | `4h` | If the user has no activity for this long, the session expires. `0` for no idle expiration |
 
-Uses Go duration format: `24h`, `168h`, `720h`, etc.
+Uses Go duration format for timeouts: `24h`, `168h`, `720h`, etc.
 
 The idle timeout can be overridden per-client, so different clients can have stricter session requirements. See [Per-Client Overrides](/configuration/per-client-overrides/).
 

--- a/docs-web/src/content/docs/authentication/sso-sessions.mdx
+++ b/docs-web/src/content/docs/authentication/sso-sessions.mdx
@@ -26,7 +26,7 @@ Sessions have two separate lifetime controls:
 | Setting | Default | Description |
 |---|---|---|
 | `sso_session_max_age` | `720h` | Absolute maximum session duration — the session expires after this regardless of activity |
-| `sso_session_idle_timeout` | `168h` | If the user has no activity for this long, the session expires |
+| `sso_session_idle_timeout` | `4h` | If the user has no activity for this long, the session expires. `0` for no idle expiration |
 
 Both use Go duration format: `24h`, `168h`, `720h`, etc.
 

--- a/docs-web/src/content/docs/configuration/per-client-overrides.mdx
+++ b/docs-web/src/content/docs/configuration/per-client-overrides.mdx
@@ -44,7 +44,7 @@ curl -X PUT https://auth.example.com/oauth2/register/YOUR_CLIENT_ID \
 ```
 
 <Aside type="tip">
-Duration strings use Go's `time.Duration` format: `"15m"`, `"1h"`, `"720h"`, `"30s"`. A value of `"0"` disables the feature (e.g. `sso_session_idle_timeout: "0"` disables IdP sessions for that client).
+Duration strings use Go's `time.Duration` format: `"15m"`, `"1h"`, `"720h"`, `"30s"`. A value of `"0"` means no idle expiration (e.g. `sso_session_idle_timeout: "0"` means sessions for that client never expire from inactivity).
 </Aside>
 
 ---

--- a/docs-web/src/content/docs/configuration/runtime-settings.mdx
+++ b/docs-web/src/content/docs/configuration/runtime-settings.mdx
@@ -109,9 +109,9 @@ How long a password reset link remains valid. Only sent to users with a verified
 ## SSO sessions
 
 ### `sso_session_idle_timeout`
-Default: `0`
+Default: `4h`
 
-IdP session idle timeout. `0` disables IdP sessions entirely. When set (e.g. `8h`), users who return within the timeout window are automatically re-authorized without entering credentials.
+IdP session idle timeout. Users who return within the timeout window are automatically re-authorized without entering credentials. `0` means sessions never expire from inactivity (infinite idle timeout).
 
 ---
 

--- a/docs-web/src/content/docs/configuration/runtime-settings.mdx
+++ b/docs-web/src/content/docs/configuration/runtime-settings.mdx
@@ -108,6 +108,11 @@ How long a password reset link remains valid. Only sent to users with a verified
 
 ## SSO sessions
 
+### `sso_enabled`
+Default: `true`
+
+Enable Single Sign-On. When enabled, returning users with an active session are automatically re-authorized without entering credentials. When disabled, users must log in on every authorization request. Device sessions are still tracked regardless of this setting.
+
 ### `sso_session_idle_timeout`
 Default: `4h`
 

--- a/docs-web/src/content/docs/deployment/production-checklist.mdx
+++ b/docs-web/src/content/docs/deployment/production-checklist.mdx
@@ -19,7 +19,7 @@ import { Aside } from '@astrojs/starlight/components';
 - [ ] **`AUTENTICO_APP_URL` is correct** — This value appears in the OIDC discovery document, token `iss` claim, and redirect validation. It must exactly match the URL clients use.
 - [ ] **MFA enabled** (recommended) — `mfa_enabled = true` in settings, with `mfa_method = totp` or `email`. TOTP is preferred.
 - [ ] **Account lockout configured** — `lockout_max_attempts` and `lockout_duration` are set to reasonable values.
-- [ ] **Session lifetimes reviewed** — `sso_session_max_age` and `sso_session_idle_timeout` match your security policy.
+- [ ] **Session lifetimes reviewed** — `sso_session_idle_timeout` matches your security policy.
 - [ ] **Token lifetimes reviewed** — `access_token_expiration` is short (15m default). `refresh_token_expiration` reflects your session policy.
 - [ ] **Self-signup decision made** — `allow_self_signup` is `false` unless you intend to allow open registration.
 - [ ] **SMTP configured** (if using email OTP or email-verified registration) — SMTP settings tested via a login attempt.

--- a/pkg/appsettings/load.go
+++ b/pkg/appsettings/load.go
@@ -16,6 +16,7 @@ var defaults = map[string]string{
 	"authorization_code_expiration":  "10m",
 	"access_token_audience":          "[]",
 	"allow_self_signup":              "false",
+	"sso_enabled":                   "true",
 	"sso_session_idle_timeout":       "4h",
 	"validation_min_username_length": "4",
 	"validation_max_username_length": "64",
@@ -108,6 +109,9 @@ func LoadIntoConfig() error {
 	}
 	if v, ok := all["allow_self_signup"]; ok {
 		cfg.AuthAllowSelfSignup = parseBool(v, false)
+	}
+	if v, ok := all["sso_enabled"]; ok {
+		cfg.AuthSsoEnabled = parseBool(v, true)
 	}
 	if v, ok := all["sso_session_idle_timeout"]; ok {
 		cfg.AuthSsoSessionIdleTimeoutStr = v

--- a/pkg/authorize/handler.go
+++ b/pkg/authorize/handler.go
@@ -125,57 +125,12 @@ func HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check for valid IdP session (auto-login)
 	// OIDC Core §3.1.2.1: prompt=login requires fresh authentication — skip SSO auto-login
 	// OIDC Core §3.1.2.1: prompt=consent requires user consent — skip SSO auto-login
-	// max_age requires re-authentication if session is older than max_age seconds
 	cfg := config.Get()
-	maxAgeSecs := parseMaxAge(request.MaxAge)
-	if request.Prompt != "login" && request.Prompt != "consent" {
-		sessionID := idpsession.ReadCookie(r)
-		if sessionID != "" {
-			session, err := idpsession.IdpSessionByID(sessionID)
-			if err == nil {
-				sessionAge := time.Since(session.CreatedAt)
-				maxAgeExceeded := maxAgeSecs >= 0 && sessionAge > time.Duration(maxAgeSecs)*time.Second
-				idleOk := cfg.AuthSsoSessionIdleTimeout == 0 || time.Since(session.LastActivityAt) < cfg.AuthSsoSessionIdleTimeout
-				if idleOk && !maxAgeExceeded {
-					// Valid IdP session — auto-login
-					_ = idpsession.UpdateLastActivity(session.ID)
-
-					code, err := authcode.GenerateSecureCode()
-					if err == nil {
-						// Carry the IdP session id onto the auth code so /oauth2/token can
-						// stamp it on the resulting sessions row — DeactivateWithCascade
-						// then revokes every OAuth session born from this browser login.
-						ac := authcode.AuthCode{
-							Code:                code,
-							UserID:              session.UserID,
-							ClientID:            request.ClientID,
-							RedirectURI:         request.RedirectURI,
-							Scope:               request.Scope,
-							Nonce:               request.Nonce,
-							CodeChallenge:       request.CodeChallenge,
-							CodeChallengeMethod: request.CodeChallengeMethod,
-							ExpiresAt:           time.Now().Add(cfg.AuthAuthorizationCodeExpiration),
-							Used:                false,
-							CreatedAt:           session.CreatedAt,
-							IdpSessionID:        session.ID,
-						}
-						if authcode.CreateAuthCode(ac) == nil {
-							// RFC 6749 §4.1.2: authorization response MUST include code; state MUST be echoed unchanged if present
-							redirectParams := url.Values{}
-							redirectParams.Set("code", ac.Code)
-							if request.State != "" {
-								redirectParams.Set("state", request.State)
-							}
-							http.Redirect(w, r, request.RedirectURI+"?"+redirectParams.Encode(), http.StatusFound)
-							return
-						}
-					}
-				}
-			}
-		}
+	if redirectURL := tryAutoLogin(r, cfg, request); redirectURL != "" {
+		http.Redirect(w, r, redirectURL, http.StatusFound)
+		return
 	}
 
 	if request.Prompt == "none" {
@@ -274,6 +229,68 @@ func redirectWithError(w http.ResponseWriter, r *http.Request, redirectURI, stat
 		q.Set("state", state)
 	}
 	http.Redirect(w, r, redirectURI+"?"+q.Encode(), http.StatusFound)
+}
+
+// tryAutoLogin checks for a valid IdP session and returns a redirect URL with
+// an authorization code if SSO auto-login succeeds. Returns "" if auto-login
+// should not or cannot proceed, letting the caller fall through to the login form.
+func tryAutoLogin(r *http.Request, cfg *config.Config, request AuthorizeRequest) string {
+	if !cfg.AuthSsoEnabled || request.Prompt == "login" || request.Prompt == "consent" {
+		return ""
+	}
+
+	sessionID := idpsession.ReadCookie(r)
+	if sessionID == "" {
+		return ""
+	}
+
+	session, err := idpsession.IdpSessionByID(sessionID)
+	if err != nil {
+		return ""
+	}
+
+	withinIdleTimeout := cfg.AuthSsoSessionIdleTimeout == 0 || time.Since(session.LastActivityAt) < cfg.AuthSsoSessionIdleTimeout
+	if !withinIdleTimeout {
+		return ""
+	}
+
+	maxAgeSecs := parseMaxAge(request.MaxAge)
+	if maxAgeSecs >= 0 && time.Since(session.CreatedAt) > time.Duration(maxAgeSecs)*time.Second {
+		return ""
+	}
+
+	_ = idpsession.UpdateLastActivity(session.ID)
+
+	code, err := authcode.GenerateSecureCode()
+	if err != nil {
+		return ""
+	}
+
+	ac := authcode.AuthCode{
+		Code:                code,
+		UserID:              session.UserID,
+		ClientID:            request.ClientID,
+		RedirectURI:         request.RedirectURI,
+		Scope:               request.Scope,
+		Nonce:               request.Nonce,
+		CodeChallenge:       request.CodeChallenge,
+		CodeChallengeMethod: request.CodeChallengeMethod,
+		ExpiresAt:           time.Now().Add(cfg.AuthAuthorizationCodeExpiration),
+		Used:                false,
+		CreatedAt:           session.CreatedAt,
+		IdpSessionID:        session.ID,
+	}
+	if err := authcode.CreateAuthCode(ac); err != nil {
+		return ""
+	}
+
+	// RFC 6749 §4.1.2: authorization response MUST include code; state MUST be echoed unchanged if present
+	redirectParams := url.Values{}
+	redirectParams.Set("code", ac.Code)
+	if request.State != "" {
+		redirectParams.Set("state", request.State)
+	}
+	return request.RedirectURI + "?" + redirectParams.Encode()
 }
 
 // parseMaxAge parses the max_age query parameter as seconds.

--- a/pkg/authorize/handler.go
+++ b/pkg/authorize/handler.go
@@ -131,14 +131,15 @@ func HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	// max_age requires re-authentication if session is older than max_age seconds
 	cfg := config.Get()
 	maxAgeSecs := parseMaxAge(request.MaxAge)
-	if cfg.AuthSsoSessionIdleTimeout > 0 && request.Prompt != "login" && request.Prompt != "consent" {
+	if request.Prompt != "login" && request.Prompt != "consent" {
 		sessionID := idpsession.ReadCookie(r)
 		if sessionID != "" {
 			session, err := idpsession.IdpSessionByID(sessionID)
 			if err == nil {
 				sessionAge := time.Since(session.CreatedAt)
 				maxAgeExceeded := maxAgeSecs >= 0 && sessionAge > time.Duration(maxAgeSecs)*time.Second
-				if time.Since(session.LastActivityAt) < cfg.AuthSsoSessionIdleTimeout && !maxAgeExceeded {
+				idleOk := cfg.AuthSsoSessionIdleTimeout == 0 || time.Since(session.LastActivityAt) < cfg.AuthSsoSessionIdleTimeout
+				if idleOk && !maxAgeExceeded {
 					// Valid IdP session — auto-login
 					_ = idpsession.UpdateLastActivity(session.ID)
 

--- a/pkg/authorize/handler_test.go
+++ b/pkg/authorize/handler_test.go
@@ -260,6 +260,38 @@ func TestHandleAuthorize_AutoLogin_ZeroIdleTimeout_MeansInfinite(t *testing.T) {
 	assert.Contains(t, rr.Header().Get("Location"), "state=xyz123")
 }
 
+func TestHandleAuthorize_AutoLogin_SsoDisabled(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestClient(t, "test-client", []string{"http://localhost/callback"})
+	testutils.WithConfigOverride(t, func() {
+		config.Values.AuthSsoEnabled = false
+		config.Values.AuthSsoSessionIdleTimeout = 24 * time.Hour
+	})
+
+	_, err := db.GetDB().Exec(`INSERT INTO users (id, username, email, password) VALUES ('user-1', 'testuser', 'test@example.com', 'hashed')`)
+	assert.NoError(t, err)
+
+	session := idpsession.IdpSession{
+		ID:        "idp-sso-off-1",
+		UserID:    "user-1",
+		UserAgent: "test-agent",
+		IPAddress: "127.0.0.1",
+	}
+	err = idpsession.CreateIdpSession(session)
+	assert.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/authorize?response_type=code&client_id=test-client&redirect_uri=http://localhost/callback&state=xyz123&code_challenge=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk&code_challenge_method=S256", nil)
+	req.AddCookie(&http.Cookie{Name: "autentico_idp_session", Value: "idp-sso-off-1"})
+	rr := httptest.NewRecorder()
+
+	HandleAuthorize(rr, req)
+
+	// sso_enabled=false: should show login form despite valid session
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "form")
+	assert.Contains(t, rr.Body.String(), "username")
+}
+
 func TestHandleAuthorize_AutoLogin_ExpiredSession(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.InsertTestClient(t, "test-client", []string{"http://localhost/callback"})

--- a/pkg/authorize/handler_test.go
+++ b/pkg/authorize/handler_test.go
@@ -228,11 +228,11 @@ func TestHandleAuthorize_AutoLogin_ValidSession(t *testing.T) {
 	assert.Contains(t, location, "state=xyz123")
 }
 
-func TestHandleAuthorize_AutoLogin_Disabled(t *testing.T) {
+func TestHandleAuthorize_AutoLogin_ZeroIdleTimeout_MeansInfinite(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.InsertTestClient(t, "test-client", []string{"http://localhost/callback"})
 	testutils.WithConfigOverride(t, func() {
-		config.Values.AuthSsoSessionIdleTimeout = 0 // disabled
+		config.Values.AuthSsoSessionIdleTimeout = 0 // 0 = infinite (no idle expiration)
 	})
 
 	// Create a user and IdP session
@@ -254,10 +254,10 @@ func TestHandleAuthorize_AutoLogin_Disabled(t *testing.T) {
 
 	HandleAuthorize(rr, req)
 
-	// Should show login form, not redirect
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "form")
-	assert.Contains(t, rr.Body.String(), "username")
+	// 0 = infinite idle timeout, so auto-login should succeed
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "code=")
+	assert.Contains(t, rr.Header().Get("Location"), "state=xyz123")
 }
 
 func TestHandleAuthorize_AutoLogin_ExpiredSession(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,6 +68,7 @@ type Config struct {
 	AuthAuthorizationCodeExpirationStr string
 	AuthAccessTokenAudience            []string
 	AuthAllowSelfSignup                bool
+	AuthSsoEnabled                     bool
 	AuthSsoSessionIdleTimeout          time.Duration
 	AuthSsoSessionIdleTimeoutStr       string
 	AuthAccountLockoutMaxAttempts      int
@@ -141,6 +142,7 @@ var defaultConfig = Config{
 	AuthAuthorizationCodeExpirationStr: "10m",
 	AuthAccessTokenAudience:            []string{},
 	AuthAllowSelfSignup:                false,
+	AuthSsoEnabled:                     true,
 	AuthSsoSessionIdleTimeout:          4 * time.Hour,
 	AuthSsoSessionIdleTimeoutStr:       "4h",
 	AuthAccountLockoutMaxAttempts:      5,

--- a/pkg/emailverification/handler.go
+++ b/pkg/emailverification/handler.go
@@ -160,21 +160,18 @@ func HandleVerifyEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create IdP session if SSO idle timeout is enabled, matching the login flow.
 	var idpSessionID string
-	if config.Get().AuthSsoSessionIdleTimeout > 0 {
-		sessionID, err := authcode.GenerateSecureCode()
-		if err == nil {
-			session := idpsession.IdpSession{
-				ID:        sessionID,
-				UserID:    userID,
-				UserAgent: r.UserAgent(),
-				IPAddress: utils.GetClientIP(r),
-			}
-			if idpsession.CreateIdpSession(session) == nil {
-				idpsession.SetCookie(w, sessionID)
-				idpSessionID = sessionID
-			}
+	sessionID, err := authcode.GenerateSecureCode()
+	if err == nil {
+		session := idpsession.IdpSession{
+			ID:        sessionID,
+			UserID:    userID,
+			UserAgent: r.UserAgent(),
+			IPAddress: utils.GetClientIP(r),
+		}
+		if idpsession.CreateIdpSession(session) == nil {
+			idpsession.SetCookie(w, sessionID)
+			idpSessionID = sessionID
 		}
 	}
 

--- a/pkg/emailverification/handler_test.go
+++ b/pkg/emailverification/handler_test.go
@@ -255,7 +255,7 @@ func TestHandleVerifyEmail_CreatesIdpSession_WhenSsoEnabled(t *testing.T) {
 	assert.True(t, found, "IdP session cookie should be set")
 }
 
-func TestHandleVerifyEmail_NoIdpSession_WhenSsoDisabled(t *testing.T) {
+func TestHandleVerifyEmail_CreatesIdpSession_WhenSsoDisabled(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.WithConfigOverride(t, func() {
 		config.Values.AuthAuthorizationCodeExpiration = 5 * time.Minute
@@ -290,13 +290,11 @@ func TestHandleVerifyEmail_NoIdpSession_WhenSsoDisabled(t *testing.T) {
 
 	ac, err := authcode.AuthCodeByCode(codeStr)
 	require.NoError(t, err)
-	assert.Empty(t, ac.IdpSessionID, "auth code should NOT have IdpSessionID when SSO is disabled")
+	assert.NotEmpty(t, ac.IdpSessionID, "auth code should have IdpSessionID even when SSO idle timeout is 0")
 
-	// Verify no IdP session cookie was set
-	cookieName := config.GetBootstrap().AuthIdpSessionCookieName
-	for _, c := range rr.Result().Cookies() {
-		assert.NotEqual(t, cookieName, c.Name, "IdP session cookie should not be set")
-	}
+	idpSess, err := idpsession.IdpSessionByID(ac.IdpSessionID)
+	require.NoError(t, err)
+	assert.Equal(t, u.ID, idpSess.UserID)
 }
 
 func TestBuildVerifyURL(t *testing.T) {

--- a/pkg/federation/handler.go
+++ b/pkg/federation/handler.go
@@ -270,21 +270,18 @@ func resolveUser(ctx context.Context, providerID, sub, email string, emailVerifi
 func completeAuthFlow(w http.ResponseWriter, r *http.Request, usr *user.User, state *FederationState) error {
 	cfg := config.Get()
 
-	// Create an IdP session if SSO is enabled
 	var idpSessionID string
-	if cfg.AuthSsoSessionIdleTimeout > 0 {
-		sessionID, err := authcode.GenerateSecureCode()
-		if err == nil {
-			sess := idpsession.IdpSession{
-				ID:        sessionID,
-				UserID:    usr.ID,
-				UserAgent: r.UserAgent(),
-				IPAddress: utils.GetClientIP(r),
-			}
-			if idpsession.CreateIdpSession(sess) == nil {
-				idpsession.SetCookie(w, sessionID)
-				idpSessionID = sessionID
-			}
+	sessionID, err := authcode.GenerateSecureCode()
+	if err == nil {
+		sess := idpsession.IdpSession{
+			ID:        sessionID,
+			UserID:    usr.ID,
+			UserAgent: r.UserAgent(),
+			IPAddress: utils.GetClientIP(r),
+		}
+		if idpsession.CreateIdpSession(sess) == nil {
+			idpsession.SetCookie(w, sessionID)
+			idpSessionID = sessionID
 		}
 	}
 

--- a/pkg/login/handler.go
+++ b/pkg/login/handler.go
@@ -218,22 +218,18 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create IdP session if authSsoSessionIdleTimeout is enabled. Capture the
-	// id so it can be stamped onto the auth code for cascade-revocation linkage.
 	var idpSessionID string
-	if config.Get().AuthSsoSessionIdleTimeout > 0 {
-		sessionID, err := authcode.GenerateSecureCode()
-		if err == nil {
-			session := idpsession.IdpSession{
-				ID:        sessionID,
-				UserID:    usr.ID,
-				UserAgent: r.UserAgent(),
-				IPAddress: utils.GetClientIP(r),
-			}
-			if idpsession.CreateIdpSession(session) == nil {
-				idpsession.SetCookie(w, sessionID)
-				idpSessionID = sessionID
-			}
+	sessionID, err := authcode.GenerateSecureCode()
+	if err == nil {
+		session := idpsession.IdpSession{
+			ID:        sessionID,
+			UserID:    usr.ID,
+			UserAgent: r.UserAgent(),
+			IPAddress: utils.GetClientIP(r),
+		}
+		if idpsession.CreateIdpSession(session) == nil {
+			idpsession.SetCookie(w, sessionID)
+			idpSessionID = sessionID
 		}
 	}
 

--- a/pkg/mfa/handler.go
+++ b/pkg/mfa/handler.go
@@ -228,21 +228,18 @@ func handleMfaPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create IdP session if configured
 	var idpSessionID string
-	if cfg.AuthSsoSessionIdleTimeout > 0 {
-		sessionID, err := authcode.GenerateSecureCode()
-		if err == nil {
-			session := idpsession.IdpSession{
-				ID:        sessionID,
-				UserID:    usr.ID,
-				UserAgent: r.UserAgent(),
-				IPAddress: utils.GetClientIP(r),
-			}
-			if idpsession.CreateIdpSession(session) == nil {
-				idpsession.SetCookie(w, sessionID)
-				idpSessionID = sessionID
-			}
+	sessionID, err := authcode.GenerateSecureCode()
+	if err == nil {
+		session := idpsession.IdpSession{
+			ID:        sessionID,
+			UserID:    usr.ID,
+			UserAgent: r.UserAgent(),
+			IPAddress: utils.GetClientIP(r),
+		}
+		if idpsession.CreateIdpSession(session) == nil {
+			idpsession.SetCookie(w, sessionID)
+			idpSessionID = sessionID
 		}
 	}
 

--- a/pkg/onboarding/handler.go
+++ b/pkg/onboarding/handler.go
@@ -84,18 +84,16 @@ func handleOnboardDirectPost(w http.ResponseWriter, r *http.Request) {
 	_ = appsettings.SetSetting("onboarded", "true")
 	_ = appsettings.LoadIntoConfig()
 
-	if config.Get().AuthSsoSessionIdleTimeout > 0 {
-		sessionID, err := authcode.GenerateSecureCode()
-		if err == nil {
-			session := idpsession.IdpSession{
-				ID:        sessionID,
-				UserID:    usr.ID,
-				UserAgent: r.UserAgent(),
-				IPAddress: utils.GetClientIP(r),
-			}
-			if idpsession.CreateIdpSession(session) == nil {
-				idpsession.SetCookie(w, sessionID)
-			}
+	sessionID, err := authcode.GenerateSecureCode()
+	if err == nil {
+		session := idpsession.IdpSession{
+			ID:        sessionID,
+			UserID:    usr.ID,
+			UserAgent: r.UserAgent(),
+			IPAddress: utils.GetClientIP(r),
+		}
+		if idpsession.CreateIdpSession(session) == nil {
+			idpsession.SetCookie(w, sessionID)
 		}
 	}
 

--- a/pkg/passkey/handler.go
+++ b/pkg/passkey/handler.go
@@ -492,19 +492,17 @@ func completeAuthFlow(w http.ResponseWriter, r *http.Request, usr *user.User, lo
 
 	cfg := config.Get()
 	var idpSessionID string
-	if cfg.AuthSsoSessionIdleTimeout > 0 {
-		sessionID, err := authcode.GenerateSecureCode()
-		if err == nil {
-			session := idpsession.IdpSession{
-				ID:        sessionID,
-				UserID:    usr.ID,
-				UserAgent: r.UserAgent(),
-				IPAddress: utils.GetClientIP(r),
-			}
-			if idpsession.CreateIdpSession(session) == nil {
-				idpsession.SetCookie(w, sessionID)
-				idpSessionID = sessionID
-			}
+	sessionID, err := authcode.GenerateSecureCode()
+	if err == nil {
+		session := idpsession.IdpSession{
+			ID:        sessionID,
+			UserID:    usr.ID,
+			UserAgent: r.UserAgent(),
+			IPAddress: utils.GetClientIP(r),
+		}
+		if idpsession.CreateIdpSession(session) == nil {
+			idpsession.SetCookie(w, sessionID)
+			idpSessionID = sessionID
 		}
 	}
 

--- a/pkg/signup/handler.go
+++ b/pkg/signup/handler.go
@@ -202,19 +202,17 @@ func handleSignupPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var idpSessionID string
-	if config.Get().AuthSsoSessionIdleTimeout > 0 {
-		sessionID, err := authcode.GenerateSecureCode()
-		if err == nil {
-			session := idpsession.IdpSession{
-				ID:        sessionID,
-				UserID:    usr.ID,
-				UserAgent: r.UserAgent(),
-				IPAddress: utils.GetClientIP(r),
-			}
-			if idpsession.CreateIdpSession(session) == nil {
-				idpsession.SetCookie(w, sessionID)
-				idpSessionID = sessionID
-			}
+	sessionID, err := authcode.GenerateSecureCode()
+	if err == nil {
+		session := idpsession.IdpSession{
+			ID:        sessionID,
+			UserID:    usr.ID,
+			UserAgent: r.UserAgent(),
+			IPAddress: utils.GetClientIP(r),
+		}
+		if idpsession.CreateIdpSession(session) == nil {
+			idpsession.SetCookie(w, sessionID)
+			idpSessionID = sessionID
 		}
 	}
 


### PR DESCRIPTION
## Summary

- **Always create IdP sessions** on every login path (password, MFA, passkey, email verification, signup, federation, onboarding) — removes the `AuthSsoSessionIdleTimeout > 0` guard from 7 handlers
- **Treat `sso_session_idle_timeout = 0` as infinite** — `/authorize` auto-login now works when idle timeout is 0 (session never expires from inactivity), consistent with Keycloak/Okta behavior
- **Update docs and UI tooltip** — corrects "0 to disable" to "0 for no idle expiration" across admin-ui tooltip, runtime-settings, per-client-overrides, and sso-sessions docs

Closes #243

## Why

The idle timeout setting was overloaded — it controlled both SSO auto-login and whether IdP sessions were created at all. Setting it to 0 silently disabled device tracking, the Sessions UI (admin + account), and cascade revocation. No major IdP interprets timeout=0 as "disable sessions."

## Files changed

| Area | Files |
|---|---|
| Login paths (remove guard) | `pkg/login/handler.go`, `pkg/mfa/handler.go`, `pkg/passkey/handler.go`, `pkg/emailverification/handler.go`, `pkg/onboarding/handler.go`, `pkg/signup/handler.go`, `pkg/federation/handler.go` |
| Auto-login (0 = infinite) | `pkg/authorize/handler.go` |
| Tests | `pkg/authorize/handler_test.go`, `pkg/emailverification/handler_test.go` |
| Docs + UI | `admin-ui/src/pages/SettingsPage.tsx`, `docs-web/.../runtime-settings.mdx`, `docs-web/.../per-client-overrides.mdx`, `docs-web/.../sso-sessions.mdx` |

## Test plan

- [x] Updated `TestHandleAuthorize_AutoLogin_ZeroIdleTimeout_MeansInfinite` — verifies auto-login succeeds when idle timeout is 0
- [x] Updated `TestHandleVerifyEmail_CreatesIdpSession_WhenSsoDisabled` — verifies IdP session is created even when idle timeout is 0
- [x] All existing tests pass across authorize, login, mfa, passkey, emailverification, onboarding, federation, signup, and e2e suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)