### PR TITLE
fix: trim whitespace from username and email inputs

### DIFF
--- a/pkg/onboarding/handler.go
+++ b/pkg/onboarding/handler.go
@@ -2,6 +2,7 @@ package onboarding
 
 import (
 	"net/http"
+	"strings"
 
 	authcode "github.com/eugenioenko/autentico/pkg/auth_code"
 	"github.com/eugenioenko/autentico/pkg/appsettings"
@@ -52,10 +53,10 @@ func handleOnboardDirectPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	params := onboardParams{FormAction: "/onboard"}
-	username := r.FormValue("username")
+	username := strings.TrimSpace(r.FormValue("username"))
 	password := r.FormValue("password")
 	confirmPassword := r.FormValue("confirm_password")
-	email := r.FormValue("email")
+	email := strings.TrimSpace(r.FormValue("email"))
 
 	if password != confirmPassword {
 		renderOnboard(w, r, params, "Passwords do not match")

--- a/pkg/passkey/handler.go
+++ b/pkg/passkey/handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/eugenioenko/autentico/pkg/audit"
@@ -34,12 +35,12 @@ import (
 // Success 200 "WebAuthn registration options"
 func HandleRegisterBegin(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
-	username := q.Get("username")
+	username := strings.TrimSpace(q.Get("username"))
 	if username == "" {
 		writeJSONError(w, http.StatusBadRequest, "missing username")
 		return
 	}
-	email := q.Get("email")
+	email := strings.TrimSpace(q.Get("email"))
 	if config.Get().ProfileFieldEmail == "is_username" && email == "" {
 		email = username
 	}

--- a/pkg/signup/handler.go
+++ b/pkg/signup/handler.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/eugenioenko/autentico/pkg/audit"
@@ -92,10 +93,10 @@ func handleSignupPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	username := r.FormValue("username")
+	username := strings.TrimSpace(r.FormValue("username"))
 	password := r.FormValue("password")
 	confirmPassword := r.FormValue("confirm_password")
-	email := r.FormValue("email")
+	email := strings.TrimSpace(r.FormValue("email"))
 	if config.Get().ProfileFieldEmail == "is_username" && email == "" {
 		email = username
 	}

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -29,6 +29,8 @@ func HandleCreateUser(w http.ResponseWriter, r *http.Request) {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Invalid request payload")
 		return
 	}
+	request.Username = strings.TrimSpace(request.Username)
+	request.Email = strings.TrimSpace(request.Email)
 	err := ValidateUserCreateRequest(request)
 	if err != nil {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", fmt.Sprintf("User validation error. %v", err))
@@ -98,6 +100,8 @@ func HandleUpdateUser(w http.ResponseWriter, r *http.Request) {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Invalid request payload")
 		return
 	}
+	req.Username = strings.TrimSpace(req.Username)
+	req.Email = strings.TrimSpace(req.Email)
 	// In is_username mode, keep username and email in sync
 	if config.Get().ProfileFieldEmail == "is_username" && req.Username != "" {
 		req.Email = req.Username


### PR DESCRIPTION
## Summary
- Adds `strings.TrimSpace()` to username and email inputs at all entry points: signup, onboarding, admin API (create + update), and passkey registration
- Prevents accounts from being created with leading/trailing whitespace that could cause conflicts with trimmed or encoded versions downstream

Closes #223
Related: #159 (configurable regex validation rules for usernames and passwords)

## Test plan
- [x] Build passes
- [x] Unit tests pass for all affected packages (user, signup, onboarding, passkey)
- [ ] Manual: attempt signup with ` username ` — should create `username` (trimmed)
- [ ] Manual: create user via admin API with whitespace in username — should be trimmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)