### PR TITLE
refactor: consolidate post-auth IdP session into FinalizeLogin

### DIFF
--- a/pkg/emailverification/handler.go
+++ b/pkg/emailverification/handler.go
@@ -160,20 +160,7 @@ func HandleVerifyEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var idpSessionID string
-	sessionID, err := authcode.GenerateSecureCode()
-	if err == nil {
-		session := idpsession.IdpSession{
-			ID:        sessionID,
-			UserID:    userID,
-			UserAgent: r.UserAgent(),
-			IPAddress: utils.GetClientIP(r),
-		}
-		if idpsession.CreateIdpSession(session) == nil {
-			idpsession.SetCookie(w, sessionID)
-			idpSessionID = sessionID
-		}
-	}
+	idpSessionID := idpsession.FinalizeLogin(w, r, userID)
 
 	// Issue auth code and redirect — user is now logged in
 	authCodeStr, err := authcode.GenerateSecureCode()

--- a/pkg/federation/handler.go
+++ b/pkg/federation/handler.go
@@ -270,20 +270,7 @@ func resolveUser(ctx context.Context, providerID, sub, email string, emailVerifi
 func completeAuthFlow(w http.ResponseWriter, r *http.Request, usr *user.User, state *FederationState) error {
 	cfg := config.Get()
 
-	var idpSessionID string
-	sessionID, err := authcode.GenerateSecureCode()
-	if err == nil {
-		sess := idpsession.IdpSession{
-			ID:        sessionID,
-			UserID:    usr.ID,
-			UserAgent: r.UserAgent(),
-			IPAddress: utils.GetClientIP(r),
-		}
-		if idpsession.CreateIdpSession(sess) == nil {
-			idpsession.SetCookie(w, sessionID)
-			idpSessionID = sessionID
-		}
-	}
+	idpSessionID := idpsession.FinalizeLogin(w, r, usr.ID)
 
 	authCode, err := authcode.GenerateSecureCode()
 	if err != nil {

--- a/pkg/idpsession/finalize.go
+++ b/pkg/idpsession/finalize.go
@@ -1,0 +1,26 @@
+package idpsession
+
+import (
+	"net/http"
+
+	authcode "github.com/eugenioenko/autentico/pkg/auth_code"
+	"github.com/eugenioenko/autentico/pkg/utils"
+)
+
+func FinalizeLogin(w http.ResponseWriter, r *http.Request, userID string) string {
+	sessionID, err := authcode.GenerateSecureCode()
+	if err != nil {
+		return ""
+	}
+	session := IdpSession{
+		ID:        sessionID,
+		UserID:    userID,
+		UserAgent: r.UserAgent(),
+		IPAddress: utils.GetClientIP(r),
+	}
+	if CreateIdpSession(session) != nil {
+		return ""
+	}
+	SetCookie(w, sessionID)
+	return sessionID
+}

--- a/pkg/idpsession/finalize_test.go
+++ b/pkg/idpsession/finalize_test.go
@@ -1,0 +1,63 @@
+package idpsession
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/db"
+	testutils "github.com/eugenioenko/autentico/tests/utils"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFinalizeLogin_Success(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AuthIdpSessionCookieName = "autentico_idp_session"
+		config.Bootstrap.AppOAuthPath = "/oauth2"
+		config.Bootstrap.AuthIdpSessionSecureCookie = false
+	})
+	testutils.InsertTestUser(t, "user-1")
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("User-Agent", "test-agent")
+
+	sessionID := FinalizeLogin(rr, req, "user-1")
+
+	assert.NotEmpty(t, sessionID)
+
+	// Verify session was created in database
+	var dbID string
+	err := db.GetDB().QueryRow(`SELECT id FROM idp_sessions WHERE id = ?`, sessionID).Scan(&dbID)
+	assert.NoError(t, err)
+	assert.Equal(t, sessionID, dbID)
+
+	// Verify cookie was set
+	cookies := rr.Result().Cookies()
+	assert.Len(t, cookies, 1)
+	assert.Equal(t, "autentico_idp_session", cookies[0].Name)
+	assert.Equal(t, sessionID, cookies[0].Value)
+}
+
+func TestFinalizeLogin_InvalidUser(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AuthIdpSessionCookieName = "autentico_idp_session"
+		config.Bootstrap.AppOAuthPath = "/oauth2"
+		config.Bootstrap.AuthIdpSessionSecureCookie = false
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	sessionID := FinalizeLogin(rr, req, "nonexistent-user")
+
+	assert.Empty(t, sessionID)
+
+	// Verify no cookie was set
+	cookies := rr.Result().Cookies()
+	assert.Empty(t, cookies)
+}

--- a/pkg/login/handler.go
+++ b/pkg/login/handler.go
@@ -218,20 +218,7 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var idpSessionID string
-	sessionID, err := authcode.GenerateSecureCode()
-	if err == nil {
-		session := idpsession.IdpSession{
-			ID:        sessionID,
-			UserID:    usr.ID,
-			UserAgent: r.UserAgent(),
-			IPAddress: utils.GetClientIP(r),
-		}
-		if idpsession.CreateIdpSession(session) == nil {
-			idpsession.SetCookie(w, sessionID)
-			idpSessionID = sessionID
-		}
-	}
+	idpSessionID := idpsession.FinalizeLogin(w, r, usr.ID)
 
 	authCode, err := authcode.GenerateSecureCode()
 	if err != nil {

--- a/pkg/mfa/handler.go
+++ b/pkg/mfa/handler.go
@@ -228,20 +228,7 @@ func handleMfaPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var idpSessionID string
-	sessionID, err := authcode.GenerateSecureCode()
-	if err == nil {
-		session := idpsession.IdpSession{
-			ID:        sessionID,
-			UserID:    usr.ID,
-			UserAgent: r.UserAgent(),
-			IPAddress: utils.GetClientIP(r),
-		}
-		if idpsession.CreateIdpSession(session) == nil {
-			idpsession.SetCookie(w, sessionID)
-			idpSessionID = sessionID
-		}
-	}
+	idpSessionID := idpsession.FinalizeLogin(w, r, usr.ID)
 
 	authorizationCode, err := authcode.GenerateSecureCode()
 	if err != nil {

--- a/pkg/onboarding/handler.go
+++ b/pkg/onboarding/handler.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"strings"
 
-	authcode "github.com/eugenioenko/autentico/pkg/auth_code"
 	"github.com/eugenioenko/autentico/pkg/appsettings"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/idpsession"
@@ -85,18 +84,7 @@ func handleOnboardDirectPost(w http.ResponseWriter, r *http.Request) {
 	_ = appsettings.SetSetting("onboarded", "true")
 	_ = appsettings.LoadIntoConfig()
 
-	sessionID, err := authcode.GenerateSecureCode()
-	if err == nil {
-		session := idpsession.IdpSession{
-			ID:        sessionID,
-			UserID:    usr.ID,
-			UserAgent: r.UserAgent(),
-			IPAddress: utils.GetClientIP(r),
-		}
-		if idpsession.CreateIdpSession(session) == nil {
-			idpsession.SetCookie(w, sessionID)
-		}
-	}
+	idpsession.FinalizeLogin(w, r, usr.ID)
 
 	http.Redirect(w, r, "/admin/", http.StatusFound)
 }

--- a/pkg/passkey/handler.go
+++ b/pkg/passkey/handler.go
@@ -492,20 +492,7 @@ func completeAuthFlow(w http.ResponseWriter, r *http.Request, usr *user.User, lo
 	}
 
 	cfg := config.Get()
-	var idpSessionID string
-	sessionID, err := authcode.GenerateSecureCode()
-	if err == nil {
-		session := idpsession.IdpSession{
-			ID:        sessionID,
-			UserID:    usr.ID,
-			UserAgent: r.UserAgent(),
-			IPAddress: utils.GetClientIP(r),
-		}
-		if idpsession.CreateIdpSession(session) == nil {
-			idpsession.SetCookie(w, sessionID)
-			idpSessionID = sessionID
-		}
-	}
+	idpSessionID := idpsession.FinalizeLogin(w, r, usr.ID)
 
 	authorizationCode, err := authcode.GenerateSecureCode()
 	if err != nil {

--- a/pkg/signup/handler.go
+++ b/pkg/signup/handler.go
@@ -202,20 +202,7 @@ func handleSignupPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var idpSessionID string
-	sessionID, err := authcode.GenerateSecureCode()
-	if err == nil {
-		session := idpsession.IdpSession{
-			ID:        sessionID,
-			UserID:    usr.ID,
-			UserAgent: r.UserAgent(),
-			IPAddress: utils.GetClientIP(r),
-		}
-		if idpsession.CreateIdpSession(session) == nil {
-			idpsession.SetCookie(w, sessionID)
-			idpSessionID = sessionID
-		}
-	}
+	idpSessionID := idpsession.FinalizeLogin(w, r, usr.ID)
 
 	authCode, err := authcode.GenerateSecureCode()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Extracts duplicated IdP session creation block into `idpsession.FinalizeLogin(w, r, userID) string`
- Replaces the identical 14-line block across 7 handlers: login, mfa, passkey, emailverification, federation, signup, and onboarding
- Adds unit tests for the helper (success + invalid user)

Closes #232

## Test plan
- [x] Build passes
- [x] All 8 affected packages pass tests (idpsession, login, mfa, passkey, emailverification, federation, signup, onboarding)
- [x] `FinalizeLogin` tests verify session creation in DB, cookie set on success, and empty return + no cookie on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)