### PR TITLE
test: shared post-auth invariant assertions across login paths

### DIFF
--- a/pkg/login/handler_test.go
+++ b/pkg/login/handler_test.go
@@ -22,10 +22,11 @@ func TestHandleLoginUser_Success(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.WithConfigOverride(t, func() {
 		config.Values.AuthSsoSessionIdleTimeout = 0
+		config.Bootstrap.AuthIdpSessionCookieName = "autentico_idp_session"
 	})
 
 	// Create user and client
-	_, _ = user.CreateUser("testuser", "password123", "test@example.com")
+	usr, _ := user.CreateUser("testuser", "password123", "test@example.com")
 	testutils.InsertTestClient(t, "test-client", []string{"http://localhost/callback"})
 
 	form := url.Values{}
@@ -42,8 +43,7 @@ func TestHandleLoginUser_Success(t *testing.T) {
 
 	HandleLoginUser(rr, req)
 
-	assert.Equal(t, http.StatusFound, rr.Code)
-	assert.Contains(t, rr.Header().Get("Location"), "code=")
+	testutils.AssertPostAuthInvariants(t, rr, usr.ID)
 }
 
 func TestHandleLoginUser_MfaTotp(t *testing.T) {

--- a/pkg/mfa/handler_test.go
+++ b/pkg/mfa/handler_test.go
@@ -53,15 +53,21 @@ func TestHandleMfa_GetEnroll(t *testing.T) {
 
 func TestHandleMfa_Post_Success(t *testing.T) {
 	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Values.AuthSsoSessionIdleTimeout = 0
+		config.Bootstrap.AuthIdpSessionCookieName = "autentico_idp_session"
+	})
+
 	u, _ := user.CreateUser("mfauser", "pass", "mfa@example.com")
 	secret, _, _ := GenerateTotpSecret("mfauser", "Auth")
 	_ = user.SaveTotpSecret(u.ID, secret)
+	testutils.InsertTestClient(t, "c1", []string{"http://localhost/cb"})
 
 	c := MfaChallenge{
 		ID:         "chall1",
 		UserID:     u.ID,
 		Method:     "totp",
-		LoginState: `{"redirect_uri":"http://localhost/cb","state":"s1"}`,
+		LoginState: `{"redirect_uri":"http://localhost/cb","state":"s1","client_id":"c1","scope":"openid","nonce":"","code_challenge":"","code_challenge_method":""}`,
 		ExpiresAt:  time.Now().Add(time.Hour),
 	}
 	_ = CreateMfaChallenge(c)
@@ -78,8 +84,7 @@ func TestHandleMfa_Post_Success(t *testing.T) {
 	rr := httptest.NewRecorder()
 	HandleMfa(rr, req)
 
-	assert.Equal(t, http.StatusFound, rr.Code)
-	assert.Contains(t, rr.Header().Get("Location"), "http://localhost/cb")
+	testutils.AssertPostAuthInvariants(t, rr, u.ID)
 }
 
 func TestHandleMfa_Post_EnrollSuccess(t *testing.T) {

--- a/pkg/passkey/handler_test.go
+++ b/pkg/passkey/handler_test.go
@@ -617,6 +617,10 @@ func TestNewWebAuthn(t *testing.T) {
 func TestCompleteAuthFlow_Success(t *testing.T) {
 	testutils.WithTestDB(t)
 	withPasskeyConfig(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Values.AuthSsoSessionIdleTimeout = 0
+		config.Bootstrap.AuthIdpSessionCookieName = "autentico_idp_session"
+	})
 
 	usr, err := user.CreateUser("authflow-user", "password123", "authflow@test.com")
 	require.NoError(t, err)
@@ -635,6 +639,34 @@ func TestCompleteAuthFlow_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, redirectURL, "http://localhost/cb?code=")
 	assert.Contains(t, redirectURL, "state=s1")
+
+	// completeAuthFlow doesn't call http.Redirect, so verify post-auth
+	// invariants (IdP session + cookie + auth code linkage) directly.
+	codeStart := strings.Index(redirectURL, "code=") + len("code=")
+	codeEnd := strings.Index(redirectURL[codeStart:], "&")
+	codeStr := redirectURL[codeStart:]
+	if codeEnd > 0 {
+		codeStr = redirectURL[codeStart : codeStart+codeEnd]
+	}
+	var idpSessionID string
+	err = db.GetDB().QueryRow(`SELECT idp_session_id FROM auth_codes WHERE code = ?`, codeStr).Scan(&idpSessionID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, idpSessionID)
+
+	var dbUserID string
+	err = db.GetDB().QueryRow(`SELECT user_id FROM idp_sessions WHERE id = ?`, idpSessionID).Scan(&dbUserID)
+	require.NoError(t, err)
+	assert.Equal(t, usr.ID, dbUserID)
+
+	var sessionCookie *http.Cookie
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == "autentico_idp_session" {
+			sessionCookie = c
+			break
+		}
+	}
+	require.NotNil(t, sessionCookie)
+	assert.Equal(t, idpSessionID, sessionCookie.Value)
 }
 
 func TestCompleteAuthFlow_InvalidLoginState(t *testing.T) {

--- a/pkg/signup/handler_test.go
+++ b/pkg/signup/handler_test.go
@@ -14,6 +14,7 @@ import (
 	testutils "github.com/eugenioenko/autentico/tests/utils"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandleSignup_DisabledReturns404(t *testing.T) {
@@ -159,7 +160,10 @@ func TestHandleSignup_Post_Success(t *testing.T) {
 		config.Values.AuthAllowSelfSignup = true
 		config.Values.ProfileFieldEmail = "hidden"
 		config.Values.AuthSsoSessionIdleTimeout = 0
+		config.Bootstrap.AuthIdpSessionCookieName = "autentico_idp_session"
 	})
+
+	testutils.InsertTestClient(t, "test-client", []string{"http://localhost/callback"})
 
 	form := url.Values{}
 	form.Set("username", "newuser")
@@ -176,11 +180,9 @@ func TestHandleSignup_Post_Success(t *testing.T) {
 
 	HandleSignup(rr, req)
 
-	assert.Equal(t, http.StatusFound, rr.Code)
-	location := rr.Header().Get("Location")
-	assert.Contains(t, location, "http://localhost/callback")
-	assert.Contains(t, location, "code=")
-	assert.Contains(t, location, "state=abc123")
+	usr, err := user.UserByUsername("newuser")
+	require.NoError(t, err)
+	testutils.AssertPostAuthInvariants(t, rr, usr.ID)
 }
 
 func TestHandleSignup_Post_SetsIdpSessionCookie(t *testing.T) {

--- a/tests/utils/post_auth.go
+++ b/tests/utils/post_auth.go
@@ -1,0 +1,52 @@
+package testutils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/db"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func AssertPostAuthInvariants(t *testing.T, rr *httptest.ResponseRecorder, userID string) {
+	t.Helper()
+
+	require.Equal(t, http.StatusFound, rr.Code)
+
+	loc := rr.Header().Get("Location")
+	locURL, err := url.Parse(loc)
+	require.NoError(t, err)
+	codeStr := locURL.Query().Get("code")
+	require.NotEmpty(t, codeStr, "redirect should contain a code parameter")
+
+	var idpSessionID string
+	err = db.GetDB().QueryRow(
+		`SELECT idp_session_id FROM auth_codes WHERE code = ?`, codeStr,
+	).Scan(&idpSessionID)
+	require.NoError(t, err, "auth code should exist in DB")
+	assert.NotEmpty(t, idpSessionID, "auth code should have idp_session_id set")
+
+	var dbUserID string
+	err = db.GetDB().QueryRow(
+		`SELECT user_id FROM idp_sessions WHERE id = ?`, idpSessionID,
+	).Scan(&dbUserID)
+	require.NoError(t, err, "IdP session should exist in DB")
+	assert.Equal(t, userID, dbUserID, "IdP session should belong to the authenticated user")
+
+	cookieName := config.GetBootstrap().AuthIdpSessionCookieName
+	var sessionCookie *http.Cookie
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == cookieName {
+			sessionCookie = c
+			break
+		}
+	}
+	require.NotNil(t, sessionCookie, "IdP session cookie should be set")
+	assert.Equal(t, idpSessionID, sessionCookie.Value, "cookie value should match auth code's idp_session_id")
+	assert.True(t, sessionCookie.HttpOnly, "IdP session cookie should be HttpOnly")
+}


### PR DESCRIPTION
## Summary
- Adds `testutils.AssertPostAuthInvariants` helper (`tests/utils/post_auth.go`) that verifies the three post-auth invariants: auth code has `idp_session_id`, IdP session exists for the correct user, and the IdP session cookie is set with the matching value
- Threads the helper into success tests for login, MFA, and signup handlers
- Adds equivalent inline assertions to the passkey `completeAuthFlow` test (which returns a URL string rather than calling `http.Redirect`)
- Uses raw SQL queries to avoid import cycles between `testutils` and the packages under test

Closes #233

## Test plan
- [x] All existing tests pass (`go test -p 1 ./...`)
- [x] New assertions verified in `TestHandleLoginUser_Success`, `TestHandleMfa_Post_Success`, `TestHandleSignup_Post_Success`, `TestCompleteAuthFlow_Success`

🤖 Generated with [Claude Code](https://claude.com/claude-code)