### PR TITLE
refactor: harden OAuth2 read paths with SQL-level filtering (#250)

### DIFF
--- a/pkg/account/passkey.go
+++ b/pkg/account/passkey.go
@@ -233,7 +233,7 @@ func HandleAddPasskeyFinish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	challenge, err := passkey.PasskeyChallengeByID(challengeID)
+	challenge, err := passkey.PasskeyChallengeByIDIncludingExpired(challengeID)
 	if err != nil || challenge.Type != "account-registration" {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Invalid challenge")
 		return

--- a/pkg/account/trusted_devices.go
+++ b/pkg/account/trusted_devices.go
@@ -69,7 +69,7 @@ func HandleRevokeTrustedDevice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	device, err := trusteddevice.TrustedDeviceByID(deviceID)
+	device, err := trusteddevice.TrustedDeviceByIDIncludingExpired(deviceID)
 	if err != nil || device.UserID != usr.ID {
 		utils.WriteErrorResponse(w, http.StatusForbidden, "forbidden", "Device not found or not owned by you")
 		return

--- a/pkg/auth_code/create_test.go
+++ b/pkg/auth_code/create_test.go
@@ -52,7 +52,7 @@ func TestCreateAuthCode_ZeroCreatedAt_DefaultsToNow(t *testing.T) {
 	err := CreateAuthCode(authCode)
 	assert.NoError(t, err)
 
-	result, err := AuthCodeByCode("zero-created-at")
+	result, err := AuthCodeByCodeIncludingUsed("zero-created-at")
 	assert.NoError(t, err)
 	assert.False(t, result.CreatedAt.IsZero(), "CreatedAt must not be zero after insert")
 	assert.True(t, result.CreatedAt.After(before), "CreatedAt must be close to now")

--- a/pkg/auth_code/read.go
+++ b/pkg/auth_code/read.go
@@ -4,11 +4,56 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/eugenioenko/autentico/pkg/db"
 )
 
 func AuthCodeByCode(code string) (*AuthCode, error) {
+	query := `
+        SELECT code, user_id, client_id, redirect_uri, scope, nonce,
+               code_challenge, code_challenge_method,
+               expires_at, used, created_at, idp_session_id
+        FROM auth_codes
+        WHERE code = ? AND used = 0 AND expires_at > ?;
+    `
+	var authCode AuthCode
+	var clientID, idpSessionID sql.NullString
+	err := db.GetDB().QueryRow(query, code, time.Now().UTC()).Scan(
+		&authCode.Code,
+		&authCode.UserID,
+		&clientID,
+		&authCode.RedirectURI,
+		&authCode.Scope,
+		&authCode.Nonce,
+		&authCode.CodeChallenge,
+		&authCode.CodeChallengeMethod,
+		&authCode.ExpiresAt,
+		&authCode.Used,
+		&authCode.CreatedAt,
+		&idpSessionID,
+	)
+
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("authorization code not found")
+		}
+		return nil, err // Other errors
+	}
+
+	if clientID.Valid {
+		authCode.ClientID = clientID.String
+	}
+	if idpSessionID.Valid {
+		authCode.IdpSessionID = idpSessionID.String
+	}
+
+	return &authCode, nil
+}
+
+// AuthCodeByCodeIncludingUsed returns the auth code regardless of used/expired status.
+// Required by the token exchange flow for replay detection (RFC 6749 §10.6).
+func AuthCodeByCodeIncludingUsed(code string) (*AuthCode, error) {
 	query := `
         SELECT code, user_id, client_id, redirect_uri, scope, nonce,
                code_challenge, code_challenge_method,
@@ -37,7 +82,7 @@ func AuthCodeByCode(code string) (*AuthCode, error) {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("authorization code not found")
 		}
-		return nil, err // Other errors
+		return nil, err
 	}
 
 	if clientID.Valid {

--- a/pkg/auth_code/read_test.go
+++ b/pkg/auth_code/read_test.go
@@ -2,6 +2,7 @@ package authcode
 
 import (
 	"testing"
+	"time"
 
 	"github.com/eugenioenko/autentico/pkg/db"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
@@ -51,4 +52,35 @@ func TestAuthCodeByCode_WithClientID(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "code-with-client", authCode.Code)
 	assert.Equal(t, "client-123", authCode.ClientID)
+}
+
+func TestAuthCodeByCode_ExcludesExpired(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user-1")
+
+	expired := time.Now().Add(-1 * time.Hour).UTC().Format("2006-01-02 15:04:05")
+	_, err := db.GetDB().Exec(`
+		INSERT INTO auth_codes (code, user_id, redirect_uri, scope, expires_at, used, created_at)
+		VALUES ('expired-code', 'user-1', 'http://localhost/callback', 'read', ?, FALSE, DATETIME('now'))
+	`, expired)
+	assert.NoError(t, err)
+
+	_, err = AuthCodeByCode("expired-code")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestAuthCodeByCode_ExcludesUsed(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user-1")
+
+	_, err := db.GetDB().Exec(`
+		INSERT INTO auth_codes (code, user_id, redirect_uri, scope, expires_at, used, created_at)
+		VALUES ('used-code', 'user-1', 'http://localhost/callback', 'read', DATETIME('now', '+1 hour'), TRUE, DATETIME('now'))
+	`)
+	assert.NoError(t, err)
+
+	_, err = AuthCodeByCode("used-code")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }

--- a/pkg/authorize/handler_test.go
+++ b/pkg/authorize/handler_test.go
@@ -151,7 +151,7 @@ func TestHandleAuthorize_InactiveClient(t *testing.T) {
 	HandleAuthorize(rr, req)
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
-	assert.Contains(t, rr.Body.String(), "Client is inactive")
+	assert.Contains(t, rr.Body.String(), "Unknown client_id")
 }
 
 func TestHandleAuthorize_RedirectURINotAllowed(t *testing.T) {

--- a/pkg/client/admin_read.go
+++ b/pkg/client/admin_read.go
@@ -7,7 +7,9 @@ import (
 	"github.com/eugenioenko/autentico/pkg/db"
 )
 
-func AdminClientByClientID(clientID string) (*Client, error) {
+// ClientByClientIDIncludingDisabled returns the client regardless of is_active status.
+// Used by admin endpoints that need to view or modify deactivated clients.
+func ClientByClientIDIncludingDisabled(clientID string) (*Client, error) {
 	query := `
 		SELECT
 			id, client_id, client_secret, client_name, client_type, redirect_uris,
@@ -44,7 +46,9 @@ func AdminClientByClientID(clientID string) (*Client, error) {
 	return &c, nil
 }
 
-func AdminClientByID(id string) (*Client, error) {
+// ClientByIDIncludingDisabled returns the client regardless of is_active status.
+// Used by admin endpoints that need to view or modify deactivated clients.
+func ClientByIDIncludingDisabled(id string) (*Client, error) {
 	query := `
 		SELECT
 			id, client_id, client_secret, client_name, client_type, redirect_uris,

--- a/pkg/client/admin_read.go
+++ b/pkg/client/admin_read.go
@@ -7,59 +7,16 @@ import (
 	"github.com/eugenioenko/autentico/pkg/db"
 )
 
-func ListClients() ([]*Client, error) {
+func AdminClientByClientID(clientID string) (*Client, error) {
 	query := `
-		SELECT 
-			id, client_id, client_secret, client_name, client_type, redirect_uris, 
-			post_logout_redirect_uris, grant_types, response_types, scopes, 
+		SELECT
+			id, client_id, client_secret, client_name, client_type, redirect_uris,
+			post_logout_redirect_uris, grant_types, response_types, scopes,
 			token_endpoint_auth_method, is_active, created_at, updated_at,
 			access_token_expiration, refresh_token_expiration, authorization_code_expiration,
 			allowed_audiences, allow_self_signup, sso_session_idle_timeout,
 			trust_device_enabled, trust_device_expiration
-		FROM clients WHERE is_active = 1 ORDER BY created_at DESC
-	`
-	rows, err := db.GetDB().Query(query)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list clients: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var clients []*Client
-	for rows.Next() {
-		var c Client
-		var secret sql.NullString
-		var audiences sql.NullString
-		if err := rows.Scan(
-			&c.ID, &c.ClientID, &secret, &c.ClientName, &c.ClientType, &c.RedirectURIs,
-			&c.PostLogoutRedirectURIs, &c.GrantTypes, &c.ResponseTypes, &c.Scopes,
-			&c.TokenEndpointAuthMethod, &c.IsActive, &c.CreatedAt, &c.UpdatedAt,
-			&c.AccessTokenExpiration, &c.RefreshTokenExpiration, &c.AuthorizationCodeExpiration,
-			&audiences, &c.AllowSelfSignup, &c.SsoSessionIdleTimeout,
-			&c.TrustDeviceEnabled, &c.TrustDeviceExpiration,
-		); err != nil {
-			return nil, fmt.Errorf("failed to scan client: %w", err)
-		}
-		if secret.Valid {
-			c.ClientSecret = secret.String
-		}
-		if audiences.Valid {
-			c.AllowedAudiences = &audiences.String
-		}
-		clients = append(clients, &c)
-	}
-	return clients, rows.Err()
-}
-
-func ClientByClientID(clientID string) (*Client, error) {
-	query := `
-		SELECT 
-			id, client_id, client_secret, client_name, client_type, redirect_uris, 
-			post_logout_redirect_uris, grant_types, response_types, scopes, 
-			token_endpoint_auth_method, is_active, created_at, updated_at,
-			access_token_expiration, refresh_token_expiration, authorization_code_expiration,
-			allowed_audiences, allow_self_signup, sso_session_idle_timeout,
-			trust_device_enabled, trust_device_expiration
-		FROM clients WHERE client_id = ? AND is_active = 1
+		FROM clients WHERE client_id = ?
 	`
 	var c Client
 	var secret sql.NullString
@@ -87,16 +44,16 @@ func ClientByClientID(clientID string) (*Client, error) {
 	return &c, nil
 }
 
-func ClientByID(id string) (*Client, error) {
+func AdminClientByID(id string) (*Client, error) {
 	query := `
-		SELECT 
-			id, client_id, client_secret, client_name, client_type, redirect_uris, 
-			post_logout_redirect_uris, grant_types, response_types, scopes, 
+		SELECT
+			id, client_id, client_secret, client_name, client_type, redirect_uris,
+			post_logout_redirect_uris, grant_types, response_types, scopes,
 			token_endpoint_auth_method, is_active, created_at, updated_at,
 			access_token_expiration, refresh_token_expiration, authorization_code_expiration,
 			allowed_audiences, allow_self_signup, sso_session_idle_timeout,
 			trust_device_enabled, trust_device_expiration
-		FROM clients WHERE id = ? AND is_active = 1
+		FROM clients WHERE id = ?
 	`
 	var c Client
 	var secret sql.NullString

--- a/pkg/client/authenticate_test.go
+++ b/pkg/client/authenticate_test.go
@@ -232,7 +232,7 @@ func TestAuthenticateClient_InactiveClient(t *testing.T) {
 	// Attempt to authenticate
 	_, err = AuthenticateClient(created.ClientID, "")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "inactive")
+	assert.Contains(t, err.Error(), "invalid client credentials")
 }
 
 func TestAuthenticateClient_ConfidentialMissingSecret(t *testing.T) {

--- a/pkg/client/delete.go
+++ b/pkg/client/delete.go
@@ -10,7 +10,7 @@ import (
 // DeleteClient performs a soft delete by setting is_active to false
 func DeleteClient(clientID string) error {
 	// First, verify the client exists
-	_, err := AdminClientByClientID(clientID)
+	_, err := ClientByClientIDIncludingDisabled(clientID)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/delete.go
+++ b/pkg/client/delete.go
@@ -10,7 +10,7 @@ import (
 // DeleteClient performs a soft delete by setting is_active to false
 func DeleteClient(clientID string) error {
 	// First, verify the client exists
-	_, err := ClientByClientID(clientID)
+	_, err := AdminClientByClientID(clientID)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/delete_test.go
+++ b/pkg/client/delete_test.go
@@ -29,8 +29,8 @@ func TestDeleteClient(t *testing.T) {
 	err = DeleteClient(created.ClientID)
 	assert.NoError(t, err)
 
-	// Verify client is now inactive
-	client, err = ClientByClientID(created.ClientID)
+	// Verify client is now inactive (use admin read to see deactivated clients)
+	client, err = ClientByClientIDIncludingDisabled(created.ClientID)
 	assert.NoError(t, err)
 	assert.False(t, client.IsActive)
 }

--- a/pkg/client/handler.go
+++ b/pkg/client/handler.go
@@ -80,13 +80,13 @@ func HandleGetClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client, err := ClientByClientID(clientID)
+	c, err := AdminClientByClientID(clientID)
 	if err != nil {
 		utils.WriteErrorResponse(w, http.StatusNotFound, "invalid_client", "Client not found")
 		return
 	}
 
-	utils.WriteApiResponse(w, client.ToInfoResponse(), http.StatusOK)
+	utils.WriteApiResponse(w, c.ToInfoResponse(), http.StatusOK)
 }
 
 // HandleUpdateClient handles PUT /oauth2/register/{client_id} (RFC 7591) and PUT /admin/api/clients/{client_id}
@@ -141,7 +141,7 @@ func HandleUpdateClient(w http.ResponseWriter, r *http.Request) {
 	}
 
 	audit.Log(audit.EventClientUpdated, audit.ActorFromRequest(r), audit.TargetClient, clientID, nil, utils.GetClientIP(r))
-	updated, _ := ClientByClientID(clientID)
+	updated, _ := AdminClientByClientID(clientID)
 	utils.WriteApiResponse(w, updated.ToInfoResponse(), http.StatusOK)
 }
 

--- a/pkg/client/handler.go
+++ b/pkg/client/handler.go
@@ -80,7 +80,7 @@ func HandleGetClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c, err := AdminClientByClientID(clientID)
+	c, err := ClientByClientIDIncludingDisabled(clientID)
 	if err != nil {
 		utils.WriteErrorResponse(w, http.StatusNotFound, "invalid_client", "Client not found")
 		return
@@ -141,7 +141,7 @@ func HandleUpdateClient(w http.ResponseWriter, r *http.Request) {
 	}
 
 	audit.Log(audit.EventClientUpdated, audit.ActorFromRequest(r), audit.TargetClient, clientID, nil, utils.GetClientIP(r))
-	updated, _ := AdminClientByClientID(clientID)
+	updated, _ := ClientByClientIDIncludingDisabled(clientID)
 	utils.WriteApiResponse(w, updated.ToInfoResponse(), http.StatusOK)
 }
 

--- a/pkg/client/handler_test.go
+++ b/pkg/client/handler_test.go
@@ -177,7 +177,7 @@ func TestHandleDeleteClient(t *testing.T) {
 
 	assert.Equal(t, http.StatusNoContent, rr.Code)
 
-	client, err := ClientByClientID(created.ClientID)
+	client, err := ClientByClientIDIncludingDisabled(created.ClientID)
 	assert.NoError(t, err)
 	assert.False(t, client.IsActive)
 }

--- a/pkg/client/read_test.go
+++ b/pkg/client/read_test.go
@@ -101,6 +101,43 @@ func TestClientByID_NotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
+func TestClientByClientID_ExcludesInactive(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	created, err := CreateClient(ClientCreateRequest{
+		ClientName:   "Deactivated App",
+		RedirectURIs: []string{"http://localhost:3000/callback"},
+	})
+	assert.NoError(t, err)
+
+	err = DeleteClient(created.ClientID)
+	assert.NoError(t, err)
+
+	_, err = ClientByClientID(created.ClientID)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestClientByID_ExcludesInactive(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	created, err := CreateClient(ClientCreateRequest{
+		ClientName:   "Deactivated App",
+		RedirectURIs: []string{"http://localhost:3000/callback"},
+	})
+	assert.NoError(t, err)
+
+	c, err := AdminClientByClientID(created.ClientID)
+	assert.NoError(t, err)
+
+	err = DeleteClient(created.ClientID)
+	assert.NoError(t, err)
+
+	_, err = ClientByID(c.ID)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
 func TestListClients_ExcludesInactive(t *testing.T) {
 	testutils.WithTestDB(t)
 

--- a/pkg/client/read_test.go
+++ b/pkg/client/read_test.go
@@ -127,7 +127,7 @@ func TestClientByID_ExcludesInactive(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	c, err := AdminClientByClientID(created.ClientID)
+	c, err := ClientByClientIDIncludingDisabled(created.ClientID)
 	assert.NoError(t, err)
 
 	err = DeleteClient(created.ClientID)

--- a/pkg/client/update.go
+++ b/pkg/client/update.go
@@ -9,7 +9,7 @@ import (
 
 func UpdateClient(clientID string, req ClientUpdateRequest) error {
 	// Get existing client to preserve values
-	c, err := ClientByClientID(clientID)
+	c, err := AdminClientByClientID(clientID)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/update.go
+++ b/pkg/client/update.go
@@ -9,7 +9,7 @@ import (
 
 func UpdateClient(clientID string, req ClientUpdateRequest) error {
 	// Get existing client to preserve values
-	c, err := AdminClientByClientID(clientID)
+	c, err := ClientByClientIDIncludingDisabled(clientID)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/update_test.go
+++ b/pkg/client/update_test.go
@@ -65,7 +65,7 @@ func TestUpdateClient_MultipleFields(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	updated, err := ClientByClientID(created.ClientID)
+	updated, err := ClientByClientIDIncludingDisabled(created.ClientID)
 	assert.NoError(t, err)
 	assert.Equal(t, "New Name", updated.ClientName)
 	assert.Equal(t, []string{"http://newhost.com/callback"}, updated.GetRedirectURIs())

--- a/pkg/emailverification/handler_test.go
+++ b/pkg/emailverification/handler_test.go
@@ -234,7 +234,7 @@ func TestHandleVerifyEmail_CreatesIdpSession_WhenSsoEnabled(t *testing.T) {
 	codeStr := locURL.Query().Get("code")
 	require.NotEmpty(t, codeStr)
 
-	ac, err := authcode.AuthCodeByCode(codeStr)
+	ac, err := authcode.AuthCodeByCodeIncludingUsed(codeStr)
 	require.NoError(t, err)
 	assert.NotEmpty(t, ac.IdpSessionID, "auth code should have IdpSessionID set")
 
@@ -288,7 +288,7 @@ func TestHandleVerifyEmail_CreatesIdpSession_WhenSsoDisabled(t *testing.T) {
 	codeStr := locURL.Query().Get("code")
 	require.NotEmpty(t, codeStr)
 
-	ac, err := authcode.AuthCodeByCode(codeStr)
+	ac, err := authcode.AuthCodeByCodeIncludingUsed(codeStr)
 	require.NoError(t, err)
 	assert.NotEmpty(t, ac.IdpSessionID, "auth code should have IdpSessionID even when SSO idle timeout is 0")
 

--- a/pkg/login/handler_test.go
+++ b/pkg/login/handler_test.go
@@ -112,7 +112,7 @@ func TestHandleLoginUser_InactiveClient(t *testing.T) {
 	rr := httptest.NewRecorder()
 	HandleLoginUser(rr, req)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
-	assert.Contains(t, rr.Body.String(), "Client is inactive")
+	assert.Contains(t, rr.Body.String(), "Unknown client_id")
 }
 
 func TestHandleLoginUser_InvalidScope(t *testing.T) {

--- a/pkg/mfa/crud_test.go
+++ b/pkg/mfa/crud_test.go
@@ -6,6 +6,7 @@ import (
 
 	testutils "github.com/eugenioenko/autentico/tests/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMfaChallengeCRUD(t *testing.T) {
@@ -24,18 +25,59 @@ func TestMfaChallengeCRUD(t *testing.T) {
 	err := CreateMfaChallenge(c)
 	assert.NoError(t, err)
 
-	read, err := MfaChallengeByID("chall1")
+	read, err := MfaChallengeByIDIncludingExpired("chall1")
 	assert.NoError(t, err)
 	assert.Equal(t, "user1", read.UserID)
 	assert.False(t, read.Used)
 
 	err = UpdateChallengeCode("chall1", "654321")
 	assert.NoError(t, err)
-	read, _ = MfaChallengeByID("chall1")
+	read, _ = MfaChallengeByIDIncludingExpired("chall1")
 	assert.Equal(t, "654321", read.Code)
 
 	err = MarkChallengeUsed("chall1")
 	assert.NoError(t, err)
-	read, _ = MfaChallengeByID("chall1")
+	read, _ = MfaChallengeByIDIncludingExpired("chall1")
+	assert.True(t, read.Used)
+}
+
+func TestMfaChallengeByIDIncludingExpired_ReturnsExpired(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+
+	c := MfaChallenge{
+		ID:         "expired-chall",
+		UserID:     "user1",
+		Method:     "totp",
+		Code:       "123456",
+		LoginState: "{}",
+		ExpiresAt:  time.Now().Add(-1 * time.Hour),
+	}
+	require.NoError(t, CreateMfaChallenge(c))
+
+	read, err := MfaChallengeByIDIncludingExpired("expired-chall")
+	require.NoError(t, err)
+	assert.Equal(t, "expired-chall", read.ID)
+	assert.True(t, time.Now().After(read.ExpiresAt))
+}
+
+func TestMfaChallengeByIDIncludingExpired_ReturnsUsed(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+
+	c := MfaChallenge{
+		ID:         "used-chall",
+		UserID:     "user1",
+		Method:     "totp",
+		Code:       "123456",
+		LoginState: "{}",
+		ExpiresAt:  time.Now().Add(time.Hour),
+	}
+	require.NoError(t, CreateMfaChallenge(c))
+	require.NoError(t, MarkChallengeUsed("used-chall"))
+
+	read, err := MfaChallengeByIDIncludingExpired("used-chall")
+	require.NoError(t, err)
+	assert.Equal(t, "used-chall", read.ID)
 	assert.True(t, read.Used)
 }

--- a/pkg/mfa/handler.go
+++ b/pkg/mfa/handler.go
@@ -55,7 +55,7 @@ func handleMfaGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	challenge, err := MfaChallengeByID(challengeID)
+	challenge, err := MfaChallengeByIDIncludingExpired(challengeID)
 	if err != nil {
 		redirectToLoginWithError(w, r, nil, "Verification session not found. Please log in again.")
 		return
@@ -129,7 +129,7 @@ func handleMfaPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	challenge, err := MfaChallengeByID(challengeID)
+	challenge, err := MfaChallengeByIDIncludingExpired(challengeID)
 	if err != nil {
 		redirectToLoginWithError(w, r, nil, "Verification session not found. Please log in again.")
 		return

--- a/pkg/mfa/handler_post_test.go
+++ b/pkg/mfa/handler_post_test.go
@@ -73,7 +73,7 @@ func TestHandleMfaPost_EmailLockoutAfterFiveFailures(t *testing.T) {
 	assert.Contains(t, rr.Header().Get("Location"), "Too+many+failed+attempts")
 
 	// Challenge must be marked used
-	ch, err := MfaChallengeByID("chall1")
+	ch, err := MfaChallengeByIDIncludingExpired("chall1")
 	require.NoError(t, err)
 	assert.True(t, ch.Used)
 }

--- a/pkg/mfa/read.go
+++ b/pkg/mfa/read.go
@@ -3,18 +3,19 @@ package mfa
 import (
 	"database/sql"
 	"fmt"
-	"time"
 
 	"github.com/eugenioenko/autentico/pkg/db"
 )
 
-func MfaChallengeByID(id string) (*MfaChallenge, error) {
+// MfaChallengeByIDIncludingExpired returns the challenge regardless of used/expired status.
+// Callers must check Used and ExpiresAt to provide distinct error messages to the user.
+func MfaChallengeByIDIncludingExpired(id string) (*MfaChallenge, error) {
 	var challenge MfaChallenge
 	query := `
 		SELECT id, user_id, method, code, login_state, created_at, expires_at, used, failed_attempts, otp_sent_at
-		FROM mfa_challenges WHERE id = ? AND used = 0 AND expires_at > ?
+		FROM mfa_challenges WHERE id = ?
 	`
-	row := db.GetDB().QueryRow(query, id, time.Now().UTC())
+	row := db.GetDB().QueryRow(query, id)
 	err := row.Scan(
 		&challenge.ID,
 		&challenge.UserID,

--- a/pkg/mfa/read.go
+++ b/pkg/mfa/read.go
@@ -3,6 +3,7 @@ package mfa
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/eugenioenko/autentico/pkg/db"
 )
@@ -11,9 +12,9 @@ func MfaChallengeByID(id string) (*MfaChallenge, error) {
 	var challenge MfaChallenge
 	query := `
 		SELECT id, user_id, method, code, login_state, created_at, expires_at, used, failed_attempts, otp_sent_at
-		FROM mfa_challenges WHERE id = ?
+		FROM mfa_challenges WHERE id = ? AND used = 0 AND expires_at > ?
 	`
-	row := db.GetDB().QueryRow(query, id)
+	row := db.GetDB().QueryRow(query, id, time.Now().UTC())
 	err := row.Scan(
 		&challenge.ID,
 		&challenge.UserID,

--- a/pkg/mfa/update_test.go
+++ b/pkg/mfa/update_test.go
@@ -24,7 +24,7 @@ func TestMarkChallengeUsed(t *testing.T) {
 	err := MarkChallengeUsed("c1")
 	assert.NoError(t, err)
 
-	retrieved, err := MfaChallengeByID("c1")
+	retrieved, err := MfaChallengeByIDIncludingExpired("c1")
 	assert.NoError(t, err)
 	assert.True(t, retrieved.Used)
 }
@@ -45,7 +45,7 @@ func TestUpdateChallengeCode(t *testing.T) {
 	err := UpdateChallengeCode("c1", "new-code")
 	assert.NoError(t, err)
 
-	retrieved, err := MfaChallengeByID("c1")
+	retrieved, err := MfaChallengeByIDIncludingExpired("c1")
 	assert.NoError(t, err)
 	assert.Equal(t, "new-code", retrieved.Code)
 }

--- a/pkg/passkey/crud_test.go
+++ b/pkg/passkey/crud_test.go
@@ -116,7 +116,7 @@ func TestCreatePasskeyCredential_DuplicateID(t *testing.T) {
 
 // --- PasskeyChallengeByID ---
 
-func TestPasskeyChallengeByID(t *testing.T) {
+func TestPasskeyChallengeByIDIncludingExpired(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.InsertTestUser(t, "user-1")
 
@@ -131,7 +131,7 @@ func TestPasskeyChallengeByID(t *testing.T) {
 	}
 	require.NoError(t, CreatePasskeyChallenge(challenge))
 
-	result, err := PasskeyChallengeByID("read-challenge-1")
+	result, err := PasskeyChallengeByIDIncludingExpired("read-challenge-1")
 	assert.NoError(t, err)
 	assert.Equal(t, "read-challenge-1", result.ID)
 	assert.Equal(t, "user-1", result.UserID)
@@ -139,10 +139,31 @@ func TestPasskeyChallengeByID(t *testing.T) {
 	assert.False(t, result.Used)
 }
 
+func TestPasskeyChallengeByIDIncludingExpired_ReturnsExpired(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user-1")
+
+	challenge := PasskeyChallenge{
+		ID:            "expired-challenge",
+		UserID:        "user-1",
+		ChallengeData: sampleChallengeData(),
+		Type:          "authentication",
+		LoginState:    `{}`,
+		ExpiresAt:     time.Now().Add(-1 * time.Hour),
+		Used:          false,
+	}
+	require.NoError(t, CreatePasskeyChallenge(challenge))
+
+	result, err := PasskeyChallengeByIDIncludingExpired("expired-challenge")
+	require.NoError(t, err)
+	assert.Equal(t, "expired-challenge", result.ID)
+	assert.True(t, time.Now().After(result.ExpiresAt))
+}
+
 func TestPasskeyChallengeByID_NotFound(t *testing.T) {
 	testutils.WithTestDB(t)
 
-	_, err := PasskeyChallengeByID("nonexistent")
+	_, err := PasskeyChallengeByIDIncludingExpired("nonexistent")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
@@ -221,7 +242,7 @@ func TestMarkPasskeyChallengeUsed(t *testing.T) {
 	err := MarkPasskeyChallengeUsed("used-challenge")
 	assert.NoError(t, err)
 
-	result, err := PasskeyChallengeByID("used-challenge")
+	result, err := PasskeyChallengeByIDIncludingExpired("used-challenge")
 	assert.NoError(t, err)
 	assert.True(t, result.Used)
 }

--- a/pkg/passkey/handler.go
+++ b/pkg/passkey/handler.go
@@ -301,7 +301,7 @@ func HandleLoginFinish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	challenge, err := PasskeyChallengeByID(challengeID)
+	challenge, err := PasskeyChallengeByIDIncludingExpired(challengeID)
 	if err != nil || challenge.Type != "authentication" {
 		writeJSONError(w, http.StatusBadRequest, "invalid challenge")
 		return
@@ -386,7 +386,7 @@ func HandleRegisterFinish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	challenge, err := PasskeyChallengeByID(challengeID)
+	challenge, err := PasskeyChallengeByIDIncludingExpired(challengeID)
 	if err != nil || challenge.Type != "registration" {
 		writeJSONError(w, http.StatusBadRequest, "invalid challenge")
 		return

--- a/pkg/passkey/handler_test.go
+++ b/pkg/passkey/handler_test.go
@@ -241,7 +241,7 @@ func TestHandleLoginBegin_WithCreds_CreatesChallenge(t *testing.T) {
 	require.NotEmpty(t, challengeID)
 
 	// The challenge must exist in DB, be of type authentication, and not yet used
-	challenge, err := PasskeyChallengeByID(challengeID)
+	challenge, err := PasskeyChallengeByIDIncludingExpired(challengeID)
 	require.NoError(t, err)
 	assert.Equal(t, "authentication", challenge.Type)
 	assert.False(t, challenge.Used)

--- a/pkg/passkey/read.go
+++ b/pkg/passkey/read.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/go-webauthn/webauthn/webauthn"
@@ -13,9 +14,9 @@ func PasskeyChallengeByID(id string) (*PasskeyChallenge, error) {
 	var c PasskeyChallenge
 	query := `
 		SELECT id, user_id, challenge_data, type, login_state, created_at, expires_at, used
-		FROM passkey_challenges WHERE id = ?
+		FROM passkey_challenges WHERE id = ? AND used = 0 AND expires_at > ?
 	`
-	row := db.GetDB().QueryRow(query, id)
+	row := db.GetDB().QueryRow(query, id, time.Now().UTC())
 	err := row.Scan(
 		&c.ID,
 		&c.UserID,

--- a/pkg/passkey/read.go
+++ b/pkg/passkey/read.go
@@ -4,19 +4,20 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/go-webauthn/webauthn/webauthn"
 )
 
-func PasskeyChallengeByID(id string) (*PasskeyChallenge, error) {
+// PasskeyChallengeByIDIncludingExpired returns the challenge regardless of used/expired status.
+// Callers must check Used and ExpiresAt to provide distinct error messages to the user.
+func PasskeyChallengeByIDIncludingExpired(id string) (*PasskeyChallenge, error) {
 	var c PasskeyChallenge
 	query := `
 		SELECT id, user_id, challenge_data, type, login_state, created_at, expires_at, used
-		FROM passkey_challenges WHERE id = ? AND used = 0 AND expires_at > ?
+		FROM passkey_challenges WHERE id = ?
 	`
-	row := db.GetDB().QueryRow(query, id, time.Now().UTC())
+	row := db.GetDB().QueryRow(query, id)
 	err := row.Scan(
 		&c.ID,
 		&c.UserID,

--- a/pkg/session/admin_handler_test.go
+++ b/pkg/session/admin_handler_test.go
@@ -77,7 +77,7 @@ func TestHandleDeactivateSession(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 
-	sess, _ := SessionByID("sess1")
+	sess, _ := SessionByIDIncludingDeactivated("sess1")
 	assert.NotNil(t, sess.DeactivatedAt)
 }
 

--- a/pkg/session/read.go
+++ b/pkg/session/read.go
@@ -65,11 +65,13 @@ func DeactivateSessionByID(sessionID string) error {
 	return nil
 }
 
-func SessionByID(sessionID string) (*Session, error) {
+// SessionByIDIncludingDeactivated returns the session regardless of deactivation status.
+// Callers must check DeactivatedAt to provide distinct error messages to the user.
+func SessionByIDIncludingDeactivated(sessionID string) (*Session, error) {
 	var session Session
 	query := `
 		SELECT id, user_id, access_token, refresh_token, user_agent, ip_address, location, created_at, expires_at, deactivated_at, idp_session_id
-		FROM sessions WHERE id = ? AND deactivated_at IS NULL
+		FROM sessions WHERE id = ?
 	`
 	row := db.GetDB().QueryRow(query, sessionID)
 	err := row.Scan(

--- a/pkg/session/read.go
+++ b/pkg/session/read.go
@@ -69,7 +69,7 @@ func SessionByID(sessionID string) (*Session, error) {
 	var session Session
 	query := `
 		SELECT id, user_id, access_token, refresh_token, user_agent, ip_address, location, created_at, expires_at, deactivated_at, idp_session_id
-		FROM sessions WHERE id = ?
+		FROM sessions WHERE id = ? AND deactivated_at IS NULL
 	`
 	row := db.GetDB().QueryRow(query, sessionID)
 	err := row.Scan(

--- a/pkg/session/read_test.go
+++ b/pkg/session/read_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSessionByID(t *testing.T) {
+func TestSessionByIDIncludingDeactivated(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.InsertTestUser(t, "test-user-id")
 
@@ -29,7 +29,7 @@ func TestSessionByID(t *testing.T) {
 	assert.NoError(t, err, "failed to create test session")
 
 	// Test: Retrieve the session by ID
-	retrievedSession, err := SessionByID("test-session-id")
+	retrievedSession, err := SessionByIDIncludingDeactivated("test-session-id")
 	assert.NoError(t, err, "failed to retrieve session by ID")
 	assert.NotNil(t, retrievedSession, "retrieved session is nil")
 
@@ -48,7 +48,7 @@ func TestSessionByID(t *testing.T) {
 func TestSessionByID_NotFound(t *testing.T) {
 	testutils.WithTestDB(t)
 
-	result, err := SessionByID("nonexistent-session")
+	result, err := SessionByIDIncludingDeactivated("nonexistent-session")
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "session not found")
@@ -123,7 +123,7 @@ func TestDeactivateSessionByID(t *testing.T) {
 	err := DeactivateSessionByID("s1")
 	assert.NoError(t, err)
 
-	s, err := SessionByID("s1")
+	s, err := SessionByIDIncludingDeactivated("s1")
 	assert.NoError(t, err)
 	assert.NotNil(t, s.DeactivatedAt)
 }

--- a/pkg/token/authorization_code.go
+++ b/pkg/token/authorization_code.go
@@ -21,7 +21,7 @@ func UserByAuthorizationCode(w http.ResponseWriter, request TokenRequest) (*user
 		return nil, nil, err
 	}
 
-	code, err := authcode.AuthCodeByCode(request.Code)
+	code, err := authcode.AuthCodeByCodeIncludingUsed(request.Code)
 	if err != nil {
 		slog.Warn("token: authorization code not found", "error", err)
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_grant", fmt.Sprintf("%v", err))

--- a/pkg/token/refresh_token.go
+++ b/pkg/token/refresh_token.go
@@ -56,7 +56,7 @@ func UserByRefreshToken(w http.ResponseWriter, request TokenRequest) (*user.User
 		return nil, err
 	}
 
-	sess, err := session.SessionByID(authToken.SessionID)
+	sess, err := session.SessionByIDIncludingDeactivated(authToken.SessionID)
 	if err != nil {
 		slog.Warn("token: session not found for refresh token", "error", err, "session_id", authToken.SessionID)
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_grant", fmt.Sprintf("Failed to retrieve session: %v", err))

--- a/pkg/trusteddevice/read.go
+++ b/pkg/trusteddevice/read.go
@@ -3,7 +3,6 @@ package trusteddevice
 import (
 	"database/sql"
 	"fmt"
-	"time"
 
 	"github.com/eugenioenko/autentico/pkg/db"
 )
@@ -30,13 +29,15 @@ func TrustedDevicesByUserID(userID string) ([]*TrustedDevice, error) {
 	return devices, rows.Err()
 }
 
-func TrustedDeviceByID(id string) (*TrustedDevice, error) {
+// TrustedDeviceByIDIncludingExpired returns the device regardless of expiration status.
+// Callers must check ExpiresAt to handle expired devices appropriately.
+func TrustedDeviceByIDIncludingExpired(id string) (*TrustedDevice, error) {
 	var d TrustedDevice
 	query := `
 		SELECT id, user_id, device_name, created_at, last_used_at, expires_at
-		FROM trusted_devices WHERE id = ? AND expires_at > ?
+		FROM trusted_devices WHERE id = ?
 	`
-	row := db.GetDB().QueryRow(query, id, time.Now().UTC())
+	row := db.GetDB().QueryRow(query, id)
 	err := row.Scan(&d.ID, &d.UserID, &d.DeviceName, &d.CreatedAt, &d.LastUsedAt, &d.ExpiresAt)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/pkg/trusteddevice/read.go
+++ b/pkg/trusteddevice/read.go
@@ -3,6 +3,7 @@ package trusteddevice
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/eugenioenko/autentico/pkg/db"
 )
@@ -33,9 +34,9 @@ func TrustedDeviceByID(id string) (*TrustedDevice, error) {
 	var d TrustedDevice
 	query := `
 		SELECT id, user_id, device_name, created_at, last_used_at, expires_at
-		FROM trusted_devices WHERE id = ?
+		FROM trusted_devices WHERE id = ? AND expires_at > ?
 	`
-	row := db.GetDB().QueryRow(query, id)
+	row := db.GetDB().QueryRow(query, id, time.Now().UTC())
 	err := row.Scan(&d.ID, &d.UserID, &d.DeviceName, &d.CreatedAt, &d.LastUsedAt, &d.ExpiresAt)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/pkg/trusteddevice/service.go
+++ b/pkg/trusteddevice/service.go
@@ -39,7 +39,7 @@ func IsDeviceTrusted(userID string, r *http.Request) bool {
 	if token == "" {
 		return false
 	}
-	device, err := TrustedDeviceByID(token)
+	device, err := TrustedDeviceByIDIncludingExpired(token)
 	if err != nil {
 		return false
 	}

--- a/pkg/trusteddevice/trusteddevice_test.go
+++ b/pkg/trusteddevice/trusteddevice_test.go
@@ -41,22 +41,39 @@ func TestCreateTrustedDeviceDuplicateID(t *testing.T) {
 
 // --- TrustedDeviceByID ---
 
-func TestTrustedDeviceByID(t *testing.T) {
+func TestTrustedDeviceByIDIncludingExpired(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.InsertTestUser(t, "user-read-1")
 	dev := sampleDevice("dev-read-1", "user-read-1")
 	require.NoError(t, CreateTrustedDevice(dev))
 
-	got, err := TrustedDeviceByID("dev-read-1")
+	got, err := TrustedDeviceByIDIncludingExpired("dev-read-1")
 	require.NoError(t, err)
 	assert.Equal(t, dev.ID, got.ID)
 	assert.Equal(t, dev.UserID, got.UserID)
 	assert.Equal(t, dev.DeviceName, got.DeviceName)
 }
 
+func TestTrustedDeviceByIDIncludingExpired_ReturnsExpired(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user-exp-read")
+	dev := TrustedDevice{
+		ID:         "dev-expired-read",
+		UserID:     "user-exp-read",
+		DeviceName: "TestBrowser",
+		ExpiresAt:  time.Now().Add(-1 * time.Hour),
+	}
+	require.NoError(t, CreateTrustedDevice(dev))
+
+	got, err := TrustedDeviceByIDIncludingExpired("dev-expired-read")
+	require.NoError(t, err)
+	assert.Equal(t, "dev-expired-read", got.ID)
+	assert.True(t, time.Now().After(got.ExpiresAt))
+}
+
 func TestTrustedDeviceByIDNotFound(t *testing.T) {
 	testutils.WithTestDB(t)
-	_, err := TrustedDeviceByID("does-not-exist")
+	_, err := TrustedDeviceByIDIncludingExpired("does-not-exist")
 	assert.Error(t, err)
 }
 
@@ -71,7 +88,7 @@ func TestUpdateLastUsed(t *testing.T) {
 	err := UpdateLastUsed("dev-update-1")
 	require.NoError(t, err)
 
-	got, err := TrustedDeviceByID("dev-update-1")
+	got, err := TrustedDeviceByIDIncludingExpired("dev-update-1")
 	require.NoError(t, err)
 	assert.Equal(t, "dev-update-1", got.ID)
 }
@@ -191,6 +208,6 @@ func TestDeleteTrustedDevice(t *testing.T) {
 	err := DeleteTrustedDevice("dev-1")
 	assert.NoError(t, err)
 
-	_, err = TrustedDeviceByID("dev-1")
+	_, err = TrustedDeviceByIDIncludingExpired("dev-1")
 	assert.Error(t, err)
 }

--- a/tests/e2e/client_auth_test.go
+++ b/tests/e2e/client_auth_test.go
@@ -258,7 +258,7 @@ func TestInactiveClient_Rejected(t *testing.T) {
 
 	body, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "inactive client should be rejected at /authorize: %s", string(body))
-	assert.Contains(t, string(body), "Client is inactive")
+	assert.Contains(t, string(body), "Unknown client_id")
 }
 
 func TestClient_GrantTypeRestriction(t *testing.T) {


### PR DESCRIPTION
## Summary

- **OAuth2 reads** (`ClientByClientID`, `ClientByID`, `AuthCodeByCode`) now filter out inactive/expired/used records at the SQL layer, preventing stale data from leaking through even if caller-side checks have bugs
- **Admin reads** (`AdminClientByClientID`, `AdminClientByID`) return all records regardless of `is_active` status for admin API use
- **Renamed unfiltered functions** to `IncludingExpired`/`IncludingDeactivated`/`IncludingUsed` (`MfaChallengeByIDIncludingExpired`, `PasskeyChallengeByIDIncludingExpired`, `TrustedDeviceByIDIncludingExpired`, `SessionByIDIncludingDeactivated`, `AuthCodeByCodeIncludingUsed`) — callers that need to distinguish "not found" from "expired" for user-facing error messages use these explicitly
- **Defense in depth**: application-level `IsActive`/`Used`/`ExpiresAt` checks retained as safety nets alongside SQL filtering
- **Tests added** for all behavioral changes: filtered reads reject expired/inactive/used records; unfiltered reads return them

Closes #250

## Test plan

- [x] `go test -p 1 ./...` — all tests pass
- [x] Inactive clients return "Unknown client_id" at `/authorize` (no information leakage)
- [x] Expired/used auth codes filtered by `AuthCodeByCode`, returned by `AuthCodeByCodeIncludingUsed`
- [x] Expired MFA/passkey challenges and trusted devices returned by `IncludingExpired` variants
- [x] Deactivated sessions returned by `SessionByIDIncludingDeactivated`
- [x] E2E test `TestInactiveClient_Rejected` passes with updated expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)