### PR TITLE
fix: clamp negative offset and add list query edge case tests

### DIFF
--- a/pkg/api/listquery.go
+++ b/pkg/api/listquery.go
@@ -108,7 +108,11 @@ func BuildListQuery(params ListParams, cfg ListConfig) ListResult {
 	if limit <= 0 || limit > maxLimit {
 		limit = maxLimit
 	}
-	result.Order += fmt.Sprintf(" LIMIT %d OFFSET %d", limit, params.Offset)
+	offset := params.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	result.Order += fmt.Sprintf(" LIMIT %d OFFSET %d", limit, offset)
 
 	return result
 }

--- a/pkg/api/listquery_test.go
+++ b/pkg/api/listquery_test.go
@@ -101,6 +101,31 @@ func TestBuildListQuery_LimitCapped(t *testing.T) {
 	assert.Contains(t, result.Order, "LIMIT 50")
 }
 
+func TestBuildListQuery_NegativeLimit(t *testing.T) {
+	params := ListParams{Limit: -10}
+	result := BuildListQuery(params, testConfig)
+	assert.Contains(t, result.Order, "LIMIT 50 OFFSET 0")
+}
+
+func TestBuildListQuery_NegativeOffset(t *testing.T) {
+	params := ListParams{Limit: 10, Offset: -5}
+	result := BuildListQuery(params, testConfig)
+	assert.Contains(t, result.Order, "LIMIT 10 OFFSET 0")
+}
+
+func TestBuildListQuery_ZeroLimit(t *testing.T) {
+	params := ListParams{Limit: 0}
+	result := BuildListQuery(params, testConfig)
+	assert.Contains(t, result.Order, "LIMIT 50 OFFSET 0")
+}
+
+func TestParseListParams_NonNumeric(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/items?limit=abc&offset=xyz", nil)
+	params := ParseListParams(req)
+	assert.Equal(t, 0, params.Limit)
+	assert.Equal(t, 0, params.Offset)
+}
+
 func TestBuildListQuery_SearchAndFilter(t *testing.T) {
 	params := ListParams{
 		Search:  "test",


### PR DESCRIPTION
## Summary

- Clamp negative `offset` to 0 in `BuildListQuery` (limit was already clamped, offset was not)
- Add edge case tests: negative limit, negative offset, zero limit, non-numeric params

Follow-up to #254 — these changes were committed after the squash merge.

## Test plan

- [x] `go test ./pkg/api/...` — all 16 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)