### PR TITLE
feat: server-side list queries for groups admin

### DIFF
--- a/admin-ui/src/api/groups.ts
+++ b/admin-ui/src/api/groups.ts
@@ -1,4 +1,5 @@
 import apiClient from "./client";
+import type { ListParams, ListResponse } from "./users";
 import type {
   Group,
   GroupCreateRequest,
@@ -8,8 +9,20 @@ import type {
 
 const BASE = "/admin/api/groups";
 
-export async function listGroups(): Promise<Group[]> {
-  const { data } = await apiClient.get<{ data: Group[] }>(BASE);
+export async function listGroups(
+  params?: ListParams
+): Promise<ListResponse<Group>> {
+  const query = new URLSearchParams();
+  if (params) {
+    for (const [key, val] of Object.entries(params)) {
+      if (val !== undefined && val !== "") {
+        query.set(key, String(val));
+      }
+    }
+  }
+  const qs = query.toString();
+  const url = qs ? `${BASE}?${qs}` : BASE;
+  const { data } = await apiClient.get<{ data: ListResponse<Group> }>(url);
   return data.data;
 }
 

--- a/admin-ui/src/components/users/UserGroupsDrawer.tsx
+++ b/admin-ui/src/components/users/UserGroupsDrawer.tsx
@@ -57,7 +57,7 @@ export default function UserGroupsDrawer({ open, userId, username, onClose }: Us
   };
 
   const memberGroupIds = new Set((userGroups ?? []).map((g) => g.id));
-  const availableGroups = (allGroups ?? []).filter((g) => !memberGroupIds.has(g.id));
+  const availableGroups = (allGroups?.items ?? []).filter((g) => !memberGroupIds.has(g.id));
 
   const columns: ColumnsType<Group> = [
     { title: "Name", dataIndex: "name", key: "name" },

--- a/admin-ui/src/hooks/useGroups.ts
+++ b/admin-ui/src/hooks/useGroups.ts
@@ -8,14 +8,15 @@ import {
   addMember,
   removeMember,
 } from "../api/groups";
+import type { ListParams } from "../api/users";
 import type { GroupCreateRequest, GroupUpdateRequest } from "../types/group";
 
 const GROUPS_KEY = ["groups"] as const;
 
-export function useGroups() {
+export function useGroups(params?: ListParams) {
   return useQuery({
-    queryKey: GROUPS_KEY,
-    queryFn: listGroups,
+    queryKey: [...GROUPS_KEY, params],
+    queryFn: () => listGroups(params),
   });
 }
 
@@ -67,6 +68,7 @@ export function useAddMember() {
       queryClient.invalidateQueries({
         queryKey: ["group-members", variables.groupId],
       });
+      queryClient.invalidateQueries({ queryKey: GROUPS_KEY });
     },
   });
 }
@@ -80,6 +82,7 @@ export function useRemoveMember() {
       queryClient.invalidateQueries({
         queryKey: ["group-members", variables.groupId],
       });
+      queryClient.invalidateQueries({ queryKey: GROUPS_KEY });
     },
   });
 }

--- a/admin-ui/src/pages/GroupsPage.tsx
+++ b/admin-ui/src/pages/GroupsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback, useRef } from "react";
 import {
   Typography,
   Table,
@@ -10,7 +10,8 @@ import {
   Modal,
   Form,
   Input,
-  Select,
+  AutoComplete,
+  Tag,
 } from "antd";
 import {
   PlusOutlined,
@@ -20,7 +21,8 @@ import {
   TeamOutlined,
   ArrowLeftOutlined,
 } from "@ant-design/icons";
-import type { ColumnsType } from "antd/es/table";
+import type { ColumnsType, TablePaginationConfig } from "antd/es/table";
+import type { SorterResult } from "antd/es/table/interface";
 import {
   useGroups,
   useCreateGroup,
@@ -31,8 +33,10 @@ import {
   useRemoveMember,
 } from "../hooks/useGroups";
 import { useUsers } from "../hooks/useUsers";
-import type { UserResponseExt } from "../types/user";
+import type { ListParams } from "../api/users";
 import type { Group, GroupMember } from "../types/group";
+import { useTableScrollY } from "../hooks/useTableScrollY";
+import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from "../constants/table";
 
 function GroupMembersView({
   group,
@@ -41,12 +45,44 @@ function GroupMembersView({
   group: Group;
   onBack: () => void;
 }) {
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+  const scrollY = useTableScrollY(tableContainerRef);
+
   const { data: members, isLoading } = useGroupMembers(group.id);
-  const { data: users } = useUsers();
   const addMember = useAddMember();
   const removeMember = useRemoveMember();
   const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
   const [adding, setAdding] = useState(false);
+  const [userSearch, setUserSearch] = useState("");
+  const [userSearchParams, setUserSearchParams] = useState<ListParams>({
+    limit: 20,
+    offset: 0,
+  });
+  const { data: usersData } = useUsers(userSearchParams);
+
+  const memberUserIds = new Set((members ?? []).map((m) => m.user_id));
+  const userOptions = (usersData?.items ?? [])
+    .filter((u) => !memberUserIds.has(u.id) && !selectedUserIds.includes(u.id))
+    .map((u) => ({
+      value: u.id,
+      label: `${u.username} (${u.email})`,
+    }));
+
+  const handleUserSearch = (value: string) => {
+    setUserSearch(value);
+    setUserSearchParams((prev) => ({
+      ...prev,
+      search: value || undefined,
+      offset: 0,
+    }));
+  };
+
+  const handleSelectUser = (userId: string) => {
+    if (!selectedUserIds.includes(userId)) {
+      setSelectedUserIds((prev) => [...prev, userId]);
+    }
+    setUserSearch("");
+  };
 
   const handleAddSelected = async () => {
     if (selectedUserIds.length === 0) return;
@@ -77,9 +113,10 @@ function GroupMembersView({
     }
   };
 
-  const memberUserIds = new Set((members ?? []).map((m) => m.user_id));
-  const allUsers = users?.items ?? [];
-  const availableUsers = allUsers.filter((u: UserResponseExt) => !memberUserIds.has(u.id));
+  const selectedUsers = selectedUserIds.map((id) => {
+    const user = usersData?.items?.find((u) => u.id === id);
+    return { id, label: user ? user.username : id };
+  });
 
   const columns: ColumnsType<GroupMember> = [
     { title: "Username", dataIndex: "username", key: "username" },
@@ -113,38 +150,37 @@ function GroupMembersView({
   ];
 
   return (
-    <Space direction="vertical" size="middle" style={{ display: "flex" }}>
-      <Space>
-        <Button icon={<ArrowLeftOutlined />} onClick={onBack}>
-          Back to Groups
-        </Button>
+    <>
+      <Space style={{ justifyContent: "space-between", width: "100%", flexShrink: 0 }}>
+        <Space>
+          <Button icon={<ArrowLeftOutlined />} onClick={onBack}>
+            Back to Groups
+          </Button>
+          <Typography.Title level={4} style={{ margin: 0 }}>
+            Members of {group.name}
+          </Typography.Title>
+        </Space>
       </Space>
 
-      <Typography.Title level={4} style={{ margin: 0 }}>
-        Members of {group.name}
-      </Typography.Title>
-
       {group.description && (
-        <Typography.Text type="secondary">{group.description}</Typography.Text>
+        <Typography.Text type="secondary" style={{ display: "block", marginTop: 8, flexShrink: 0 }}>
+          {group.description}
+        </Typography.Text>
       )}
 
-      <div>
+      <div style={{ marginTop: 12, flexShrink: 0 }}>
         <Typography.Text type="secondary" style={{ display: "block", marginBottom: 8 }}>
           Add members
         </Typography.Text>
-        <Space.Compact style={{ width: "100%" }}>
-          <Select
-            mode="multiple"
-            style={{ width: "100%" }}
-            placeholder="Select users to add"
-            showSearch
-            optionFilterProp="label"
-            value={selectedUserIds}
-            onChange={setSelectedUserIds}
-            options={availableUsers.map((u) => ({
-              value: u.id,
-              label: `${u.username} (${u.email})`,
-            }))}
+        <Space.Compact style={{ maxWidth: 480 }}>
+          <AutoComplete
+            style={{ width: 320 }}
+            placeholder="Search users to add"
+            options={userOptions}
+            value={userSearch}
+            onSearch={handleUserSearch}
+            onSelect={handleSelectUser}
+            allowClear
           />
           <Button
             type="primary"
@@ -153,29 +189,52 @@ function GroupMembersView({
             loading={adding}
             disabled={selectedUserIds.length === 0}
           >
-            Add
+            Add{selectedUserIds.length > 0 ? ` (${selectedUserIds.length})` : ""}
           </Button>
         </Space.Compact>
+        {selectedUsers.length > 0 && (
+          <div style={{ marginTop: 8, display: "flex", flexWrap: "wrap", gap: 4, alignItems: "center" }}>
+            {selectedUsers.map((u) => (
+              <Tag
+                key={u.id}
+                closable
+                onClose={() => setSelectedUserIds((prev) => prev.filter((id) => id !== u.id))}
+              >
+                {u.label}
+              </Tag>
+            ))}
+          </div>
+        )}
       </div>
 
-      <Typography.Text type="secondary">
-        {(members ?? []).length} member{(members ?? []).length !== 1 ? "s" : ""}
-      </Typography.Text>
-
-      <Table<GroupMember>
-        columns={columns}
-        dataSource={members ?? []}
-        rowKey="user_id"
-        loading={isLoading}
-        pagination={false}
-        size="small"
-      />
-    </Space>
+      <div ref={tableContainerRef} style={{ flex: 1, overflow: "hidden", marginTop: 16 }}>
+        <Table<GroupMember>
+          columns={columns}
+          dataSource={members ?? []}
+          rowKey="user_id"
+          loading={isLoading}
+          scroll={scrollY ? { y: scrollY } : undefined}
+          pagination={false}
+          size="small"
+        />
+      </div>
+    </>
   );
 }
 
 export default function GroupsPage() {
-  const { data: groups, isLoading, error } = useGroups();
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+  const scrollY = useTableScrollY(tableContainerRef);
+
+  const [listParams, setListParams] = useState<ListParams>({
+    limit: DEFAULT_PAGE_SIZE,
+    offset: 0,
+    sort: "name",
+    order: "asc",
+  });
+  const [searchValue, setSearchValue] = useState("");
+
+  const { data, isLoading, error } = useGroups(listParams);
   const createGroup = useCreateGroup();
   const updateGroup = useUpdateGroup();
   const deleteGroupMutation = useDeleteGroup();
@@ -219,6 +278,32 @@ export default function GroupsPage() {
     }
   };
 
+  const handleTableChange = useCallback(
+    (
+      pagination: TablePaginationConfig,
+      _filters: Record<string, unknown>,
+      sorter: SorterResult<Group> | SorterResult<Group>[]
+    ) => {
+      const s = Array.isArray(sorter) ? sorter[0] : sorter;
+      setListParams((prev) => ({
+        ...prev,
+        offset: ((pagination.current ?? 1) - 1) * (pagination.pageSize ?? DEFAULT_PAGE_SIZE),
+        limit: pagination.pageSize ?? DEFAULT_PAGE_SIZE,
+        sort: s.field ? String(s.field) : "name",
+        order: s.order === "descend" ? "desc" : "asc",
+      }));
+    },
+    []
+  );
+
+  const handleSearch = useCallback((value: string) => {
+    setListParams((prev) => ({
+      ...prev,
+      search: value || undefined,
+      offset: 0,
+    }));
+  }, []);
+
   if (membersGroup) {
     return (
       <GroupMembersView
@@ -229,7 +314,12 @@ export default function GroupsPage() {
   }
 
   const columns: ColumnsType<Group> = [
-    { title: "Name", dataIndex: "name", key: "name" },
+    {
+      title: "Name",
+      dataIndex: "name",
+      key: "name",
+      sorter: true,
+    },
     {
       title: "Description",
       dataIndex: "description",
@@ -237,17 +327,38 @@ export default function GroupsPage() {
       ellipsis: true,
     },
     {
+      title: "Members",
+      dataIndex: "member_count",
+      key: "member_count",
+      width: 100,
+    },
+    {
       title: "Created",
       dataIndex: "created_at",
       key: "created_at",
+      sorter: true,
       render: (val: string) => new Date(val).toLocaleDateString(),
     },
     {
       title: "Actions",
       key: "actions",
-      width: 150,
+      width: 120,
       render: (_, record) => (
         <Space>
+          <Popconfirm
+            title="Delete this group?"
+            description="All memberships will be removed."
+            onConfirm={() => handleDelete(record.id)}
+            okText="Delete"
+            okButtonProps={{ danger: true }}
+          >
+            <Button
+              type="text"
+              size="small"
+              danger
+              icon={<DeleteOutlined />}
+            />
+          </Popconfirm>
           <Button
             type="text"
             size="small"
@@ -266,20 +377,6 @@ export default function GroupsPage() {
               });
             }}
           />
-          <Popconfirm
-            title="Delete this group?"
-            description="All memberships will be removed."
-            onConfirm={() => handleDelete(record.id)}
-            okText="Delete"
-            okButtonProps={{ danger: true }}
-          >
-            <Button
-              type="text"
-              size="small"
-              danger
-              icon={<DeleteOutlined />}
-            />
-          </Popconfirm>
         </Space>
       ),
     },
@@ -291,11 +388,19 @@ export default function GroupsPage() {
 
   return (
     <>
-      <Space direction="vertical" size="middle" style={{ display: "flex" }}>
-        <Space style={{ justifyContent: "space-between", width: "100%" }}>
-          <Typography.Title level={4} style={{ margin: 0 }}>
-            Groups
-          </Typography.Title>
+      <Space style={{ justifyContent: "space-between", width: "100%", flexShrink: 0 }}>
+        <Typography.Title level={4} style={{ margin: 0 }}>
+          Groups
+        </Typography.Title>
+        <Space>
+          <Input.Search
+            placeholder="Search groups..."
+            allowClear
+            value={searchValue}
+            onChange={(e) => setSearchValue(e.target.value)}
+            onSearch={handleSearch}
+            style={{ width: 250 }}
+          />
           <Button
             type="primary"
             icon={<PlusOutlined />}
@@ -304,15 +409,26 @@ export default function GroupsPage() {
             Create Group
           </Button>
         </Space>
+      </Space>
 
+      <div ref={tableContainerRef} style={{ flex: 1, overflow: "hidden", marginTop: 16 }}>
         <Table<Group>
           columns={columns}
-          dataSource={groups ?? []}
+          dataSource={data?.items ?? []}
           rowKey="id"
           loading={isLoading}
-          pagination={false}
+          onChange={handleTableChange}
+          scroll={scrollY ? { y: scrollY } : undefined}
+          pagination={{
+            current: Math.floor((listParams.offset ?? 0) / (listParams.limit ?? DEFAULT_PAGE_SIZE)) + 1,
+            pageSize: listParams.limit ?? DEFAULT_PAGE_SIZE,
+            total: data?.total ?? 0,
+            showSizeChanger: true,
+            pageSizeOptions: PAGE_SIZE_OPTIONS,
+            showTotal: (total) => `${total} groups`,
+          }}
         />
-      </Space>
+      </div>
 
       {/* Create Modal */}
       <Modal

--- a/admin-ui/src/pages/SettingsPage.tsx
+++ b/admin-ui/src/pages/SettingsPage.tsx
@@ -226,6 +226,7 @@ export default function SettingsPage() {
   if (error) return <Alert type="error" message="Failed to load settings" />;
 
   return (
+    <div style={{ flex: 1, overflow: "auto" }}>
     <Space direction="vertical" size="large" style={{ display: "flex" }}>
       <div>
         <Title level={2}>System Settings</Title>
@@ -959,5 +960,6 @@ export default function SettingsPage() {
         )}
       </Form>
     </Space>
+    </div>
   );
 }

--- a/admin-ui/src/pages/UsersPage.tsx
+++ b/admin-ui/src/pages/UsersPage.tsx
@@ -222,7 +222,7 @@ export default function UsersPage() {
     {
       title: "Groups",
       key: "groups",
-      filters: (groups ?? []).map((g) => ({ text: g.name, value: g.name })),
+      filters: (groups?.items ?? []).map((g) => ({ text: g.name, value: g.name })),
       filterMultiple: false,
       render: (_, record) => <TagOverflow items={record.groups} />,
     },

--- a/admin-ui/src/types/group.d.ts
+++ b/admin-ui/src/types/group.d.ts
@@ -2,6 +2,7 @@ export interface Group {
   id: string;
   name: string;
   description: string;
+  member_count: number;
   created_at: string;
   updated_at: string;
 }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1620,14 +1620,46 @@ const docTemplate = `{
                     "admin-groups"
                 ],
                 "summary": "List all groups",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Sort field (name, created_at, updated_at)",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "asc",
+                        "description": "Sort order (asc, desc)",
+                        "name": "order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search across name and description",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 100,
+                        "description": "Max results per page (1–100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Number of results to skip",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/group.GroupResponse"
-                            }
+                            "$ref": "#/definitions/model.ListResponse-group_GroupResponse"
                         }
                     }
                 }
@@ -2314,14 +2346,70 @@ const docTemplate = `{
                     "admin-users"
                 ],
                 "summary": "List all users",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Sort field (username, email, created_at, updated_at, role, id, given_name, family_name, middle_name, nickname, phone_number)",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "desc",
+                        "description": "Sort order (asc, desc)",
+                        "name": "order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search across username, email, id, given_name, family_name, middle_name, nickname, phone_number",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 100,
+                        "description": "Max results per page (1–100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Number of results to skip",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by role (admin, user)",
+                        "name": "role",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by email verification (0, 1)",
+                        "name": "is_email_verified",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by MFA enrollment (0, 1)",
+                        "name": "totp_verified",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by group name",
+                        "name": "group",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/user.UserResponse"
-                            }
+                            "$ref": "#/definitions/model.ListResponse-user_UserResponse"
                         }
                     },
                     "500": {
@@ -4054,6 +4142,9 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "member_count": {
+                    "type": "integer"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -4236,6 +4327,34 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/model.JWK"
                     }
+                }
+            }
+        },
+        "model.ListResponse-group_GroupResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/group.GroupResponse"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "model.ListResponse-user_UserResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/user.UserResponse"
+                    }
+                },
+                "total": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1614,14 +1614,46 @@
                     "admin-groups"
                 ],
                 "summary": "List all groups",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Sort field (name, created_at, updated_at)",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "asc",
+                        "description": "Sort order (asc, desc)",
+                        "name": "order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search across name and description",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 100,
+                        "description": "Max results per page (1–100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Number of results to skip",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/group.GroupResponse"
-                            }
+                            "$ref": "#/definitions/model.ListResponse-group_GroupResponse"
                         }
                     }
                 }
@@ -2308,14 +2340,70 @@
                     "admin-users"
                 ],
                 "summary": "List all users",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Sort field (username, email, created_at, updated_at, role, id, given_name, family_name, middle_name, nickname, phone_number)",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "desc",
+                        "description": "Sort order (asc, desc)",
+                        "name": "order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search across username, email, id, given_name, family_name, middle_name, nickname, phone_number",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 100,
+                        "description": "Max results per page (1–100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Number of results to skip",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by role (admin, user)",
+                        "name": "role",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by email verification (0, 1)",
+                        "name": "is_email_verified",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by MFA enrollment (0, 1)",
+                        "name": "totp_verified",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by group name",
+                        "name": "group",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/user.UserResponse"
-                            }
+                            "$ref": "#/definitions/model.ListResponse-user_UserResponse"
                         }
                     },
                     "500": {
@@ -4048,6 +4136,9 @@
                 "id": {
                     "type": "string"
                 },
+                "member_count": {
+                    "type": "integer"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -4230,6 +4321,34 @@
                     "items": {
                         "$ref": "#/definitions/model.JWK"
                     }
+                }
+            }
+        },
+        "model.ListResponse-group_GroupResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/group.GroupResponse"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "model.ListResponse-user_UserResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/user.UserResponse"
+                    }
+                },
+                "total": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -437,6 +437,8 @@ definitions:
         type: string
       id:
         type: string
+      member_count:
+        type: integer
       name:
         type: string
       updated_at:
@@ -562,6 +564,24 @@ definitions:
         items:
           $ref: '#/definitions/model.JWK'
         type: array
+    type: object
+  model.ListResponse-group_GroupResponse:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/group.GroupResponse'
+        type: array
+      total:
+        type: integer
+    type: object
+  model.ListResponse-user_UserResponse:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/user.UserResponse'
+        type: array
+      total:
+        type: integer
     type: object
   model.WellKnownConfigResponse:
     properties:
@@ -1852,15 +1872,37 @@ paths:
       - admin-federation
   /admin/api/groups:
     get:
+      parameters:
+      - description: Sort field (name, created_at, updated_at)
+        in: query
+        name: sort
+        type: string
+      - default: asc
+        description: Sort order (asc, desc)
+        in: query
+        name: order
+        type: string
+      - description: Search across name and description
+        in: query
+        name: search
+        type: string
+      - default: 100
+        description: Max results per page (1–100)
+        in: query
+        name: limit
+        type: integer
+      - default: 0
+        description: Number of results to skip
+        in: query
+        name: offset
+        type: integer
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/group.GroupResponse'
-            type: array
+            $ref: '#/definitions/model.ListResponse-group_GroupResponse'
       security:
       - AdminAuth: []
       summary: List all groups
@@ -2285,15 +2327,55 @@ paths:
       - admin-settings
   /admin/api/users:
     get:
+      parameters:
+      - description: Sort field (username, email, created_at, updated_at, role, id,
+          given_name, family_name, middle_name, nickname, phone_number)
+        in: query
+        name: sort
+        type: string
+      - default: desc
+        description: Sort order (asc, desc)
+        in: query
+        name: order
+        type: string
+      - description: Search across username, email, id, given_name, family_name, middle_name,
+          nickname, phone_number
+        in: query
+        name: search
+        type: string
+      - default: 100
+        description: Max results per page (1–100)
+        in: query
+        name: limit
+        type: integer
+      - default: 0
+        description: Number of results to skip
+        in: query
+        name: offset
+        type: integer
+      - description: Filter by role (admin, user)
+        in: query
+        name: role
+        type: string
+      - description: Filter by email verification (0, 1)
+        in: query
+        name: is_email_verified
+        type: string
+      - description: Filter by MFA enrollment (0, 1)
+        in: query
+        name: totp_verified
+        type: string
+      - description: Filter by group name
+        in: query
+        name: group
+        type: string
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/user.UserResponse'
-            type: array
+            $ref: '#/definitions/model.ListResponse-user_UserResponse'
         "500":
           description: Internal Server Error
           schema:

--- a/pkg/group/handler.go
+++ b/pkg/group/handler.go
@@ -15,6 +15,11 @@ import (
 // @Summary List all groups
 // @Tags admin-groups
 // @Produce json
+// @Param sort query string false "Sort field (name, created_at, updated_at)"
+// @Param order query string false "Sort order (asc, desc)" default(asc)
+// @Param search query string false "Search across name and description"
+// @Param limit query integer false "Max results per page (1–100)" default(100)
+// @Param offset query integer false "Number of results to skip" default(0)
 // @Security AdminAuth
 // @Success 200 {object} model.ListResponse[GroupResponse]
 // @Router /admin/api/groups [get]

--- a/pkg/group/handler.go
+++ b/pkg/group/handler.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/eugenioenko/autentico/pkg/api"
+	"github.com/eugenioenko/autentico/pkg/model"
 	"github.com/eugenioenko/autentico/pkg/utils"
 )
 
@@ -14,15 +16,21 @@ import (
 // @Tags admin-groups
 // @Produce json
 // @Security AdminAuth
-// @Success 200 {array} GroupResponse
+// @Success 200 {object} model.ListResponse[GroupResponse]
 // @Router /admin/api/groups [get]
 func HandleListGroups(w http.ResponseWriter, r *http.Request) {
-	groups, err := ListGroups()
+	params := api.ParseListParams(r)
+	params.Filters = api.ParseFilters(r, groupListConfig.AllowedFilters)
+
+	groups, total, err := ListGroupsWithParams(params)
 	if err != nil {
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
 	}
-	utils.SuccessResponse(w, groups, http.StatusOK)
+	utils.SuccessResponse(w, model.ListResponse[GroupResponse]{
+		Items: groups,
+		Total: total,
+	}, http.StatusOK)
 }
 
 // HandleCreateGroup godoc

--- a/pkg/group/handler_test.go
+++ b/pkg/group/handler_test.go
@@ -73,9 +73,10 @@ func TestHandleListGroups(t *testing.T) {
 	HandleListGroups(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	var resp model.ApiResponse[[]GroupResponse]
+	var resp model.ApiResponse[model.ListResponse[GroupResponse]]
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
-	assert.Len(t, resp.Data, 2)
+	assert.Len(t, resp.Data.Items, 2)
+	assert.Equal(t, 2, resp.Data.Total)
 }
 
 // --- HandleGetGroup ---

--- a/pkg/group/model.go
+++ b/pkg/group/model.go
@@ -22,6 +22,7 @@ type GroupResponse struct {
 	ID          string    `json:"id"`
 	Name        string    `json:"name"`
 	Description string    `json:"description"`
+	MemberCount int       `json:"member_count"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
 }

--- a/pkg/group/read.go
+++ b/pkg/group/read.go
@@ -5,8 +5,54 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/eugenioenko/autentico/pkg/api"
 	"github.com/eugenioenko/autentico/pkg/db"
 )
+
+var groupListConfig = api.ListConfig{
+	AllowedSort: map[string]bool{
+		"name": true, "created_at": true, "updated_at": true,
+	},
+	SearchColumns: []string{"name", "description"},
+	AllowedFilters: map[string]bool{},
+	DefaultSort:   "name",
+	MaxLimit:      api.DefaultMaxLimit,
+	TableAlias:    "groups",
+}
+
+func ListGroupsWithParams(params api.ListParams) ([]GroupResponse, int, error) {
+	lq := api.BuildListQuery(params, groupListConfig)
+
+	baseWhere := "WHERE 1=1"
+
+	var total int
+	countQuery := "SELECT COUNT(*) FROM groups " + baseWhere + lq.Where
+	if err := db.GetDB().QueryRow(countQuery, lq.Args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("failed to count groups: %w", err)
+	}
+
+	query := `SELECT groups.id, groups.name, groups.description, groups.created_at, groups.updated_at,
+		(SELECT COUNT(*) FROM user_groups WHERE user_groups.group_id = groups.id) AS member_count
+		FROM groups ` + baseWhere + lq.Where + lq.Order
+	rows, err := db.GetDB().Query(query, lq.Args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list groups: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var groups []GroupResponse
+	for rows.Next() {
+		var g GroupResponse
+		if err := rows.Scan(&g.ID, &g.Name, &g.Description, &g.CreatedAt, &g.UpdatedAt, &g.MemberCount); err != nil {
+			return nil, 0, fmt.Errorf("failed to scan group: %w", err)
+		}
+		groups = append(groups, g)
+	}
+	if groups == nil {
+		groups = []GroupResponse{}
+	}
+	return groups, total, rows.Err()
+}
 
 func ListGroups() ([]GroupResponse, error) {
 	query := `SELECT id, name, description, created_at, updated_at FROM groups ORDER BY name`

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -235,8 +235,17 @@ func HandleReactivateUser(w http.ResponseWriter, r *http.Request) {
 // @Summary List all users
 // @Tags admin-users
 // @Produce json
+// @Param sort query string false "Sort field (username, email, created_at, updated_at, role, id, given_name, family_name, middle_name, nickname, phone_number)"
+// @Param order query string false "Sort order (asc, desc)" default(desc)
+// @Param search query string false "Search across username, email, id, given_name, family_name, middle_name, nickname, phone_number"
+// @Param limit query integer false "Max results per page (1–100)" default(100)
+// @Param offset query integer false "Number of results to skip" default(0)
+// @Param role query string false "Filter by role (admin, user)"
+// @Param is_email_verified query string false "Filter by email verification (0, 1)"
+// @Param totp_verified query string false "Filter by MFA enrollment (0, 1)"
+// @Param group query string false "Filter by group name"
 // @Security AdminAuth
-// @Success 200 {array} UserResponse
+// @Success 200 {object} model.ListResponse[UserResponse]
 // @Failure 500 {object} model.ApiError
 // @Router /admin/api/users [get]
 func HandleListUsers(w http.ResponseWriter, r *http.Request) {

--- a/tests/e2e/groups_test.go
+++ b/tests/e2e/groups_test.go
@@ -87,10 +87,10 @@ func TestGroupCRUD(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = resp3.Body.Close() }()
 	body3, _ := io.ReadAll(resp3.Body)
-	var listResp model.ApiResponse[[]group.GroupResponse]
+	var listResp model.ApiResponse[model.ListResponse[group.GroupResponse]]
 	require.NoError(t, json.Unmarshal(body3, &listResp))
-	assert.Len(t, listResp.Data, 1)
-	assert.Equal(t, "renamed-group", listResp.Data[0].Name)
+	assert.Len(t, listResp.Data.Items, 1)
+	assert.Equal(t, "renamed-group", listResp.Data.Items[0].Name)
 
 	// Delete
 	req, _ = http.NewRequest("DELETE", ts.BaseURL+"/admin/api/groups/"+g.ID, nil)


### PR DESCRIPTION
## Summary
- Add server-side sorting, search, pagination, and member count to groups admin API and UI
- Backend: `ListGroupsWithParams` with `groupListConfig` (sort by name/created_at/updated_at, search by name/description), member count via subquery
- Frontend: Rewrite GroupsPage with scrollable tables, `useTableScrollY`, search bar, pagination with page size selector, member count column
- Replace Add Members `Select` with `AutoComplete` using user search API; selected users shown as closable Tag chips
- Actions column on the right (delete, members, edit order)
- Fix `useGroups` consumers (UsersPage, UserGroupsDrawer) for new `ListResponse` format

## Test plan
- [x] Go unit tests pass (`pkg/group`, `pkg/api`)
- [x] TypeScript compiles clean
- [x] Admin UI builds successfully
- [ ] Verify groups list shows member count, search, sorting, pagination in browser
- [ ] Verify members view scrolls, autocomplete searches users, chips are closable
- [ ] Verify UsersPage group filter dropdown still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)