### PR TITLE
fix: enable audit logging by default with 30-day retention

### DIFF
--- a/pkg/appsettings/load.go
+++ b/pkg/appsettings/load.go
@@ -36,7 +36,7 @@ var defaults = map[string]string{
 	"require_email_verification":     "false",
 	"email_verification_expiration":  "24h",
 	"password_reset_expiration":      "1h",
-	"audit_log_retention":            "0",
+	"audit_log_retention":            "720h",
 	"smtp_host":                       "",
 	"smtp_port":                       "587",
 	"smtp_username":                   "",


### PR DESCRIPTION
## Summary
- Change `audit_log_retention` default from `"0"` (disabled) to `"720h"` (30 days)
- Audit logging is important for an auth server — incident response, compliance, and troubleshooting
- 30 days covers most investigation windows without bloating the SQLite DB
- Existing installations with `audit_log_retention` already set in the DB are unaffected (the default only applies to fresh setups or unset settings)

## Test plan
- [ ] Fresh install: verify audit logs are recorded for login, user creation, etc.
- [ ] Verify cleanup service purges audit entries older than 30 days
- [ ] Verify setting `audit_log_retention` to `0` in admin UI still disables logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)