### PR TITLE
feat: server-side list queries for federation admin

### DIFF
--- a/admin-ui/src/api/federation.ts
+++ b/admin-ui/src/api/federation.ts
@@ -4,12 +4,27 @@ import type {
   FederationProviderCreateRequest,
   FederationProviderUpdateRequest,
 } from "../types/federation";
+import type { ListParams, ListResponse } from "./users";
 
 const BASE = "/admin/api/federation";
 
-export async function listFederationProviders(): Promise<FederationProvider[]> {
-  const { data } = await apiClient.get<FederationProvider[]>(BASE);
-  return data;
+export async function listFederationProviders(
+  params?: ListParams
+): Promise<ListResponse<FederationProvider>> {
+  const query = new URLSearchParams();
+  if (params) {
+    for (const [key, val] of Object.entries(params)) {
+      if (val !== undefined && val !== "") {
+        query.set(key, String(val));
+      }
+    }
+  }
+  const qs = query.toString();
+  const url = qs ? `${BASE}?${qs}` : BASE;
+  const { data } = await apiClient.get<{
+    data: ListResponse<FederationProvider>;
+  }>(url);
+  return data.data;
 }
 
 export async function createFederationProvider(

--- a/admin-ui/src/hooks/useFederation.ts
+++ b/admin-ui/src/hooks/useFederation.ts
@@ -9,13 +9,14 @@ import type {
   FederationProviderCreateRequest,
   FederationProviderUpdateRequest,
 } from "../types/federation";
+import type { ListParams } from "../api/users";
 
 const FEDERATION_KEY = ["federation"] as const;
 
-export function useFederationProviders() {
+export function useFederationProviders(params?: ListParams) {
   return useQuery({
-    queryKey: FEDERATION_KEY,
-    queryFn: listFederationProviders,
+    queryKey: [...FEDERATION_KEY, params],
+    queryFn: () => listFederationProviders(params),
   });
 }
 

--- a/admin-ui/src/pages/FederationPage.tsx
+++ b/admin-ui/src/pages/FederationPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback, useRef } from "react";
 import {
   Typography,
   Table,
@@ -8,16 +8,38 @@ import {
   Popconfirm,
   message,
   Alert,
+  Input,
 } from "antd";
-import { PlusOutlined, EditOutlined, DeleteOutlined } from "@ant-design/icons";
-import type { ColumnsType } from "antd/es/table";
+import {
+  PlusOutlined,
+  EditOutlined,
+  DeleteOutlined,
+} from "@ant-design/icons";
+import type { ColumnsType, TablePaginationConfig } from "antd/es/table";
+import type { FilterValue, SorterResult } from "antd/es/table/interface";
 import { useFederationProviders, useDeleteFederationProvider } from "../hooks/useFederation";
 import type { FederationProvider } from "../types/federation";
+import type { ListParams } from "../api/users";
 import FederationCreateForm from "../components/federation/FederationCreateForm";
 import FederationEditForm from "../components/federation/FederationEditForm";
+import { useTableScrollY } from "../hooks/useTableScrollY";
+import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from "../constants/table";
+
+const { Text } = Typography;
 
 export default function FederationPage() {
-  const { data: providers, isLoading, error } = useFederationProviders();
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+  const scrollY = useTableScrollY(tableContainerRef);
+
+  const [listParams, setListParams] = useState<ListParams>({
+    limit: DEFAULT_PAGE_SIZE,
+    offset: 0,
+    sort: "sort_order",
+    order: "asc",
+  });
+  const [searchValue, setSearchValue] = useState("");
+
+  const { data, isLoading, error } = useFederationProviders(listParams);
   const deleteProvider = useDeleteFederationProvider();
 
   const [createOpen, setCreateOpen] = useState(false);
@@ -32,35 +54,101 @@ export default function FederationPage() {
     }
   };
 
+  const handleTableChange = useCallback(
+    (
+      pagination: TablePaginationConfig,
+      filters: Record<string, FilterValue | null>,
+      sorter: SorterResult<FederationProvider> | SorterResult<FederationProvider>[]
+    ) => {
+      const s = Array.isArray(sorter) ? sorter[0] : sorter;
+      const newParams: ListParams = {
+        ...listParams,
+        offset:
+          ((pagination.current ?? 1) - 1) *
+          (pagination.pageSize ?? DEFAULT_PAGE_SIZE),
+        limit: pagination.pageSize ?? DEFAULT_PAGE_SIZE,
+        sort: s.field ? String(s.field) : "sort_order",
+        order: s.order === "ascend" ? "asc" : "desc",
+      };
+
+      if (filters.enabled?.length) {
+        newParams.enabled = filters.enabled[0] as string;
+      } else {
+        delete newParams.enabled;
+      }
+
+      setListParams(newParams);
+    },
+    [listParams]
+  );
+
+  const handleSearch = useCallback((value: string) => {
+    setListParams((prev) => ({
+      ...prev,
+      search: value || undefined,
+      offset: 0,
+    }));
+  }, []);
+
+  const sortOrder = (field: string) =>
+    listParams.sort === field
+      ? listParams.order === "desc"
+        ? ("descend" as const)
+        : ("ascend" as const)
+      : undefined;
+
   const columns: ColumnsType<FederationProvider> = [
     {
       title: "Name",
       dataIndex: "name",
       key: "name",
+      sorter: true,
+      sortOrder: sortOrder("name"),
+      ellipsis: true,
+      render: (name: string) => (
+        <Text copyable={{ text: name }} ellipsis>
+          {name}
+        </Text>
+      ),
     },
     {
       title: "Issuer",
       dataIndex: "issuer",
       key: "issuer",
+      sorter: true,
+      sortOrder: sortOrder("issuer"),
       ellipsis: true,
+      render: (issuer: string) => (
+        <Text copyable={{ text: issuer }} ellipsis>
+          {issuer}
+        </Text>
+      ),
     },
     {
       title: "Client ID",
       dataIndex: "client_id",
       key: "client_id",
+      sorter: true,
+      sortOrder: sortOrder("client_id"),
       ellipsis: true,
-    },
-    {
-      title: "Order",
-      dataIndex: "sort_order",
-      key: "sort_order",
-      width: 80,
+      render: (id: string) => (
+        <Text copyable={{ text: id }} ellipsis>
+          {id}
+        </Text>
+      ),
     },
     {
       title: "Status",
       dataIndex: "enabled",
       key: "enabled",
+      sorter: true,
+      sortOrder: sortOrder("enabled"),
       width: 100,
+      filters: [
+        { text: "Enabled", value: "1" },
+        { text: "Disabled", value: "0" },
+      ],
+      filterMultiple: false,
       render: (enabled: boolean) => (
         <Tag color={enabled ? "success" : "default"}>
           {enabled ? "Enabled" : "Disabled"}
@@ -68,17 +156,19 @@ export default function FederationPage() {
       ),
     },
     {
+      title: "Order",
+      dataIndex: "sort_order",
+      key: "sort_order",
+      sorter: true,
+      sortOrder: sortOrder("sort_order"),
+      width: 80,
+    },
+    {
       title: "Actions",
       key: "actions",
       width: 100,
       render: (_, record) => (
         <Space>
-          <Button
-            type="text"
-            size="small"
-            icon={<EditOutlined />}
-            onClick={() => setEditProvider(record)}
-          />
           <Popconfirm
             title="Delete this provider?"
             description="Users who signed in via this provider will keep their accounts but won't be able to log in with it again."
@@ -88,6 +178,12 @@ export default function FederationPage() {
           >
             <Button type="text" size="small" danger icon={<DeleteOutlined />} />
           </Popconfirm>
+          <Button
+            type="text"
+            size="small"
+            icon={<EditOutlined />}
+            onClick={() => setEditProvider(record)}
+          />
         </Space>
       ),
     },
@@ -99,11 +195,25 @@ export default function FederationPage() {
 
   return (
     <>
-      <Space direction="vertical" size="middle" style={{ display: "flex" }}>
-        <Space style={{ justifyContent: "space-between", width: "100%" }}>
-          <Typography.Title level={4} style={{ margin: 0 }}>
-            Federation Providers
-          </Typography.Title>
+      <Space
+        style={{
+          justifyContent: "space-between",
+          width: "100%",
+          flexShrink: 0,
+        }}
+      >
+        <Typography.Title level={4} style={{ margin: 0 }}>
+          Federation Providers
+        </Typography.Title>
+        <Space>
+          <Input.Search
+            placeholder="Search name, issuer, or client ID..."
+            allowClear
+            value={searchValue}
+            onChange={(e) => setSearchValue(e.target.value)}
+            onSearch={handleSearch}
+            style={{ width: 300 }}
+          />
           <Button
             type="primary"
             icon={<PlusOutlined />}
@@ -112,15 +222,33 @@ export default function FederationPage() {
             Add Provider
           </Button>
         </Space>
+      </Space>
 
+      <div
+        ref={tableContainerRef}
+        style={{ flex: 1, overflow: "hidden", marginTop: 16 }}
+      >
         <Table<FederationProvider>
           columns={columns}
-          dataSource={providers ?? []}
+          dataSource={data?.items ?? []}
           rowKey="id"
           loading={isLoading}
-          pagination={false}
+          onChange={handleTableChange}
+          scroll={scrollY ? { y: scrollY } : undefined}
+          pagination={{
+            current:
+              Math.floor(
+                (listParams.offset ?? 0) /
+                  (listParams.limit ?? DEFAULT_PAGE_SIZE)
+              ) + 1,
+            pageSize: listParams.limit ?? DEFAULT_PAGE_SIZE,
+            total: data?.total ?? 0,
+            showSizeChanger: true,
+            pageSizeOptions: PAGE_SIZE_OPTIONS,
+            showTotal: (total) => `${total} providers`,
+          }}
         />
-      </Space>
+      </div>
 
       <FederationCreateForm
         open={createOpen}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1503,10 +1503,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/federation.ProviderResponse"
-                            }
+                            "$ref": "#/definitions/model.ListResponse-federation_ProviderResponse"
                         }
                     }
                 }
@@ -4499,6 +4496,20 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/client.ClientInfoResponse"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "model.ListResponse-federation_ProviderResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/federation.ProviderResponse"
                     }
                 },
                 "total": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1497,10 +1497,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/federation.ProviderResponse"
-                            }
+                            "$ref": "#/definitions/model.ListResponse-federation_ProviderResponse"
                         }
                     }
                 }
@@ -4493,6 +4490,20 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/client.ClientInfoResponse"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "model.ListResponse-federation_ProviderResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/federation.ProviderResponse"
                     }
                 },
                 "total": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -578,6 +578,15 @@ definitions:
       total:
         type: integer
     type: object
+  model.ListResponse-federation_ProviderResponse:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/federation.ProviderResponse'
+        type: array
+      total:
+        type: integer
+    type: object
   model.ListResponse-group_GroupResponse:
     properties:
       items:
@@ -1840,9 +1849,7 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/federation.ProviderResponse'
-            type: array
+            $ref: '#/definitions/model.ListResponse-federation_ProviderResponse'
       security:
       - AdminAuth: []
       summary: List federation providers

--- a/pkg/federation/admin_handler.go
+++ b/pkg/federation/admin_handler.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/eugenioenko/autentico/pkg/api"
 	"github.com/eugenioenko/autentico/pkg/audit"
+	"github.com/eugenioenko/autentico/pkg/model"
 	"github.com/eugenioenko/autentico/pkg/utils"
 )
 
@@ -14,24 +16,27 @@ import (
 // @Tags admin-federation
 // @Produce json
 // @Security AdminAuth
-// @Success 200 {array} ProviderResponse
+// @Success 200 {object} model.ListResponse[ProviderResponse]
 // @Router /admin/api/federation [get]
 func HandleListProviders(w http.ResponseWriter, r *http.Request) {
-	providers, err := ListFederationProviders()
+	params := api.ParseListParams(r)
+	params.Filters = api.ParseFilters(r, federationListConfig.AllowedFilters)
+	if params.Order == "" {
+		params.Order = "asc"
+	}
+
+	providers, total, err := ListFederationProvidersWithParams(params)
 	if err != nil {
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
 	}
 
-	var response []ProviderResponse
+	items := make([]ProviderResponse, 0, len(providers))
 	for _, p := range providers {
-		response = append(response, toProviderResponse(*p))
-	}
-	if response == nil {
-		response = []ProviderResponse{}
+		items = append(items, toProviderResponse(*p))
 	}
 
-	utils.WriteApiResponse(w, response, http.StatusOK)
+	utils.SuccessResponse(w, model.ListResponse[ProviderResponse]{Items: items, Total: total})
 }
 
 // HandleCreateProvider godoc

--- a/pkg/federation/admin_handler_test.go
+++ b/pkg/federation/admin_handler_test.go
@@ -33,10 +33,16 @@ func TestHandleFederationProviders(t *testing.T) {
 	rr = httptest.NewRecorder()
 	HandleListProviders(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
-	var list []map[string]any
-	_ = json.Unmarshal(rr.Body.Bytes(), &list)
-	assert.Len(t, list, 1)
-	assert.Equal(t, "p1", list[0]["id"])
+	var listResp struct {
+		Data struct {
+			Items []map[string]any `json:"items"`
+			Total int              `json:"total"`
+		} `json:"data"`
+	}
+	_ = json.Unmarshal(rr.Body.Bytes(), &listResp)
+	assert.Equal(t, 1, listResp.Data.Total)
+	assert.Len(t, listResp.Data.Items, 1)
+	assert.Equal(t, "p1", listResp.Data.Items[0]["id"])
 
 	// Get provider
 	req = httptest.NewRequest(http.MethodGet, "/admin/api/federation/p1", nil)

--- a/pkg/federation/read.go
+++ b/pkg/federation/read.go
@@ -4,16 +4,45 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/eugenioenko/autentico/pkg/api"
 	"github.com/eugenioenko/autentico/pkg/db"
 )
 
-func ListFederationProviders() ([]*FederationProvider, error) {
-	rows, err := db.GetDB().Query(
-		`SELECT id, name, issuer, client_id, client_secret, icon_svg, enabled, sort_order, created_at
-		 FROM federation_providers ORDER BY sort_order ASC, created_at ASC`,
-	)
+var federationListConfig = api.ListConfig{
+	AllowedSort: map[string]bool{
+		"name":       true,
+		"issuer":     true,
+		"client_id":  true,
+		"sort_order": true,
+		"enabled":    true,
+		"created_at": true,
+	},
+	SearchColumns: []string{
+		"name", "issuer", "client_id",
+	},
+	AllowedFilters: map[string]bool{
+		"enabled": true,
+	},
+	DefaultSort: "sort_order",
+	MaxLimit:    200,
+}
+
+func ListFederationProvidersWithParams(params api.ListParams) ([]*FederationProvider, int, error) {
+	lq := api.BuildListQuery(params, federationListConfig)
+
+	baseWhere := "WHERE 1=1"
+
+	var total int
+	countQuery := "SELECT COUNT(*) FROM federation_providers " + baseWhere + lq.Where
+	if err := db.GetDB().QueryRow(countQuery, lq.Args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("failed to count federation providers: %w", err)
+	}
+
+	query := `SELECT id, name, issuer, client_id, client_secret, icon_svg, enabled, sort_order, created_at
+		FROM federation_providers ` + baseWhere + lq.Where + lq.Order
+	rows, err := db.GetDB().Query(query, lq.Args...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list federation providers: %w", err)
+		return nil, 0, fmt.Errorf("failed to list federation providers: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
@@ -21,11 +50,14 @@ func ListFederationProviders() ([]*FederationProvider, error) {
 	for rows.Next() {
 		var p FederationProvider
 		if err := rows.Scan(&p.ID, &p.Name, &p.Issuer, &p.ClientID, &p.ClientSecret, &p.IconSVG, &p.Enabled, &p.SortOrder, &p.CreatedAt); err != nil {
-			return nil, fmt.Errorf("failed to scan federation provider: %w", err)
+			return nil, 0, fmt.Errorf("failed to scan federation provider: %w", err)
 		}
 		providers = append(providers, &p)
 	}
-	return providers, rows.Err()
+	if providers == nil {
+		providers = []*FederationProvider{}
+	}
+	return providers, total, rows.Err()
 }
 
 // ListEnabledProviderViews returns only enabled providers as template-safe views,

--- a/pkg/federation/read_test.go
+++ b/pkg/federation/read_test.go
@@ -3,6 +3,7 @@ package federation
 import (
 	"testing"
 
+	"github.com/eugenioenko/autentico/pkg/api"
 	"github.com/eugenioenko/autentico/pkg/db"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
 	"github.com/stretchr/testify/assert"
@@ -11,7 +12,6 @@ import (
 func TestListFederationProviders(t *testing.T) {
 	testutils.WithTestDB(t)
 
-	// Insert test providers
 	_, err := db.GetDB().Exec(`
 		INSERT INTO federation_providers (id, name, issuer, client_id, client_secret, enabled, sort_order)
 		VALUES ('p1', 'Provider 1', 'https://issuer1.com', 'c1', 's1', TRUE, 1),
@@ -19,11 +19,48 @@ func TestListFederationProviders(t *testing.T) {
 	`)
 	assert.NoError(t, err)
 
-	providers, err := ListFederationProviders()
+	providers, total, err := ListFederationProvidersWithParams(api.ListParams{})
 	assert.NoError(t, err)
+	assert.Equal(t, 2, total)
 	assert.Len(t, providers, 2)
 	assert.Equal(t, "p1", providers[0].ID)
 	assert.Equal(t, "p2", providers[1].ID)
+}
+
+func TestListFederationProviders_FilterEnabled(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	_, err := db.GetDB().Exec(`
+		INSERT INTO federation_providers (id, name, issuer, client_id, client_secret, enabled, sort_order)
+		VALUES ('p1', 'Provider 1', 'https://issuer1.com', 'c1', 's1', TRUE, 1),
+		       ('p2', 'Provider 2', 'https://issuer2.com', 'c2', 's2', FALSE, 2)
+	`)
+	assert.NoError(t, err)
+
+	providers, total, err := ListFederationProvidersWithParams(api.ListParams{
+		Filters: map[string]string{"enabled": "1"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Len(t, providers, 1)
+	assert.Equal(t, "p1", providers[0].ID)
+}
+
+func TestListFederationProviders_Search(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	_, err := db.GetDB().Exec(`
+		INSERT INTO federation_providers (id, name, issuer, client_id, client_secret, enabled, sort_order)
+		VALUES ('p1', 'Google OIDC', 'https://accounts.google.com', 'g-client', 's1', TRUE, 1),
+		       ('p2', 'Microsoft Entra', 'https://login.microsoftonline.com', 'm-client', 's2', TRUE, 2)
+	`)
+	assert.NoError(t, err)
+
+	providers, total, err := ListFederationProvidersWithParams(api.ListParams{Search: "Google"})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Len(t, providers, 1)
+	assert.Equal(t, "p1", providers[0].ID)
 }
 
 func TestListEnabledProviderViews(t *testing.T) {

--- a/tests/functional/tests/admin-federation.test.ts
+++ b/tests/functional/tests/admin-federation.test.ts
@@ -24,9 +24,9 @@ describe('Admin Federation Providers — happy path', () => {
     expect(resp.ok).toBe(true);
 
     const body = await resp.json();
-    const providers = body.data ?? body;
-    expect(Array.isArray(providers)).toBe(true);
-    const found = providers.find((p: { id: string }) => p.id === providerId);
+    expect(body.data.items).toBeDefined();
+    expect(body.data.total).toBeGreaterThanOrEqual(1);
+    const found = body.data.items.find((p: { id: string }) => p.id === providerId);
     expect(found).toBeTruthy();
   });
 


### PR DESCRIPTION
## Summary

- Migrate federation provider listing to shared `BuildListQuery` infrastructure with server-side sorting, filtering, search, and pagination
- Backend: add `federationListConfig` (sort by name/issuer/client_id/sort_order/enabled/created_at, search by name/issuer/client_id, filter by enabled), `ListFederationProvidersWithParams`, return `model.ListResponse` via `SuccessResponse`
- Frontend: rewrite FederationPage with scrollable table (`useTableScrollY`), copyable name/issuer/client_id, enabled/disabled filter, all columns sortable, order column last before actions, delete icon first, search bar, server-side pagination
- Update unit tests, handler tests, and functional tests for new response shape

## Test plan

- [x] `go test ./pkg/federation/...` — all 33 tests pass
- [x] `pnpm tsc --noEmit` — frontend type-checks cleanly
- [ ] Verify federation page loads with scrollable table, sorting, search, and status filter
- [ ] Verify copy buttons work on name, issuer, and client_id columns
- [ ] Verify pagination with seeded data (~100 providers)
- [ ] Run functional tests (`admin-federation.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)