### PR TITLE
feat: move deletion requests into Users page tab

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -14,7 +14,6 @@ const SessionsPage = lazy(() => import("./pages/SessionsPage"));
 const SettingsPage = lazy(() => import("./pages/SettingsPage"));
 const CorsPage = lazy(() => import("./pages/CorsPage"));
 const FederationPage = lazy(() => import("./pages/FederationPage"));
-const DeletionRequestsPage = lazy(() => import("./pages/DeletionRequestsPage"));
 const GroupsPage = lazy(() => import("./pages/GroupsPage"));
 const AuditLogPage = lazy(() => import("./pages/AuditLogPage"));
 
@@ -38,7 +37,6 @@ export default function App() {
                 <Route path="settings" element={<SettingsPage />} />
                 <Route path="cors" element={<CorsPage />} />
                 <Route path="federation" element={<FederationPage />} />
-                <Route path="deletion-requests" element={<DeletionRequestsPage />} />
                 <Route path="audit-log" element={<AuditLogPage />} />
               </Route>
             </Route>

--- a/admin-ui/src/api/deletion.ts
+++ b/admin-ui/src/api/deletion.ts
@@ -5,6 +5,8 @@ const BASE = "/admin/api/deletion-requests";
 export interface DeletionRequestResponse {
   id: string;
   user_id: string;
+  username: string;
+  email: string;
   reason?: string;
   requested_at: string;
 }

--- a/admin-ui/src/components/users/DeletionRequestsTab.tsx
+++ b/admin-ui/src/components/users/DeletionRequestsTab.tsx
@@ -1,0 +1,224 @@
+import { useState, useCallback, useRef } from "react";
+import {
+  Typography,
+  Table,
+  Tag,
+  Popconfirm,
+  message,
+  Dropdown,
+  Drawer,
+  Descriptions,
+  Input,
+} from "antd";
+import { MoreOutlined } from "@ant-design/icons";
+import type { ColumnsType } from "antd/es/table";
+import {
+  useDeletionRequests,
+  useApproveDeletionRequest,
+  useAdminCancelDeletionRequest,
+} from "../../hooks/useDeletionRequests";
+import type { DeletionRequestResponse } from "../../api/deletion";
+import { useTableScrollY } from "../../hooks/useTableScrollY";
+
+const { Text } = Typography;
+
+function formatDate(date: string): string {
+  return new Date(date).toLocaleString();
+}
+
+export default function DeletionRequestsTab() {
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+  const scrollY = useTableScrollY(tableContainerRef);
+  const { data: requests, isLoading } = useDeletionRequests();
+  const approve = useApproveDeletionRequest();
+  const cancel = useAdminCancelDeletionRequest();
+
+  const [detailRequest, setDetailRequest] =
+    useState<DeletionRequestResponse | null>(null);
+  const [searchValue, setSearchValue] = useState("");
+  const [searchFilter, setSearchFilter] = useState("");
+
+  const handleApprove = async (id: string) => {
+    try {
+      await approve.mutateAsync(id);
+      message.success("User deleted successfully");
+    } catch {
+      message.error("Failed to approve deletion");
+    }
+  };
+
+  const handleCancel = async (id: string) => {
+    try {
+      await cancel.mutateAsync(id);
+      message.success("Request dismissed");
+    } catch {
+      message.error("Failed to dismiss request");
+    }
+  };
+
+  const handleSearch = useCallback((value: string) => {
+    setSearchFilter(value.toLowerCase());
+  }, []);
+
+  const filtered = (requests ?? []).filter((r) => {
+    if (!searchFilter) return true;
+    return (
+      r.username?.toLowerCase().includes(searchFilter) ||
+      r.email?.toLowerCase().includes(searchFilter) ||
+      r.reason?.toLowerCase().includes(searchFilter)
+    );
+  });
+
+  const columns: ColumnsType<DeletionRequestResponse> = [
+    {
+      title: "Username",
+      dataIndex: "username",
+      key: "username",
+      ellipsis: true,
+      sorter: (a, b) => (a.username ?? "").localeCompare(b.username ?? ""),
+    },
+    {
+      title: "Email",
+      dataIndex: "email",
+      key: "email",
+      ellipsis: true,
+      render: (email: string) => (
+        <Text copyable={{ text: email }} ellipsis>
+          {email}
+        </Text>
+      ),
+    },
+    {
+      title: "Reason",
+      dataIndex: "reason",
+      key: "reason",
+      ellipsis: true,
+      width: 250,
+      render: (reason?: string) =>
+        reason ? (
+          <Text ellipsis style={{ maxWidth: 220 }}>
+            {reason}
+          </Text>
+        ) : (
+          <Tag>No reason</Tag>
+        ),
+    },
+    {
+      title: "Requested",
+      dataIndex: "requested_at",
+      key: "requested_at",
+      sorter: (a, b) =>
+        new Date(a.requested_at).getTime() -
+        new Date(b.requested_at).getTime(),
+      defaultSortOrder: "ascend",
+      render: formatDate,
+    },
+    {
+      title: "",
+      key: "actions",
+      width: 50,
+      render: (_, record) => (
+        <Dropdown
+          menu={{
+            items: [
+              {
+                key: "view",
+                label: "View details",
+                onClick: () => setDetailRequest(record),
+              },
+              {
+                key: "approve",
+                label: (
+                  <Popconfirm
+                    title="Approve deletion?"
+                    description="This will permanently delete the user account. This action cannot be undone."
+                    onConfirm={() => handleApprove(record.id)}
+                    okText="Delete"
+                    okButtonProps={{ danger: true }}
+                  >
+                    <span style={{ color: "#ff4d4f" }}>Approve deletion</span>
+                  </Popconfirm>
+                ),
+              },
+              {
+                key: "dismiss",
+                label: (
+                  <Popconfirm
+                    title="Dismiss request?"
+                    description="The user account will be kept and the request removed."
+                    onConfirm={() => handleCancel(record.id)}
+                    okText="Dismiss"
+                  >
+                    <span>Dismiss request</span>
+                  </Popconfirm>
+                ),
+              },
+            ],
+          }}
+          trigger={["click"]}
+        >
+          <MoreOutlined style={{ fontSize: 16, cursor: "pointer" }} />
+        </Dropdown>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <div style={{ marginBottom: 16, flexShrink: 0 }}>
+        <Input.Search
+          placeholder="Search username, email, or reason..."
+          allowClear
+          value={searchValue}
+          onChange={(e) => setSearchValue(e.target.value)}
+          onSearch={handleSearch}
+          style={{ width: 320 }}
+        />
+      </div>
+
+      <div
+        ref={tableContainerRef}
+        style={{ flex: 1, overflow: "hidden" }}
+      >
+        <Table<DeletionRequestResponse>
+          columns={columns}
+          dataSource={filtered}
+          rowKey="id"
+          loading={isLoading}
+          scroll={scrollY ? { y: scrollY } : undefined}
+          pagination={{ pageSize: 20, showTotal: (total) => `${total} requests` }}
+          locale={{ emptyText: "No pending deletion requests" }}
+        />
+      </div>
+
+      <Drawer
+        title="Deletion Request"
+        open={!!detailRequest}
+        onClose={() => setDetailRequest(null)}
+        width={480}
+      >
+        {detailRequest && (
+          <Descriptions column={1} bordered size="small">
+            <Descriptions.Item label="Username">
+              {detailRequest.username}
+            </Descriptions.Item>
+            <Descriptions.Item label="Email">
+              {detailRequest.email}
+            </Descriptions.Item>
+            <Descriptions.Item label="User ID">
+              <Text copyable={{ text: detailRequest.user_id }}>
+                {detailRequest.user_id}
+              </Text>
+            </Descriptions.Item>
+            <Descriptions.Item label="Reason">
+              {detailRequest.reason ?? "No reason provided"}
+            </Descriptions.Item>
+            <Descriptions.Item label="Requested at">
+              {formatDate(detailRequest.requested_at)}
+            </Descriptions.Item>
+          </Descriptions>
+        )}
+      </Drawer>
+    </>
+  );
+}

--- a/admin-ui/src/layouts/AdminLayout.tsx
+++ b/admin-ui/src/layouts/AdminLayout.tsx
@@ -15,7 +15,6 @@ import {
   MenuFoldOutlined,
   MenuUnfoldOutlined,
   DownOutlined,
-  DeleteOutlined,
   TeamOutlined,
 } from "@ant-design/icons";
 import { useAuth } from "../context/AuthContext";
@@ -30,7 +29,6 @@ const menuItems: any[] = [
   { key: "/sessions", icon: <DesktopOutlined />, label: "Sessions" },
   { key: "/clients", icon: <AppstoreOutlined />, label: "Clients" },
   { key: "/federation", icon: <GlobalOutlined />, label: "Federation" },
-  { key: "/deletion-requests", icon: <DeleteOutlined />, label: "Deletion Requests" },
   { key: "/audit-log", icon: <FileSearchOutlined />, label: "Audit Log" },
   { key: "/cors", icon: <ApiOutlined />, label: "CORS" },
   { key: "/settings", icon: <SettingOutlined />, label: "Settings" },

--- a/admin-ui/src/pages/DashboardPage.tsx
+++ b/admin-ui/src/pages/DashboardPage.tsx
@@ -88,7 +88,7 @@ export default function DashboardPage() {
           <Col xs={24} sm={12} lg={6}>
             <Card
               style={{ cursor: "pointer" }}
-              onClick={() => navigate("/deletion-requests")}
+              onClick={() => navigate("/users?tab=deletions")}
             >
               <Statistic
                 title="Pending Deletions"

--- a/admin-ui/src/pages/UsersPage.tsx
+++ b/admin-ui/src/pages/UsersPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
   Typography,
   Table,
@@ -12,6 +12,8 @@ import {
   Tooltip,
   Input,
   DatePicker,
+  Badge,
+  Tabs,
 } from "antd";
 import {
   PlusOutlined,
@@ -26,12 +28,14 @@ import type { FilterValue, SorterResult } from "antd/es/table/interface";
 import type { Dayjs } from "dayjs";
 import { useUsers, useDeleteUser, useUnlockUser } from "../hooks/useUsers";
 import { useGroups } from "../hooks/useGroups";
+import { useDeletionRequests } from "../hooks/useDeletionRequests";
 import type { ListParams } from "../api/users";
 import type { UserResponseExt } from "../types/user";
 import UserCreateForm from "../components/users/UserCreateForm";
 import UserEditForm from "../components/users/UserEditForm";
 import UserGroupsDrawer from "../components/users/UserGroupsDrawer";
 import UserSessionsDrawer from "../components/users/UserSessionsDrawer";
+import DeletionRequestsTab from "../components/users/DeletionRequestsTab";
 import { useTableScrollY } from "../hooks/useTableScrollY";
 import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from "../constants/table";
 import CountTooltip from "../components/CountTooltip";
@@ -55,16 +59,19 @@ export default function UsersPage() {
 
   const { data, isLoading, error } = useUsers(listParams);
   const { data: groups } = useGroups();
+  const { data: deletionRequests } = useDeletionRequests();
   const deleteUser = useDeleteUser();
   const unlockUserMutation = useUnlockUser();
   const location = useLocation();
+  const navigate = useNavigate();
+
+  const searchParams = new URLSearchParams(location.search);
+  const activeTab = searchParams.get("tab") ?? "users";
 
   const [createOpen, setCreateOpen] = useState(false);
   const [editUser, setEditUser] = useState<UserResponseExt | null>(null);
   const [groupsUser, setGroupsUser] = useState<UserResponseExt | null>(null);
-  const [sessionsUser, setSessionsUser] = useState<UserResponseExt | null>(
-    null
-  );
+  const [sessionsUser, setSessionsUser] = useState<UserResponseExt | null>(null);
 
   useEffect(() => {
     if ((location.state as { create?: boolean })?.create) {
@@ -166,6 +173,10 @@ export default function UsersPage() {
     },
     []
   );
+
+  const handleTabChange = (key: string) => {
+    navigate(key === "users" ? "/users" : `/users?tab=${key}`, { replace: true });
+  };
 
   const columns: ColumnsType<UserResponseExt> = [
     {
@@ -323,54 +334,82 @@ export default function UsersPage() {
     return <Alert type="error" message="Failed to load users" />;
   }
 
+  const deletionCount = deletionRequests?.length ?? 0;
+
+  const tabItems = [
+    {
+      key: "users",
+      label: "Users",
+    },
+    {
+      key: "deletions",
+      label: (
+        <Badge count={deletionCount} size="small" offset={[8, 0]}>
+          Deletion Requests
+        </Badge>
+      ),
+    },
+  ];
+
   return (
     <>
-      <Space style={{ justifyContent: "space-between", width: "100%", flexShrink: 0 }}>
-        <Typography.Title level={4} style={{ margin: 0 }}>
-          Users
-        </Typography.Title>
-        <Space>
-          <DatePicker.RangePicker
-            value={dateRange}
-            onChange={handleDateRange}
-            allowClear
-          />
-          <Input.Search
-            placeholder="Search users..."
-            allowClear
-            value={searchValue}
-            onChange={(e) => setSearchValue(e.target.value)}
-            onSearch={handleSearch}
-            style={{ width: 250 }}
-          />
-          <Button
-            type="primary"
-            icon={<PlusOutlined />}
-            onClick={() => setCreateOpen(true)}
-          >
-            Create User
-          </Button>
-        </Space>
-      </Space>
+      <Tabs
+        activeKey={activeTab}
+        onChange={handleTabChange}
+        items={tabItems}
+        style={{ flexShrink: 0 }}
+      />
 
-      <div ref={tableContainerRef} style={{ flex: 1, overflow: "hidden", marginTop: 16 }}>
-        <Table<UserResponseExt>
-          columns={columns}
-          dataSource={data?.items ?? []}
-          rowKey="id"
-          loading={isLoading}
-          onChange={handleTableChange}
-          scroll={scrollY ? { y: scrollY } : undefined}
-          pagination={{
-            current: Math.floor((listParams.offset ?? 0) / (listParams.limit ?? DEFAULT_PAGE_SIZE)) + 1,
-            pageSize: listParams.limit ?? DEFAULT_PAGE_SIZE,
-            total: data?.total ?? 0,
-            showSizeChanger: true,
-            pageSizeOptions: PAGE_SIZE_OPTIONS,
-            showTotal: (total) => `${total} users`,
-          }}
-        />
-      </div>
+      {activeTab === "users" && (
+        <>
+          <Space style={{ justifyContent: "space-between", width: "100%", flexShrink: 0 }}>
+            <div />
+            <Space>
+              <DatePicker.RangePicker
+                value={dateRange}
+                onChange={handleDateRange}
+                allowClear
+              />
+              <Input.Search
+                placeholder="Search users..."
+                allowClear
+                value={searchValue}
+                onChange={(e) => setSearchValue(e.target.value)}
+                onSearch={handleSearch}
+                style={{ width: 250 }}
+              />
+              <Button
+                type="primary"
+                icon={<PlusOutlined />}
+                onClick={() => setCreateOpen(true)}
+              >
+                Create User
+              </Button>
+            </Space>
+          </Space>
+
+          <div ref={tableContainerRef} style={{ flex: 1, overflow: "hidden", marginTop: 16 }}>
+            <Table<UserResponseExt>
+              columns={columns}
+              dataSource={data?.items ?? []}
+              rowKey="id"
+              loading={isLoading}
+              onChange={handleTableChange}
+              scroll={scrollY ? { y: scrollY } : undefined}
+              pagination={{
+                current: Math.floor((listParams.offset ?? 0) / (listParams.limit ?? DEFAULT_PAGE_SIZE)) + 1,
+                pageSize: listParams.limit ?? DEFAULT_PAGE_SIZE,
+                total: data?.total ?? 0,
+                showSizeChanger: true,
+                pageSizeOptions: PAGE_SIZE_OPTIONS,
+                showTotal: (total) => `${total} users`,
+              }}
+            />
+          </div>
+        </>
+      )}
+
+      {activeTab === "deletions" && <DeletionRequestsTab />}
 
       <UserCreateForm
         open={createOpen}

--- a/pkg/deletion/model.go
+++ b/pkg/deletion/model.go
@@ -8,6 +8,8 @@ import (
 type DeletionRequest struct {
 	ID          string
 	UserID      string
+	Username    string
+	Email       string
 	Reason      sql.NullString
 	RequestedAt time.Time
 }
@@ -15,6 +17,8 @@ type DeletionRequest struct {
 type DeletionRequestResponse struct {
 	ID          string    `json:"id"`
 	UserID      string    `json:"user_id"`
+	Username    string    `json:"username"`
+	Email       string    `json:"email"`
 	Reason      *string   `json:"reason,omitempty"`
 	RequestedAt time.Time `json:"requested_at"`
 }
@@ -27,6 +31,8 @@ func (d *DeletionRequest) ToResponse() DeletionRequestResponse {
 	return DeletionRequestResponse{
 		ID:          d.ID,
 		UserID:      d.UserID,
+		Username:    d.Username,
+		Email:       d.Email,
 		Reason:      reason,
 		RequestedAt: d.RequestedAt,
 	}

--- a/pkg/deletion/read.go
+++ b/pkg/deletion/read.go
@@ -12,9 +12,12 @@ import (
 func scanDeletionRequest(row interface{ Scan(dest ...any) error }) (*DeletionRequest, error) {
 	var req DeletionRequest
 	var requestedAt string
-	if err := row.Scan(&req.ID, &req.UserID, &req.Reason, &requestedAt); err != nil {
+	var username, email sql.NullString
+	if err := row.Scan(&req.ID, &req.UserID, &req.Reason, &requestedAt, &username, &email); err != nil {
 		return nil, err
 	}
+	req.Username = username.String
+	req.Email = email.String
 	for _, layout := range []string{"2006-01-02 15:04:05", time.RFC3339, time.RFC3339Nano} {
 		if t, err := time.Parse(layout, requestedAt); err == nil {
 			req.RequestedAt = t
@@ -26,7 +29,9 @@ func scanDeletionRequest(row interface{ Scan(dest ...any) error }) (*DeletionReq
 
 func DeletionRequestByUserID(userID string) (*DeletionRequest, error) {
 	row := db.GetDB().QueryRow(
-		`SELECT id, user_id, reason, requested_at FROM deletion_requests WHERE user_id = ? LIMIT 1`,
+		`SELECT d.id, d.user_id, d.reason, d.requested_at, u.username, u.email
+		 FROM deletion_requests d LEFT JOIN users u ON d.user_id = u.id
+		 WHERE d.user_id = ? LIMIT 1`,
 		userID,
 	)
 	req, err := scanDeletionRequest(row)
@@ -41,7 +46,9 @@ func DeletionRequestByUserID(userID string) (*DeletionRequest, error) {
 
 func DeletionRequestByID(id string) (*DeletionRequest, error) {
 	row := db.GetDB().QueryRow(
-		`SELECT id, user_id, reason, requested_at FROM deletion_requests WHERE id = ? LIMIT 1`,
+		`SELECT d.id, d.user_id, d.reason, d.requested_at, u.username, u.email
+		 FROM deletion_requests d LEFT JOIN users u ON d.user_id = u.id
+		 WHERE d.id = ? LIMIT 1`,
 		id,
 	)
 	req, err := scanDeletionRequest(row)
@@ -56,7 +63,9 @@ func DeletionRequestByID(id string) (*DeletionRequest, error) {
 
 func ListDeletionRequests() ([]DeletionRequest, error) {
 	rows, err := db.GetDB().Query(
-		`SELECT id, user_id, reason, requested_at FROM deletion_requests ORDER BY requested_at ASC`,
+		`SELECT d.id, d.user_id, d.reason, d.requested_at, u.username, u.email
+		 FROM deletion_requests d LEFT JOIN users u ON d.user_id = u.id
+		 ORDER BY d.requested_at ASC`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list deletion requests: %w", err)


### PR DESCRIPTION
## Summary

- Move deletion requests from standalone nav item into a "Deletion Requests" tab on the Users page
- Tab shows a badge with pending request count
- Backend JOINs users table to include username and email in deletion request responses
- Actions consolidated into a compact "more" dropdown (view details, approve deletion, dismiss)
- Detail drawer shows full reason, username, email, user ID, and timestamp
- Client-side search across username, email, and reason
- Dashboard "Pending Deletions" card now navigates to `/users?tab=deletions`
- Removed `/deletion-requests` route and nav item

## Test plan

- [x] `go test ./pkg/deletion/...` — all 12 tests pass
- [x] `pnpm tsc --noEmit` — frontend type-checks cleanly
- [ ] Verify Users page shows tabs (Users / Deletion Requests)
- [ ] Verify badge count on Deletion Requests tab
- [ ] Verify approve shows success toast and removes request
- [ ] Verify dismiss shows success toast and removes request
- [ ] Verify detail drawer shows full reason
- [ ] Verify dashboard card navigates to deletion tab
- [ ] Verify search filters by username, email, reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)