### PR TITLE
ci: cache pnpm store across CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,16 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.0
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-      - name: Install pnpm
-        run: npm install -g pnpm
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: |
+            admin-ui/pnpm-lock.yaml
+            account-ui/pnpm-lock.yaml
       - name: Build binary (includes admin + account UIs)
         run: make build
       - name: Upload binary
@@ -110,12 +114,14 @@ jobs:
           name: autentico-binary
       - name: Make binary executable
         run: chmod +x autentico
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-      - name: Install pnpm
-        run: npm install -g pnpm
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: tests/functional/pnpm-lock.yaml
       - name: Install dependencies
         working-directory: tests/functional
         run: pnpm install
@@ -138,9 +144,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-      - name: Install pnpm
-        run: npm install -g pnpm
+          node-version: 22
       - name: Install browser test dependencies
         working-directory: tests/browser
         run: npm install


### PR DESCRIPTION
## Summary

- Use `pnpm/action-setup@v4` + `setup-node`'s built-in `cache: pnpm` to cache the pnpm store in **build** and **functional** jobs, keyed on lockfile hashes
- Bump Node from 20 to 22 across all jobs
- Remove unused `npm install -g pnpm` from the **smoke** job (it only uses npm for Playwright)

Closes #275

## Test plan

- [ ] Verify `build` job completes and shows cache hit/miss in setup-node output
- [ ] Verify `functional` job completes with cached pnpm store
- [ ] Verify `smoke` job still works without pnpm installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)