### PR TITLE
feat: add active/inactive toggle to client edit form

### DIFF
--- a/admin-ui/src/components/clients/ClientEditForm.tsx
+++ b/admin-ui/src/components/clients/ClientEditForm.tsx
@@ -10,6 +10,7 @@ import {
   Collapse,
   Switch,
   Typography,
+  Alert,
   App,
 } from "antd";
 import { PlusOutlined, MinusCircleOutlined, ExclamationCircleOutlined } from "@ant-design/icons";
@@ -60,7 +61,7 @@ export default function ClientEditForm({
   client,
   onClose,
 }: ClientEditFormProps) {
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
   const [form] = Form.useForm();
   const updateClient = useUpdateClient();
 
@@ -147,18 +148,20 @@ export default function ClientEditForm({
           <Switch
             checkedChildren="Active"
             unCheckedChildren="Inactive"
-            onChange={(checked) => {
-              if (!checked) {
-                modal.confirm({
-                  title: "Deactivate this client?",
-                  content: "The client will no longer be able to authenticate.",
-                  okText: "Deactivate",
-                  okButtonProps: { danger: true },
-                  onCancel: () => form.setFieldValue("is_active", true),
-                });
-              }
-            }}
           />
+        </Form.Item>
+
+        <Form.Item noStyle shouldUpdate={(prev, cur) => prev.is_active !== cur.is_active}>
+          {() =>
+            !form.getFieldValue("is_active") && (
+              <Alert
+                type="warning"
+                message="This client is disabled and will not be able to authenticate."
+                showIcon
+                style={{ marginBottom: 24 }}
+              />
+            )
+          }
         </Form.Item>
 
         <Form.List name="redirect_uris">

--- a/admin-ui/src/components/clients/ClientEditForm.tsx
+++ b/admin-ui/src/components/clients/ClientEditForm.tsx
@@ -60,7 +60,7 @@ export default function ClientEditForm({
   client,
   onClose,
 }: ClientEditFormProps) {
-  const { message } = App.useApp();
+  const { message, modal } = App.useApp();
   const [form] = Form.useForm();
   const updateClient = useUpdateClient();
 
@@ -68,6 +68,7 @@ export default function ClientEditForm({
     if (client && open) {
       form.setFieldsValue({
         client_name: client.client_name,
+        is_active: client.is_active,
         redirect_uris: client.redirect_uris,
         post_logout_redirect_uris: client.post_logout_redirect_uris ?? [],
         grant_types: client.grant_types,
@@ -136,6 +137,28 @@ export default function ClientEditForm({
           tooltip={{ title: tip("client_id"), icon: <ExclamationCircleOutlined /> }}
         >
           <Input value={client?.client_id} disabled />
+        </Form.Item>
+
+        <Form.Item
+          name="is_active"
+          label="Status"
+          valuePropName="checked"
+        >
+          <Switch
+            checkedChildren="Active"
+            unCheckedChildren="Inactive"
+            onChange={(checked) => {
+              if (!checked) {
+                modal.confirm({
+                  title: "Deactivate this client?",
+                  content: "The client will no longer be able to authenticate.",
+                  okText: "Deactivate",
+                  okButtonProps: { danger: true },
+                  onCancel: () => form.setFieldValue("is_active", true),
+                });
+              }
+            }}
+          />
         </Form.Item>
 
         <Form.List name="redirect_uris">

--- a/admin-ui/src/pages/ClientsPage.tsx
+++ b/admin-ui/src/pages/ClientsPage.tsx
@@ -6,20 +6,17 @@ import {
   Button,
   Tag,
   Space,
-  Popconfirm,
   Alert,
   Input,
-  App,
 } from "antd";
 import {
   PlusOutlined,
   EditOutlined,
-  DeleteOutlined,
   EyeOutlined,
 } from "@ant-design/icons";
 import type { ColumnsType, TablePaginationConfig } from "antd/es/table";
 import type { FilterValue, SorterResult } from "antd/es/table/interface";
-import { useClients, useDeleteClient } from "../hooks/useClients";
+import { useClients } from "../hooks/useClients";
 import type { ClientInfoResponse } from "../types/client";
 import type { ListParams } from "../api/users";
 import ClientCreateForm from "../components/clients/ClientCreateForm";
@@ -33,7 +30,6 @@ const { Text } = Typography;
 
 
 export default function ClientsPage() {
-  const { message } = App.useApp();
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const scrollY = useTableScrollY(tableContainerRef);
 
@@ -46,7 +42,6 @@ export default function ClientsPage() {
   const [searchValue, setSearchValue] = useState("");
 
   const { data, isLoading, error } = useClients(listParams);
-  const deleteClient = useDeleteClient();
   const location = useLocation();
 
   const [createOpen, setCreateOpen] = useState(false);
@@ -60,15 +55,6 @@ export default function ClientsPage() {
   const [editClient, setEditClient] = useState<ClientInfoResponse | null>(null);
   const [detailClient, setDetailClient] =
     useState<ClientInfoResponse | null>(null);
-
-  const handleDelete = async (clientId: string) => {
-    try {
-      await deleteClient.mutateAsync(clientId);
-      message.success("Client deactivated");
-    } catch {
-      message.error("Failed to deactivate client");
-    }
-  };
 
   const handleTableChange = useCallback(
     (
@@ -196,22 +182,6 @@ export default function ClientsPage() {
       key: "actions",
       render: (_, record) => (
         <Space>
-          {record.is_active && (
-            <Popconfirm
-              title="Deactivate this client?"
-              description="The client will no longer be able to authenticate."
-              onConfirm={() => handleDelete(record.client_id!)}
-              okText="Deactivate"
-              okButtonProps={{ danger: true }}
-            >
-              <Button
-                type="text"
-                size="small"
-                danger
-                icon={<DeleteOutlined />}
-              />
-            </Popconfirm>
-          )}
           <Button
             type="text"
             size="small"


### PR DESCRIPTION
## Summary

- Added an active/inactive Switch toggle to the client edit drawer
- When toggled off, an inline warning alert appears: "This client is disabled and will not be able to authenticate."
- Removed the standalone deactivate (trash) Popconfirm button from the table actions column
- Reactivation works directly from the edit form

Closes #265

## Test plan
- [ ] Open a client edit drawer — verify the Status toggle shows current state
- [ ] Toggle a client to inactive — verify the warning alert appears below the toggle
- [ ] Save — verify client shows as Inactive in the table
- [ ] Edit the inactive client, toggle back to Active — verify alert disappears
- [ ] Verify the trash icon is no longer in the table actions column

🤖 Generated with [Claude Code](https://claude.com/claude-code)