### PR TITLE
docs: highlight multi-project centralization

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 **Auténtico is a self-contained OAuth 2.0 / OpenID Connect (OIDC) Identity Provider built with Go. It handles the full authentication lifecycle — login, MFA, passkeys, sessions, token issuance, and admin — in a single binary backed by SQLite. No external database, no infrastructure dependencies, no ceremony.**
 
-Identity infrastructure is typically complex to operate: a separate database to provision and back up, a cache tier, a worker queue, multiple services to keep running, and credentials to rotate. Auténtico takes a different approach. The entire IdP — authentication, token issuance, session management, and the admin UI — runs as one Go binary backed by a single SQLite file. You deploy one thing and it works.
+Identity infrastructure is typically complex to operate: a separate database to provision and back up, a cache tier, a worker queue, multiple services to keep running, and credentials to rotate. Auténtico takes a different approach. The entire IdP — authentication, token issuance, session management, and the admin UI — runs as one Go binary backed by a single SQLite file. You deploy one thing and it works. If you have multiple projects, point them all at one instance and centralize your users, sessions, and security in one place.
 
 Auténtico implements OAuth2 and OpenID Connect correctly. It is not a simplified or non-standard subset. Authorization Code + PKCE, refresh tokens, token introspection, OIDC discovery, RS256-signed JWTs, WebAuthn/passkeys, TOTP, and email OTP are all standard-compliant. The simplicity is operational, not protocol-level.
 
-**Correctness is verified through 1600+ tests, RFC-by-RFC compliance audits, official OIDC conformance tests, and full-flow load testing.**
+**Correctness is verified through 1,600+ tests, RFC-by-RFC compliance audits, official OIDC conformance tests, and full-flow load testing.**
 
 ---
 

--- a/docs-web/src/content/docs/index.mdx
+++ b/docs-web/src/content/docs/index.mdx
@@ -24,7 +24,7 @@ import { Card, CardGrid, LinkButton } from "@astrojs/starlight/components";
 
 Autentico is a self-hosted OAuth 2.0 / OpenID Connect Identity Provider built with Go. It handles the full authentication lifecycle: login, MFA, passkeys, session management, token issuance, and administration, all in a single binary backed by SQLite.
 
-A typical self-hosted Identity Provider involves a database server, a cache layer, multiple processes, and everything that comes with keeping them running. Autentico removes that stack: just one binary and one database file. The simplicity is operational, not protocol-level.
+A typical self-hosted Identity Provider involves a database server, a cache layer, multiple processes, and everything that comes with keeping them running. Autentico removes that stack: just one binary and one database file. If you have multiple projects, point them all at one instance and centralize your users, sessions, and security in one place. The simplicity is operational, not protocol-level.
 
 ## Get running in 60 seconds
 


### PR DESCRIPTION
## Summary
- Adds one sentence to README and docs-web intro paragraphs highlighting that multiple projects can point to a single Autentico instance to centralize users, sessions, and security
- Fixes comma formatting in "1,600+ tests"

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify docs-web builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)