### PR TITLE
fix: cascade idle IdP session deactivation to child sessions and tokens

### DIFF
--- a/pkg/cleanup/service.go
+++ b/pkg/cleanup/service.go
@@ -59,44 +59,18 @@ func Run(retention time.Duration) {
 	}
 }
 
-// deactivateIdleIdpSessions flips deactivated_at on IdP sessions that have been
-// idle past the configured SSO idle timeout, so /account/api/sessions and
-// /authorize's lazy idle check agree on which browsers are "still signed in".
-// A later pass in Run hard-deletes these rows once they exceed retention.
 func deactivateIdleIdpSessions() {
 	idle := config.Get().AuthSsoSessionIdleTimeout
 	if idle <= 0 {
 		return
 	}
-	idleThreshold := time.Now().Add(-idle)
-	rows, err := db.GetDB().Query(
-		`SELECT id FROM idp_sessions
-		  WHERE deactivated_at IS NULL
-		    AND last_activity_at < ?`, idleThreshold)
+	n, err := idpsession.DeactivateIdle(idle)
 	if err != nil {
-		slog.Error("cleanup: failed to query idle idp_sessions", "error", err)
+		slog.Error("cleanup: failed to deactivate idle idp_sessions", "error", err)
 		return
 	}
-	defer rows.Close()
-
-	var ids []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			slog.Error("cleanup: failed to scan idle idp_session id", "error", err)
-			continue
-		}
-		ids = append(ids, id)
-	}
-
-	for _, id := range ids {
-		if err := idpsession.DeactivateWithCascade(id); err != nil {
-			slog.Error("cleanup: failed to cascade-deactivate idle idp_session", "id", id, "error", err)
-			continue
-		}
-	}
-	if len(ids) > 0 {
-		slog.Info("cleanup: deactivated idle idp_sessions", "count", len(ids))
+	if n > 0 {
+		slog.Info("cleanup: deactivated idle idp_sessions", "count", n)
 	}
 }
 

--- a/pkg/cleanup/service.go
+++ b/pkg/cleanup/service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
+	"github.com/eugenioenko/autentico/pkg/idpsession"
 )
 
 // Run deletes expired records older than the retention threshold from all
@@ -68,17 +69,34 @@ func deactivateIdleIdpSessions() {
 		return
 	}
 	idleThreshold := time.Now().Add(-idle)
-	res, err := db.GetDB().Exec(
-		`UPDATE idp_sessions
-		    SET deactivated_at = CURRENT_TIMESTAMP
+	rows, err := db.GetDB().Query(
+		`SELECT id FROM idp_sessions
 		  WHERE deactivated_at IS NULL
 		    AND last_activity_at < ?`, idleThreshold)
 	if err != nil {
-		slog.Error("cleanup: failed to deactivate idle idp_sessions", "error", err)
+		slog.Error("cleanup: failed to query idle idp_sessions", "error", err)
 		return
 	}
-	if n, _ := res.RowsAffected(); n > 0 {
-		slog.Info("cleanup: deactivated idle idp_sessions", "count", n)
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			slog.Error("cleanup: failed to scan idle idp_session id", "error", err)
+			continue
+		}
+		ids = append(ids, id)
+	}
+
+	for _, id := range ids {
+		if err := idpsession.DeactivateWithCascade(id); err != nil {
+			slog.Error("cleanup: failed to cascade-deactivate idle idp_session", "id", id, "error", err)
+			continue
+		}
+	}
+	if len(ids) > 0 {
+		slog.Info("cleanup: deactivated idle idp_sessions", "count", len(ids))
 	}
 }
 

--- a/pkg/cleanup/service_test.go
+++ b/pkg/cleanup/service_test.go
@@ -188,6 +188,88 @@ func TestRun_DeactivatesIdleIdpSessions(t *testing.T) {
 	assert.Nil(t, deactivatedAt, "fresh session must remain active")
 }
 
+func TestRun_DeactivatesIdleIdpSessions_CascadesToChildSessionsAndTokens(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user-1")
+
+	prev := config.Values.AuthSsoSessionIdleTimeout
+	config.Values.AuthSsoSessionIdleTimeout = 30 * time.Minute
+	t.Cleanup(func() { config.Values.AuthSsoSessionIdleTimeout = prev })
+
+	idleID := xid.New().String()
+
+	// Create an IdP session that is idle (last activity 2h ago, well beyond 30m timeout).
+	_, err := db.GetDB().Exec(
+		`INSERT INTO idp_sessions (id, user_id, user_agent, ip_address, last_activity_at)
+		 VALUES (?, ?, ?, ?, ?)`,
+		idleID, "user-1", "agent", "127.0.0.1", time.Now().Add(-2*time.Hour),
+	)
+	require.NoError(t, err)
+
+	// Child OAuth sessions linked to the idle IdP session.
+	_, err = db.GetDB().Exec(
+		`INSERT INTO sessions (id, user_id, access_token, refresh_token, expires_at, idp_session_id)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		"sess-child-1", "user-1", "at-child-1", "rt-child-1", time.Now().Add(time.Hour), idleID,
+	)
+	require.NoError(t, err)
+	_, err = db.GetDB().Exec(
+		`INSERT INTO sessions (id, user_id, access_token, refresh_token, expires_at, idp_session_id)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		"sess-child-2", "user-1", "at-child-2", "rt-child-2", time.Now().Add(time.Hour), idleID,
+	)
+	require.NoError(t, err)
+
+	// Tokens for those child sessions.
+	_, err = db.GetDB().Exec(
+		`INSERT INTO tokens (id, user_id, access_token, refresh_token, access_token_type,
+			refresh_token_expires_at, access_token_expires_at, issued_at, scope, grant_type)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"tok-child-1", "user-1", "at-child-1", "rt-child-1", "Bearer",
+		time.Now().Add(24*time.Hour), time.Now().Add(time.Hour),
+		time.Now(), "openid", "authorization_code",
+	)
+	require.NoError(t, err)
+	_, err = db.GetDB().Exec(
+		`INSERT INTO tokens (id, user_id, access_token, refresh_token, access_token_type,
+			refresh_token_expires_at, access_token_expires_at, issued_at, scope, grant_type)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"tok-child-2", "user-1", "at-child-2", "rt-child-2", "Bearer",
+		time.Now().Add(24*time.Hour), time.Now().Add(time.Hour),
+		time.Now(), "openid", "authorization_code",
+	)
+	require.NoError(t, err)
+
+	// Large retention so the hard-delete pass doesn't remove the deactivated row.
+	Run(7 * 24 * time.Hour)
+
+	// IdP session must be deactivated.
+	var deactivatedAt *time.Time
+	err = db.GetDB().QueryRow(
+		`SELECT deactivated_at FROM idp_sessions WHERE id = ?`, idleID,
+	).Scan(&deactivatedAt)
+	require.NoError(t, err)
+	require.NotNil(t, deactivatedAt, "idle IdP session must be deactivated")
+
+	// Child sessions must also be deactivated.
+	for _, sid := range []string{"sess-child-1", "sess-child-2"} {
+		var da *time.Time
+		require.NoError(t, db.GetDB().QueryRow(
+			`SELECT deactivated_at FROM sessions WHERE id = ?`, sid,
+		).Scan(&da))
+		assert.NotNil(t, da, "child session %s must be deactivated after idle cascade", sid)
+	}
+
+	// Child tokens must be revoked.
+	for _, tid := range []string{"tok-child-1", "tok-child-2"} {
+		var ra *time.Time
+		require.NoError(t, db.GetDB().QueryRow(
+			`SELECT revoked_at FROM tokens WHERE id = ?`, tid,
+		).Scan(&ra))
+		assert.NotNil(t, ra, "child token %s must be revoked after idle cascade", tid)
+	}
+}
+
 func TestRun_IdleSweepDisabledWhenIdleTimeoutZero(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.InsertTestUser(t, "user-1")

--- a/pkg/idpsession/cascade.go
+++ b/pkg/idpsession/cascade.go
@@ -11,7 +11,7 @@ import (
 // than the given timeout and cascade-deactivates each one (IdP session + child
 // OAuth sessions + tokens). Returns the number of sessions deactivated.
 func DeactivateIdle(timeout time.Duration) (int, error) {
-	ids, err := idleSessionIDs(time.Now().Add(-timeout))
+	ids, err := getIdleSessionIDs(time.Now().Add(-timeout))
 	if err != nil {
 		return 0, fmt.Errorf("idpsession: %w", err)
 	}

--- a/pkg/idpsession/cascade.go
+++ b/pkg/idpsession/cascade.go
@@ -7,6 +7,37 @@ import (
 	"github.com/eugenioenko/autentico/pkg/db"
 )
 
+// DeactivateIdle finds all active IdP sessions whose last activity is older
+// than the given timeout and cascade-deactivates each one (IdP session + child
+// OAuth sessions + tokens). Returns the number of sessions deactivated.
+func DeactivateIdle(timeout time.Duration) (int, error) {
+	idleThreshold := time.Now().Add(-timeout)
+	rows, err := db.GetDB().Query(
+		`SELECT id FROM idp_sessions
+		  WHERE deactivated_at IS NULL
+		    AND last_activity_at < ?`, idleThreshold)
+	if err != nil {
+		return 0, fmt.Errorf("idpsession: query idle sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return 0, fmt.Errorf("idpsession: scan idle session id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+
+	for _, id := range ids {
+		if err := DeactivateWithCascade(id); err != nil {
+			return 0, fmt.Errorf("idpsession: cascade-deactivate %s: %w", id, err)
+		}
+	}
+	return len(ids), nil
+}
+
 // DeactivateWithCascade deactivates an IdP (SSO) session and every OAuth
 // session + token that was born from it, atomically.
 //

--- a/pkg/idpsession/cascade.go
+++ b/pkg/idpsession/cascade.go
@@ -11,23 +11,9 @@ import (
 // than the given timeout and cascade-deactivates each one (IdP session + child
 // OAuth sessions + tokens). Returns the number of sessions deactivated.
 func DeactivateIdle(timeout time.Duration) (int, error) {
-	idleThreshold := time.Now().Add(-timeout)
-	rows, err := db.GetDB().Query(
-		`SELECT id FROM idp_sessions
-		  WHERE deactivated_at IS NULL
-		    AND last_activity_at < ?`, idleThreshold)
+	ids, err := IdleSessionIDs(time.Now().Add(-timeout))
 	if err != nil {
-		return 0, fmt.Errorf("idpsession: query idle sessions: %w", err)
-	}
-	defer rows.Close()
-
-	var ids []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return 0, fmt.Errorf("idpsession: scan idle session id: %w", err)
-		}
-		ids = append(ids, id)
+		return 0, fmt.Errorf("idpsession: %w", err)
 	}
 
 	for _, id := range ids {

--- a/pkg/idpsession/cascade.go
+++ b/pkg/idpsession/cascade.go
@@ -11,7 +11,7 @@ import (
 // than the given timeout and cascade-deactivates each one (IdP session + child
 // OAuth sessions + tokens). Returns the number of sessions deactivated.
 func DeactivateIdle(timeout time.Duration) (int, error) {
-	ids, err := IdleSessionIDs(time.Now().Add(-timeout))
+	ids, err := idleSessionIDs(time.Now().Add(-timeout))
 	if err != nil {
 		return 0, fmt.Errorf("idpsession: %w", err)
 	}

--- a/pkg/idpsession/read.go
+++ b/pkg/idpsession/read.go
@@ -149,6 +149,29 @@ func scanDeviceRows(rows *sql.Rows, withUserInfo bool) ([]DeviceRow, error) {
 	return out, rows.Err()
 }
 
+// IdleSessionIDs returns the IDs of all active IdP sessions whose last
+// activity is older than idleThreshold.
+func IdleSessionIDs(idleThreshold time.Time) ([]string, error) {
+	rows, err := db.GetDB().Query(
+		`SELECT id FROM idp_sessions
+		  WHERE deactivated_at IS NULL
+		    AND last_activity_at < ?`, idleThreshold)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query idle idp_sessions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("failed to scan idle idp_session id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 func ListIdpSessionsWithParams(params api.ListParams, dateWhere string, dateArgs []any) ([]DeviceRow, int, error) {
 	var searchWhere string
 	var searchArgs []any

--- a/pkg/idpsession/read.go
+++ b/pkg/idpsession/read.go
@@ -149,7 +149,7 @@ func scanDeviceRows(rows *sql.Rows, withUserInfo bool) ([]DeviceRow, error) {
 	return out, rows.Err()
 }
 
-func idleSessionIDs(idleThreshold time.Time) ([]string, error) {
+func getIdleSessionIDs(idleThreshold time.Time) ([]string, error) {
 	rows, err := db.GetDB().Query(
 		`SELECT id FROM idp_sessions
 		  WHERE deactivated_at IS NULL

--- a/pkg/idpsession/read.go
+++ b/pkg/idpsession/read.go
@@ -149,9 +149,7 @@ func scanDeviceRows(rows *sql.Rows, withUserInfo bool) ([]DeviceRow, error) {
 	return out, rows.Err()
 }
 
-// IdleSessionIDs returns the IDs of all active IdP sessions whose last
-// activity is older than idleThreshold.
-func IdleSessionIDs(idleThreshold time.Time) ([]string, error) {
+func idleSessionIDs(idleThreshold time.Time) ([]string, error) {
 	rows, err := db.GetDB().Query(
 		`SELECT id FROM idp_sessions
 		  WHERE deactivated_at IS NULL


### PR DESCRIPTION
## Summary

- **Bug**: `deactivateIdleIdpSessions()` in the cleanup job only marked `idp_sessions` as deactivated, leaving child OAuth sessions and tokens active — refresh tokens could mint new access tokens indefinitely past the idle timeout
- **Fix**: Query idle IdP session IDs and call `idpsession.DeactivateWithCascade()` for each, which atomically deactivates the IdP session, child sessions, and revokes their tokens in a single transaction
- **Test**: Added `TestRun_DeactivatesIdleIdpSessions_CascadesToChildSessionsAndTokens` — confirmed it fails before the fix and passes after

Closes #259

## Test plan

- [x] New test reproduces the bug (child sessions/tokens left active after idle sweep)
- [x] New test passes with the fix
- [x] All existing cleanup and idpsession tests pass
- [ ] `make test` full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)