### PR TITLE
fix: remove vestigial --auto-migrate flag from onboard command

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Download the latest binary from [GitHub Releases](https://github.com/eugenioenko
 ./autentico init
 
 # Create the first admin account (or use the browser at /onboard after starting)
-./autentico onboard --username admin --password yourpassword --email admin@example.com --auto-migrate
+./autentico onboard --username admin --password yourpassword --email admin@example.com
 
 # Start the server
 ./autentico start
@@ -787,7 +787,7 @@ As an identity provider, Auténtico is a critical trust boundary. The following 
 
 ```bash
 ./autentico init --url https://auth.example.com
-./autentico onboard --username admin --password "$ADMIN_PASSWORD" --auto-migrate
+./autentico onboard --username admin --password "$ADMIN_PASSWORD"
 ./autentico start
 ```
 

--- a/docs-web/public/llms.txt
+++ b/docs-web/public/llms.txt
@@ -529,7 +529,7 @@ Keycloak-compatible aliases are available:
 Open /onboard to create the admin account, or use the headless CLI:
 
 ```bash
-./autentico onboard --username admin --password "$ADMIN_PASSWORD" --auto-migrate
+./autentico onboard --username admin --password "$ADMIN_PASSWORD"
 ```
 
 Place behind a reverse proxy (nginx, Caddy) for TLS.

--- a/main.go
+++ b/main.go
@@ -127,11 +127,7 @@ func main() {
 						Usage:   "Admin email address",
 						EnvVars: []string{"AUTENTICO_ADMIN_EMAIL"},
 					},
-					&cli.BoolFlag{
-						Name:  "auto-migrate",
-						Usage: "Automatically apply pending database migrations",
-					},
-					&cli.BoolFlag{
+&cli.BoolFlag{
 						Name:    "enable-admin-password-grant",
 						Usage:   "Seed the autentico-admin client with the password (ROPC) grant so admin-API tokens can be obtained headlessly (for CI/CD). MFA and account lockout still apply.",
 						EnvVars: []string{"AUTENTICO_ENABLE_ADMIN_PASSWORD_GRANT"},

--- a/pkg/cli/onboard.go
+++ b/pkg/cli/onboard.go
@@ -26,11 +26,7 @@ func RunOnboard(c *cli.Context) error {
 	}
 	defer db.CloseDB()
 
-	if c.Bool("auto-migrate") {
-		if err := migrations.Run(db.GetDB(), true); err != nil {
-			return err
-		}
-	} else if err := migrations.Check(db.GetDB()); err != nil {
+	if err := migrations.Run(db.GetDB(), true); err != nil {
 		return err
 	}
 

--- a/tests/functional/setup.ts
+++ b/tests/functional/setup.ts
@@ -48,7 +48,7 @@ export async function setup() {
   // 4. Create admin account via CLI onboard
   console.log('[functional] Running onboard...');
   execSync(
-    `${BINARY} onboard --username admin --password Password123! --email admin@test.com --auto-migrate --enable-admin-password-grant`,
+    `${BINARY} onboard --username admin --password Password123! --email admin@test.com --enable-admin-password-grant`,
     { cwd: tempDir, stdio: 'inherit', env }
   );
 


### PR DESCRIPTION
## Summary

- Removed the `--auto-migrate` flag from `autentico onboard` — it now always auto-migrates
- The flag was effectively a no-op since `InitDB` already runs all migrations on fresh databases
- Makes `onboard` consistent with `start` (which auto-migrates by default)
- Updated README, docs-web/llms.txt, and functional test setup to drop the flag from examples

Closes #217

## Test plan

- [x] `go build` succeeds
- [x] `go test ./pkg/cli/` — all 26 tests pass
- [x] `--auto-migrate` removed from `main.go` flag definitions
- [x] `onboard.go` unconditionally calls `migrations.Run()`
- [x] All docs/examples updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)