### PR TITLE
feat: add sso_session_max_age setting for absolute session lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,8 @@ These live in the `settings` database table and are loaded into memory at startu
 | `mfa_method`                     | `totp` \| `email`                                      | `totp`           |
 | `trust_device_enabled`           | Allow users to bypass MFA on trusted devices           | `false`          |
 | `trust_device_expiration`        | Trusted device token lifetime                          | `720h` (30 days) |
-| `sso_session_idle_timeout`       | IdP session idle timeout (`0` = disabled)              | `0`              |
+| `sso_session_idle_timeout`       | IdP session idle timeout (`0` = disabled)              | `4h`             |
+| `sso_session_max_age`            | Absolute max session lifetime (`0` = disabled)         | `720h` (30 days) |
 | `allow_self_signup`              | Allow end users to register their own accounts         | `false`          |
 | `account_lockout_max_attempts`   | Failed logins before account lock                      | `5`              |
 | `account_lockout_duration`       | How long the account stays locked                      | `15m`            |

--- a/admin-ui/src/pages/SettingsPage.tsx
+++ b/admin-ui/src/pages/SettingsPage.tsx
@@ -56,6 +56,7 @@ const tip = makeTip({
   email_verification_expiration: "How long a verification link remains valid (e.g. 24h, 48h).",
   sso_enabled: "Enable Single Sign-On. When enabled, returning users with an active session are automatically re-authorized without entering credentials.",
   sso_session_idle_timeout: "Duration of inactivity before SSO session expires (e.g. 30m, 24h). 0 for no idle expiration.",
+  sso_session_max_age: "Absolute maximum lifetime for SSO sessions, regardless of activity (e.g. 720h for 30 days). 0 for no limit.",
   trust_device_enabled: "Allow users to trust their current device for MFA.",
   trust_device_expiration: "How long a device remains trusted (e.g. 720h).",
   validation_min_username_length: "Minimum length for usernames.",
@@ -388,7 +389,14 @@ export default function SettingsPage() {
                     name="sso_session_idle_timeout"
                     tooltip={{ title: tip("sso_session_idle_timeout"), icon: <ExclamationCircleOutlined /> }}
                   >
-                    <Input placeholder="30m" />
+                    <Input placeholder="4h" />
+                  </Form.Item>
+                  <Form.Item
+                    label="SSO Session Max Age"
+                    name="sso_session_max_age"
+                    tooltip={{ title: tip("sso_session_max_age"), icon: <ExclamationCircleOutlined /> }}
+                  >
+                    <Input placeholder="720h" />
                   </Form.Item>
 
                   <Form.Item

--- a/docs-web/public/llms.txt
+++ b/docs-web/public/llms.txt
@@ -172,7 +172,8 @@ All values are stored as strings. Durations use Go format: `15m`, `1h`, `720h`.
 
 | Setting | Default | Description |
 |---|---|---|
-| `sso_session_idle_timeout` | `0` | IdP session idle timeout. `0` disables. |
+| `sso_session_idle_timeout` | `4h` | IdP session idle timeout. `0` disables. |
+| `sso_session_max_age` | `720h` | Absolute max session lifetime. `0` disables. |
 
 #### Account Security
 

--- a/docs-web/src/content/docs/admin-ui/settings.mdx
+++ b/docs-web/src/content/docs/admin-ui/settings.mdx
@@ -15,7 +15,7 @@ Settings are grouped by category:
 |---|---|
 | **Authentication** | `auth_mode`, `mfa_enabled`, `mfa_method` |
 | **Token lifetimes** | `access_token_expiration`, `refresh_token_expiration` |
-| **SSO sessions** | `sso_enabled`, `sso_session_idle_timeout` |
+| **SSO sessions** | `sso_enabled`, `sso_session_idle_timeout`, `sso_session_max_age` |
 | **Account security** | `lockout_max_attempts`, `lockout_duration` |
 | **SMTP** | `smtp_host`, `smtp_port`, `smtp_username`, `smtp_from` |
 | **Trusted devices** | `trust_device_enabled`, `trust_device_expiration` |

--- a/docs-web/src/content/docs/authentication/sso-sessions.mdx
+++ b/docs-web/src/content/docs/authentication/sso-sessions.mdx
@@ -25,6 +25,7 @@ On a new authorization request:
 |---|---|---|
 | `sso_enabled` | `true` | Enable SSO auto-login. When disabled, users must log in on every request. Device sessions are still tracked |
 | `sso_session_idle_timeout` | `4h` | If the user has no activity for this long, the session expires. `0` for no idle expiration |
+| `sso_session_max_age` | `720h` | Absolute maximum session lifetime regardless of activity. `0` for no limit |
 
 Uses Go duration format for timeouts: `24h`, `168h`, `720h`, etc.
 
@@ -42,7 +43,7 @@ Sessions are stored in the `sessions` table with the following fields:
 | `ip_address` | Client IP at login time |
 | `last_activity_at` | Updated on each authorization request (used for idle timeout) |
 | `created_at` | Session creation time |
-| `expires_at` | Absolute expiry (not yet enforced — reserved for future `sso_session_max_age` setting) |
+| `expires_at` | Absolute expiry |
 | `deactivated_at` | Set when the session is explicitly logged out |
 
 ## Logout

--- a/docs-web/src/content/docs/authentication/sso-sessions.mdx
+++ b/docs-web/src/content/docs/authentication/sso-sessions.mdx
@@ -29,6 +29,8 @@ On a new authorization request:
 
 Uses Go duration format for timeouts: `24h`, `168h`, `720h`, etc.
 
+The session cookie's `Expires` attribute is set to `sso_session_max_age` at login time. Changing this setting does not retroactively update existing cookies — increasing the value will not extend sessions already issued, and decreasing it relies on the server-side check to reject sessions that outlive the new limit.
+
 The idle timeout can be overridden per-client, so different clients can have stricter session requirements. See [Per-Client Overrides](/configuration/per-client-overrides/).
 
 ## Session storage

--- a/docs-web/src/content/docs/configuration/runtime-settings.mdx
+++ b/docs-web/src/content/docs/configuration/runtime-settings.mdx
@@ -118,6 +118,11 @@ Default: `4h`
 
 IdP session idle timeout. Users who return within the timeout window are automatically re-authorized without entering credentials. `0` means sessions never expire from inactivity (infinite idle timeout).
 
+### `sso_session_max_age`
+Default: `720h`
+
+Absolute maximum lifetime for IdP sessions, regardless of activity. Once a session exceeds this age since creation, the user must re-authenticate. `0` means no maximum age (sessions live indefinitely as long as they remain within the idle timeout). Both `sso_session_idle_timeout` and `sso_session_max_age` must pass for a session to be valid.
+
 ---
 
 ## Account security

--- a/docs-web/src/content/docs/configuration/runtime-settings.mdx
+++ b/docs-web/src/content/docs/configuration/runtime-settings.mdx
@@ -123,6 +123,8 @@ Default: `720h`
 
 Absolute maximum lifetime for IdP sessions, regardless of activity. Once a session exceeds this age since creation, the user must re-authenticate. `0` means no maximum age (sessions live indefinitely as long as they remain within the idle timeout). Both `sso_session_idle_timeout` and `sso_session_max_age` must pass for a session to be valid.
 
+The session cookie's `Expires` attribute is set to match this value at login time. Changing the setting does not update cookies already issued — increasing it will not extend existing sessions, and decreasing it relies on the server-side check to reject sessions whose cookie has not yet expired.
+
 ---
 
 ## Account security

--- a/docs-web/src/content/docs/deployment/production-checklist.mdx
+++ b/docs-web/src/content/docs/deployment/production-checklist.mdx
@@ -19,7 +19,7 @@ import { Aside } from '@astrojs/starlight/components';
 - [ ] **`AUTENTICO_APP_URL` is correct** — This value appears in the OIDC discovery document, token `iss` claim, and redirect validation. It must exactly match the URL clients use.
 - [ ] **MFA enabled** (recommended) — `mfa_enabled = true` in settings, with `mfa_method = totp` or `email`. TOTP is preferred.
 - [ ] **Account lockout configured** — `lockout_max_attempts` and `lockout_duration` are set to reasonable values.
-- [ ] **Session lifetimes reviewed** — `sso_session_idle_timeout` matches your security policy.
+- [ ] **Session lifetimes reviewed** — `sso_session_idle_timeout` and `sso_session_max_age` match your security policy.
 - [ ] **Token lifetimes reviewed** — `access_token_expiration` is short (15m default). `refresh_token_expiration` reflects your session policy.
 - [ ] **Self-signup decision made** — `allow_self_signup` is `false` unless you intend to allow open registration.
 - [ ] **SMTP configured** (if using email OTP or email-verified registration) — SMTP settings tested via a login attempt.

--- a/pkg/appsettings/handler.go
+++ b/pkg/appsettings/handler.go
@@ -22,6 +22,7 @@ var durationSettings = map[string][]string{
 	"refresh_token_expiration":      nil,
 	"authorization_code_expiration": nil,
 	"sso_session_idle_timeout":      {"", "0"},
+	"sso_session_max_age":           {"", "0"},
 	"account_lockout_duration":      nil,
 	"trust_device_expiration":       nil,
 	"cleanup_interval":              nil,

--- a/pkg/appsettings/load.go
+++ b/pkg/appsettings/load.go
@@ -18,6 +18,7 @@ var defaults = map[string]string{
 	"allow_self_signup":              "false",
 	"sso_enabled":                   "true",
 	"sso_session_idle_timeout":       "4h",
+	"sso_session_max_age":            "720h",
 	"validation_min_username_length": "4",
 	"validation_max_username_length": "64",
 	"validation_min_password_length": "6",
@@ -116,6 +117,10 @@ func LoadIntoConfig() error {
 	if v, ok := all["sso_session_idle_timeout"]; ok {
 		cfg.AuthSsoSessionIdleTimeoutStr = v
 		cfg.AuthSsoSessionIdleTimeout = config.ParseDuration(v, 0)
+	}
+	if v, ok := all["sso_session_max_age"]; ok {
+		cfg.AuthSsoSessionMaxAgeStr = v
+		cfg.AuthSsoSessionMaxAge = config.ParseDuration(v, 0)
 	}
 	if v, ok := all["validation_min_username_length"]; ok {
 		if n, err := strconv.Atoi(v); err == nil {

--- a/pkg/authorize/handler.go
+++ b/pkg/authorize/handler.go
@@ -254,6 +254,11 @@ func tryAutoLogin(r *http.Request, cfg *config.Config, request AuthorizeRequest)
 		return ""
 	}
 
+	withinMaxAge := cfg.AuthSsoSessionMaxAge == 0 || time.Since(session.CreatedAt) < cfg.AuthSsoSessionMaxAge
+	if !withinMaxAge {
+		return ""
+	}
+
 	maxAgeSecs := parseMaxAge(request.MaxAge)
 	if maxAgeSecs >= 0 && time.Since(session.CreatedAt) > time.Duration(maxAgeSecs)*time.Second {
 		return ""

--- a/pkg/authorize/handler_test.go
+++ b/pkg/authorize/handler_test.go
@@ -850,3 +850,87 @@ func TestRedirectWithError_ErrorDescriptionEncoded(t *testing.T) {
 	// State value must round-trip correctly through encoding.
 	assert.Equal(t, "my state", parsed.Query().Get("state"), "state must decode back to its original value")
 }
+
+func TestHandleAuthorize_AutoLogin_SessionMaxAge_Expired(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestClient(t, "test-client", []string{"http://localhost/callback"})
+	testutils.WithConfigOverride(t, func() {
+		config.Values.AuthSsoSessionIdleTimeout = 24 * time.Hour
+		config.Values.AuthSsoSessionMaxAge = 1 * time.Hour
+		config.Bootstrap.AuthIdpSessionCookieName = "autentico_idp_session"
+	})
+
+	_, err := db.GetDB().Exec(`INSERT INTO users (id, username, email, password) VALUES ('user-ma-1', 'maxageuser', 'ma@test.com', 'hashed')`)
+	require.NoError(t, err)
+
+	require.NoError(t, idpsession.CreateIdpSession(idpsession.IdpSession{
+		ID: "idp-ma-expired", UserID: "user-ma-1", UserAgent: "ua", IPAddress: "127.0.0.1",
+	}))
+	// Backdate created_at to 2 hours ago (beyond 1h max age), but keep last_activity recent
+	_, err = db.GetDB().Exec(`UPDATE idp_sessions SET created_at = datetime('now', '-2 hours') WHERE id = 'idp-ma-expired'`)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/authorize?response_type=code&client_id=test-client&redirect_uri=http://localhost/callback&state=xyz&code_challenge=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk&code_challenge_method=S256", nil)
+	req.AddCookie(&http.Cookie{Name: "autentico_idp_session", Value: "idp-ma-expired"})
+	rr := httptest.NewRecorder()
+
+	HandleAuthorize(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code, "session past max age must show login form")
+	assert.Contains(t, rr.Body.String(), "form")
+}
+
+func TestHandleAuthorize_AutoLogin_SessionMaxAge_Valid(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestClient(t, "test-client", []string{"http://localhost/callback"})
+	testutils.WithConfigOverride(t, func() {
+		config.Values.AuthSsoSessionIdleTimeout = 24 * time.Hour
+		config.Values.AuthSsoSessionMaxAge = 24 * time.Hour
+		config.Bootstrap.AuthIdpSessionCookieName = "autentico_idp_session"
+	})
+
+	_, err := db.GetDB().Exec(`INSERT INTO users (id, username, email, password) VALUES ('user-ma-2', 'maxageuser2', 'ma2@test.com', 'hashed')`)
+	require.NoError(t, err)
+
+	require.NoError(t, idpsession.CreateIdpSession(idpsession.IdpSession{
+		ID: "idp-ma-valid", UserID: "user-ma-2", UserAgent: "ua", IPAddress: "127.0.0.1",
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/authorize?response_type=code&client_id=test-client&redirect_uri=http://localhost/callback&state=xyz&code_challenge=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk&code_challenge_method=S256", nil)
+	req.AddCookie(&http.Cookie{Name: "autentico_idp_session", Value: "idp-ma-valid"})
+	rr := httptest.NewRecorder()
+
+	HandleAuthorize(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code, "session within max age must auto-login")
+	assert.Contains(t, rr.Header().Get("Location"), "code=")
+}
+
+func TestHandleAuthorize_AutoLogin_SessionMaxAge_ZeroMeansInfinite(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestClient(t, "test-client", []string{"http://localhost/callback"})
+	testutils.WithConfigOverride(t, func() {
+		config.Values.AuthSsoSessionIdleTimeout = 0
+		config.Values.AuthSsoSessionMaxAge = 0
+		config.Bootstrap.AuthIdpSessionCookieName = "autentico_idp_session"
+	})
+
+	_, err := db.GetDB().Exec(`INSERT INTO users (id, username, email, password) VALUES ('user-ma-3', 'maxageuser3', 'ma3@test.com', 'hashed')`)
+	require.NoError(t, err)
+
+	require.NoError(t, idpsession.CreateIdpSession(idpsession.IdpSession{
+		ID: "idp-ma-infinite", UserID: "user-ma-3", UserAgent: "ua", IPAddress: "127.0.0.1",
+	}))
+	// Backdate to 90 days ago — should still work with 0 (infinite)
+	_, err = db.GetDB().Exec(`UPDATE idp_sessions SET created_at = datetime('now', '-90 days') WHERE id = 'idp-ma-infinite'`)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/authorize?response_type=code&client_id=test-client&redirect_uri=http://localhost/callback&state=xyz&code_challenge=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk&code_challenge_method=S256", nil)
+	req.AddCookie(&http.Cookie{Name: "autentico_idp_session", Value: "idp-ma-infinite"})
+	rr := httptest.NewRecorder()
+
+	HandleAuthorize(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code, "max age 0 means infinite — should auto-login")
+	assert.Contains(t, rr.Header().Get("Location"), "code=")
+}

--- a/pkg/authorize/prompt_none_test.go
+++ b/pkg/authorize/prompt_none_test.go
@@ -4,9 +4,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/db"
+	"github.com/eugenioenko/autentico/pkg/idpsession"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandleAuthorize_PromptNone_NoSession_Extra(t *testing.T) {
@@ -22,4 +27,35 @@ func TestHandleAuthorize_PromptNone_NoSession_Extra(t *testing.T) {
 	assert.Equal(t, http.StatusFound, rr.Code)
 	assert.Contains(t, rr.Header().Get("Location"), "error=login_required")
 	assert.Contains(t, rr.Header().Get("Location"), "state=s1")
+}
+
+func TestHandleAuthorize_PromptNone_MaxAgeExpired_ReturnsLoginRequired(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestClient(t, "c1", []string{"http://localhost/cb"})
+	testutils.WithConfigOverride(t, func() {
+		config.Values.AuthSsoSessionIdleTimeout = 24 * time.Hour
+		config.Values.AuthSsoSessionMaxAge = 1 * time.Hour
+		config.Bootstrap.AuthIdpSessionCookieName = "autentico_idp_session"
+	})
+
+	_, err := db.GetDB().Exec(`INSERT INTO users (id, username, email, password) VALUES ('user-pn-1', 'pnuser', 'pn@test.com', 'hashed')`)
+	require.NoError(t, err)
+
+	require.NoError(t, idpsession.CreateIdpSession(idpsession.IdpSession{
+		ID: "idp-pn-maxage", UserID: "user-pn-1", UserAgent: "ua", IPAddress: "127.0.0.1",
+	}))
+	// Backdate created_at to 2h ago — beyond 1h max age, but recently active
+	_, err = db.GetDB().Exec(`UPDATE idp_sessions SET created_at = datetime('now', '-2 hours') WHERE id = 'idp-pn-maxage'`)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/authorize?response_type=code&client_id=c1&redirect_uri=http://localhost/cb&prompt=none&state=s2&code_challenge=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk&code_challenge_method=S256", nil)
+	req.AddCookie(&http.Cookie{Name: "autentico_idp_session", Value: "idp-pn-maxage"})
+	rr := httptest.NewRecorder()
+
+	HandleAuthorize(rr, req)
+
+	// OIDC Core §3.1.2.6: prompt=none must not show UI; expired session must return login_required
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "error=login_required")
+	assert.Contains(t, rr.Header().Get("Location"), "state=s2")
 }

--- a/pkg/cleanup/service.go
+++ b/pkg/cleanup/service.go
@@ -16,6 +16,7 @@ func Run(retention time.Duration) {
 	threshold := time.Now().Add(-retention)
 
 	deactivateIdleIdpSessions()
+	deactivateExpiredMaxAgeIdpSessions()
 
 	queries := []struct {
 		table string
@@ -71,6 +72,21 @@ func deactivateIdleIdpSessions() {
 	}
 	if n > 0 {
 		slog.Info("cleanup: deactivated idle idp_sessions", "count", n)
+	}
+}
+
+func deactivateExpiredMaxAgeIdpSessions() {
+	maxAge := config.Get().AuthSsoSessionMaxAge
+	if maxAge <= 0 {
+		return
+	}
+	n, err := idpsession.DeactivateExpiredMaxAge(maxAge)
+	if err != nil {
+		slog.Error("cleanup: failed to deactivate expired max-age idp_sessions", "error", err)
+		return
+	}
+	if n > 0 {
+		slog.Info("cleanup: deactivated expired max-age idp_sessions", "count", n)
 	}
 }
 

--- a/pkg/cleanup/service_test.go
+++ b/pkg/cleanup/service_test.go
@@ -296,6 +296,81 @@ func TestRun_IdleSweepDisabledWhenIdleTimeoutZero(t *testing.T) {
 	assert.Nil(t, deactivatedAt, "idle sweep must be a no-op when idle timeout is zero")
 }
 
+func TestRun_DeactivatesExpiredMaxAgeIdpSessions(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user-1")
+
+	prevIdle := config.Values.AuthSsoSessionIdleTimeout
+	prevMaxAge := config.Values.AuthSsoSessionMaxAge
+	config.Values.AuthSsoSessionIdleTimeout = 0
+	config.Values.AuthSsoSessionMaxAge = 1 * time.Hour
+	t.Cleanup(func() {
+		config.Values.AuthSsoSessionIdleTimeout = prevIdle
+		config.Values.AuthSsoSessionMaxAge = prevMaxAge
+	})
+
+	expired := xid.New().String()
+	fresh := xid.New().String()
+
+	// Created 2h ago — beyond 1h max age.
+	_, err := db.GetDB().Exec(
+		`INSERT INTO idp_sessions (id, user_id, user_agent, ip_address, created_at, last_activity_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		expired, "user-1", "agent", "127.0.0.1",
+		time.Now().Add(-2*time.Hour), time.Now(),
+	)
+	require.NoError(t, err)
+
+	// Created just now — within max age.
+	_, err = db.GetDB().Exec(
+		`INSERT INTO idp_sessions (id, user_id, user_agent, ip_address)
+		 VALUES (?, ?, ?, ?)`,
+		fresh, "user-1", "agent", "127.0.0.1",
+	)
+	require.NoError(t, err)
+
+	Run(7 * 24 * time.Hour)
+
+	var deactivatedAt *time.Time
+	err = db.GetDB().QueryRow(
+		`SELECT deactivated_at FROM idp_sessions WHERE id = ?`, expired,
+	).Scan(&deactivatedAt)
+	require.NoError(t, err)
+	assert.NotNil(t, deactivatedAt, "session past max age must be deactivated")
+
+	err = db.GetDB().QueryRow(
+		`SELECT deactivated_at FROM idp_sessions WHERE id = ?`, fresh,
+	).Scan(&deactivatedAt)
+	require.NoError(t, err)
+	assert.Nil(t, deactivatedAt, "fresh session must remain active")
+}
+
+func TestRun_MaxAgeSweepDisabledWhenZero(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user-1")
+
+	prevMaxAge := config.Values.AuthSsoSessionMaxAge
+	config.Values.AuthSsoSessionMaxAge = 0
+	t.Cleanup(func() { config.Values.AuthSsoSessionMaxAge = prevMaxAge })
+
+	id := xid.New().String()
+	_, err := db.GetDB().Exec(
+		`INSERT INTO idp_sessions (id, user_id, user_agent, ip_address, created_at)
+		 VALUES (?, ?, ?, ?, ?)`,
+		id, "user-1", "agent", "127.0.0.1", time.Now().Add(-90*24*time.Hour),
+	)
+	require.NoError(t, err)
+
+	Run(7 * 24 * time.Hour)
+
+	var deactivatedAt *time.Time
+	err = db.GetDB().QueryRow(
+		`SELECT deactivated_at FROM idp_sessions WHERE id = ?`, id,
+	).Scan(&deactivatedAt)
+	require.NoError(t, err)
+	assert.Nil(t, deactivatedAt, "max age sweep must be a no-op when max age is zero")
+}
+
 func TestRun_EmptyTablesNoError(t *testing.T) {
 	testutils.WithTestDB(t)
 	// Should not panic or error on empty tables

--- a/pkg/cleanup/service_test.go
+++ b/pkg/cleanup/service_test.go
@@ -345,6 +345,93 @@ func TestRun_DeactivatesExpiredMaxAgeIdpSessions(t *testing.T) {
 	assert.Nil(t, deactivatedAt, "fresh session must remain active")
 }
 
+func TestRun_DeactivatesExpiredMaxAgeIdpSessions_CascadesToChildSessionsAndTokens(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user-1")
+
+	prevIdle := config.Values.AuthSsoSessionIdleTimeout
+	prevMaxAge := config.Values.AuthSsoSessionMaxAge
+	config.Values.AuthSsoSessionIdleTimeout = 0
+	config.Values.AuthSsoSessionMaxAge = 1 * time.Hour
+	t.Cleanup(func() {
+		config.Values.AuthSsoSessionIdleTimeout = prevIdle
+		config.Values.AuthSsoSessionMaxAge = prevMaxAge
+	})
+
+	expiredID := xid.New().String()
+
+	// IdP session created 2h ago — beyond 1h max age, but recently active.
+	_, err := db.GetDB().Exec(
+		`INSERT INTO idp_sessions (id, user_id, user_agent, ip_address, created_at, last_activity_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		expiredID, "user-1", "agent", "127.0.0.1",
+		time.Now().Add(-2*time.Hour), time.Now(),
+	)
+	require.NoError(t, err)
+
+	// Child OAuth sessions.
+	_, err = db.GetDB().Exec(
+		`INSERT INTO sessions (id, user_id, access_token, refresh_token, expires_at, idp_session_id)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		"sess-ma-1", "user-1", "at-ma-1", "rt-ma-1", time.Now().Add(time.Hour), expiredID,
+	)
+	require.NoError(t, err)
+	_, err = db.GetDB().Exec(
+		`INSERT INTO sessions (id, user_id, access_token, refresh_token, expires_at, idp_session_id)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		"sess-ma-2", "user-1", "at-ma-2", "rt-ma-2", time.Now().Add(time.Hour), expiredID,
+	)
+	require.NoError(t, err)
+
+	// Tokens for those sessions.
+	_, err = db.GetDB().Exec(
+		`INSERT INTO tokens (id, user_id, access_token, refresh_token, access_token_type,
+			refresh_token_expires_at, access_token_expires_at, issued_at, scope, grant_type)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"tok-ma-1", "user-1", "at-ma-1", "rt-ma-1", "Bearer",
+		time.Now().Add(24*time.Hour), time.Now().Add(time.Hour),
+		time.Now(), "openid", "authorization_code",
+	)
+	require.NoError(t, err)
+	_, err = db.GetDB().Exec(
+		`INSERT INTO tokens (id, user_id, access_token, refresh_token, access_token_type,
+			refresh_token_expires_at, access_token_expires_at, issued_at, scope, grant_type)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"tok-ma-2", "user-1", "at-ma-2", "rt-ma-2", "Bearer",
+		time.Now().Add(24*time.Hour), time.Now().Add(time.Hour),
+		time.Now(), "openid", "authorization_code",
+	)
+	require.NoError(t, err)
+
+	Run(7 * 24 * time.Hour)
+
+	// IdP session must be deactivated.
+	var deactivatedAt *time.Time
+	err = db.GetDB().QueryRow(
+		`SELECT deactivated_at FROM idp_sessions WHERE id = ?`, expiredID,
+	).Scan(&deactivatedAt)
+	require.NoError(t, err)
+	require.NotNil(t, deactivatedAt, "session past max age must be deactivated")
+
+	// Child sessions must also be deactivated.
+	for _, sid := range []string{"sess-ma-1", "sess-ma-2"} {
+		var da *time.Time
+		require.NoError(t, db.GetDB().QueryRow(
+			`SELECT deactivated_at FROM sessions WHERE id = ?`, sid,
+		).Scan(&da))
+		assert.NotNil(t, da, "child session %s must be deactivated after max-age cascade", sid)
+	}
+
+	// Child tokens must be revoked.
+	for _, tid := range []string{"tok-ma-1", "tok-ma-2"} {
+		var ra *time.Time
+		require.NoError(t, db.GetDB().QueryRow(
+			`SELECT revoked_at FROM tokens WHERE id = ?`, tid,
+		).Scan(&ra))
+		assert.NotNil(t, ra, "child token %s must be revoked after max-age cascade", tid)
+	}
+}
+
 func TestRun_MaxAgeSweepDisabledWhenZero(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.InsertTestUser(t, "user-1")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,6 +71,8 @@ type Config struct {
 	AuthSsoEnabled                     bool
 	AuthSsoSessionIdleTimeout          time.Duration
 	AuthSsoSessionIdleTimeoutStr       string
+	AuthSsoSessionMaxAge               time.Duration
+	AuthSsoSessionMaxAgeStr            string
 	AuthAccountLockoutMaxAttempts      int
 	AuthAccountLockoutDuration         time.Duration
 	AuthAccountLockoutDurationStr      string
@@ -145,6 +147,8 @@ var defaultConfig = Config{
 	AuthSsoEnabled:                     true,
 	AuthSsoSessionIdleTimeout:          4 * time.Hour,
 	AuthSsoSessionIdleTimeoutStr:       "4h",
+	AuthSsoSessionMaxAge:               30 * 24 * time.Hour,
+	AuthSsoSessionMaxAgeStr:            "720h",
 	AuthAccountLockoutMaxAttempts:      5,
 	AuthAccountLockoutDuration:         15 * time.Minute,
 	AuthAccountLockoutDurationStr:      "15m",

--- a/pkg/idpsession/cascade.go
+++ b/pkg/idpsession/cascade.go
@@ -24,6 +24,22 @@ func DeactivateIdle(timeout time.Duration) (int, error) {
 	return len(ids), nil
 }
 
+// DeactivateExpiredMaxAge finds all active IdP sessions created before
+// time.Now()-maxAge and cascade-deactivates each one. Returns the count.
+func DeactivateExpiredMaxAge(maxAge time.Duration) (int, error) {
+	ids, err := getExpiredMaxAgeSessionIDs(time.Now().Add(-maxAge))
+	if err != nil {
+		return 0, fmt.Errorf("idpsession: %w", err)
+	}
+
+	for _, id := range ids {
+		if err := DeactivateWithCascade(id); err != nil {
+			return 0, fmt.Errorf("idpsession: cascade-deactivate %s: %w", id, err)
+		}
+	}
+	return len(ids), nil
+}
+
 // DeactivateWithCascade deactivates an IdP (SSO) session and every OAuth
 // session + token that was born from it, atomically.
 //

--- a/pkg/idpsession/cookie.go
+++ b/pkg/idpsession/cookie.go
@@ -2,6 +2,7 @@ package idpsession
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/eugenioenko/autentico/pkg/config"
 )
@@ -14,14 +15,18 @@ const rootCookiePath = "/"
 
 func SetCookie(w http.ResponseWriter, sessionID string) {
 	bs := config.GetBootstrap()
-	http.SetCookie(w, &http.Cookie{
+	cookie := &http.Cookie{
 		Name:     bs.AuthIdpSessionCookieName,
 		Value:    sessionID,
 		Path:     rootCookiePath,
 		HttpOnly: true,
 		Secure:   bs.AuthIdpSessionSecureCookie,
 		SameSite: http.SameSiteLaxMode,
-	})
+	}
+	if maxAge := config.Get().AuthSsoSessionMaxAge; maxAge > 0 {
+		cookie.Expires = time.Now().Add(maxAge)
+	}
+	http.SetCookie(w, cookie)
 }
 
 func ReadCookie(r *http.Request) string {

--- a/pkg/idpsession/cookie_test.go
+++ b/pkg/idpsession/cookie_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/eugenioenko/autentico/pkg/config"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
@@ -16,6 +17,7 @@ func TestSetCookie(t *testing.T) {
 		config.Bootstrap.AuthIdpSessionCookieName = "autentico_idp_session"
 		config.Bootstrap.AppOAuthPath = "/oauth2"
 		config.Bootstrap.AuthIdpSessionSecureCookie = false
+		config.Values.AuthSsoSessionMaxAge = 0
 	})
 
 	rr := httptest.NewRecorder()
@@ -29,6 +31,25 @@ func TestSetCookie(t *testing.T) {
 	assert.Equal(t, "/", cookie.Path)
 	assert.True(t, cookie.HttpOnly)
 	assert.Equal(t, http.SameSiteLaxMode, cookie.SameSite)
+	assert.True(t, cookie.Expires.IsZero(), "max age 0 should produce a session cookie")
+}
+
+func TestSetCookie_WithMaxAge(t *testing.T) {
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AuthIdpSessionCookieName = "autentico_idp_session"
+		config.Bootstrap.AuthIdpSessionSecureCookie = false
+		config.Values.AuthSsoSessionMaxAge = 720 * time.Hour
+	})
+
+	before := time.Now()
+	rr := httptest.NewRecorder()
+	SetCookie(rr, "test-session-id")
+
+	cookies := rr.Result().Cookies()
+	assert.Len(t, cookies, 1)
+	cookie := cookies[0]
+	assert.False(t, cookie.Expires.IsZero(), "max age > 0 should set cookie Expires")
+	assert.WithinDuration(t, before.Add(720*time.Hour), cookie.Expires, 5*time.Second)
 }
 
 func TestReadCookie(t *testing.T) {

--- a/pkg/idpsession/read.go
+++ b/pkg/idpsession/read.go
@@ -149,6 +149,27 @@ func scanDeviceRows(rows *sql.Rows, withUserInfo bool) ([]DeviceRow, error) {
 	return out, rows.Err()
 }
 
+func getExpiredMaxAgeSessionIDs(createdBefore time.Time) ([]string, error) {
+	rows, err := db.GetDB().Query(
+		`SELECT id FROM idp_sessions
+		  WHERE deactivated_at IS NULL
+		    AND created_at < ?`, createdBefore)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query expired max-age idp_sessions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("failed to scan expired max-age idp_session id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 func getIdleSessionIDs(idleThreshold time.Time) ([]string, error) {
 	rows, err := db.GetDB().Query(
 		`SELECT id FROM idp_sessions


### PR DESCRIPTION
## Summary

- Adds `sso_session_max_age` runtime setting (default `720h` / 30 days, `0` = disabled) that enforces an absolute maximum lifetime on IdP sessions, regardless of activity
- Complements the existing `sso_session_idle_timeout` — both must pass for a session to be valid
- No per-client overrides (IdP sessions are browser-level, not owned by a single client)
- No schema changes needed (`idp_sessions.created_at` already exists)

### Changes

| Layer | What |
|---|---|
| **Config** | `AuthSsoSessionMaxAge` + `AuthSsoSessionMaxAgeStr` in `Config` struct, default in `appsettings` |
| **Authorize** | Max-age check in `tryAutoLogin()` alongside existing idle check |
| **Cleanup** | `deactivateExpiredMaxAgeIdpSessions()` calls `DeactivateExpiredMaxAge()` with full cascade |
| **IdP session** | `getExpiredMaxAgeSessionIDs()` query + `DeactivateExpiredMaxAge()` orchestrator |
| **Admin UI** | New "SSO Session Max Age" field in Authentication → Session Control |
| **Docs** | runtime-settings, sso-sessions, admin-ui/settings, production-checklist, llms.txt, README |

Closes #246

## Test plan

- [x] 3 authorize tests: expired max age shows login, valid max age auto-logins, 0 means infinite
- [x] 2 cleanup tests: deactivates expired sessions, disabled when 0
- [x] All existing authorize, cleanup, idpsession, appsettings, config tests pass
- [ ] Manual: admin UI field renders and saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)