### PR TITLE
fix: reduce oversized strings in adversarial tests

### DIFF
--- a/tests/e2e/listquery_adversarial_test.go
+++ b/tests/e2e/listquery_adversarial_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/eugenioenko/autentico/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -67,7 +68,7 @@ func TestListEndpoints_MaliciousQueryParams(t *testing.T) {
 		{"limit_zero", "limit=0"},
 
 		// Long search truncation (our MaxSearchLength code)
-		{"long_search", "search=" + strings.Repeat("A", 50000)},
+		{"long_search", "search=" + strings.Repeat("A", api.MaxSearchLength+1)},
 
 		// Filter allowlist enforcement (our code)
 		{"sqli_filter_unknown", "password=secret&admin=true"},
@@ -286,7 +287,7 @@ func TestListEndpoints_GroupFilterBypass(t *testing.T) {
 		{"sqli_drop", "x'; DROP TABLE users;--"},
 		{"sqli_subquery", "x' AND 1=(SELECT COUNT(*) FROM users)--"},
 		{"empty", ""},
-		{"long_value", strings.Repeat("G", 10000)},
+		{"long_value", strings.Repeat("G", api.MaxSearchLength+1)},
 		{"null_byte", "group\x00injected"},
 		{"wildcard", "%"},
 	}
@@ -314,7 +315,7 @@ func TestListEndpoints_SessionsUserIDInjection(t *testing.T) {
 		{"sqli_union", "x' UNION SELECT * FROM tokens--"},
 		{"sqli_drop", "'; DROP TABLE sessions;--"},
 		{"sqli_subquery", "' AND 1=(SELECT COUNT(*) FROM users)--"},
-		{"long_id", strings.Repeat("A", 50000)},
+		{"long_id", strings.Repeat("A", api.MaxSearchLength+1)},
 		{"null_byte", "user\x00id"},
 		{"empty", ""},
 		{"wildcard", "%"},

--- a/tests/security/security_jwt_test.go
+++ b/tests/security/security_jwt_test.go
@@ -189,7 +189,7 @@ func TestJWT_MalformedToken(t *testing.T) {
 		"Bearer ",
 		"eyJhbGciOiJSUzI1NiJ9",
 		"eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0",
-		strings.Repeat("a", 10000),
+		strings.Repeat("a", 512),
 	}
 
 	for _, tok := range tokens {


### PR DESCRIPTION
## Summary
- Replace 10K-50K character strings with `api.MaxSearchLength+1` in e2e adversarial tests
- Replace 10K character JWT string with 512 in security tests
- Tests still verify the same boundary behavior without flooding logs

## Test plan
- [x] All adversarial tests pass
- [x] Log output is clean — no more multi-KB lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)