### PR TITLE
feat: add failed logins and locked accounts stats to dashboard

### DIFF
--- a/admin-ui/src/api/stats.ts
+++ b/admin-ui/src/api/stats.ts
@@ -7,6 +7,8 @@ export interface StatsResponse {
   active_tokens: number;
   recent_logins: number;
   pending_deletion_requests: number;
+  failed_logins_24h: number;
+  locked_accounts: number;
 }
 
 export async function getStats(): Promise<StatsResponse> {

--- a/admin-ui/src/pages/DashboardPage.tsx
+++ b/admin-ui/src/pages/DashboardPage.tsx
@@ -9,6 +9,8 @@ import {
   CopyOutlined,
   CheckOutlined,
   DeleteOutlined,
+  WarningOutlined,
+  LockOutlined,
 } from "@ant-design/icons";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -81,6 +83,26 @@ export default function DashboardPage() {
               title="Recent Logins (24h)"
               value={stats?.recent_logins ?? 0}
               prefix={<LoginOutlined />}
+            />
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Card>
+            <Statistic
+              title="Failed Logins (24h)"
+              value={stats?.failed_logins_24h ?? 0}
+              prefix={<WarningOutlined />}
+              valueStyle={(stats?.failed_logins_24h ?? 0) > 0 ? { color: "#cf1322" } : undefined}
+            />
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Card>
+            <Statistic
+              title="Locked Accounts"
+              value={stats?.locked_accounts ?? 0}
+              prefix={<LockOutlined />}
+              valueStyle={(stats?.locked_accounts ?? 0) > 0 ? { color: "#cf1322" } : undefined}
             />
           </Card>
         </Col>

--- a/pkg/admin/stats.go
+++ b/pkg/admin/stats.go
@@ -14,6 +14,8 @@ type StatsResponse struct {
 	ActiveTokens            int `json:"active_tokens"`
 	RecentLogins            int `json:"recent_logins"`
 	PendingDeletionRequests int `json:"pending_deletion_requests"`
+	FailedLogins24h         int `json:"failed_logins_24h"`
+	LockedAccounts          int `json:"locked_accounts"`
 }
 
 // HandleStats returns system-wide statistics for the admin dashboard.
@@ -40,6 +42,8 @@ func HandleStats(w http.ResponseWriter, r *http.Request) {
 	_ = d.QueryRow(`SELECT COUNT(*) FROM tokens WHERE revoked_at IS NULL AND access_token_expires_at > CURRENT_TIMESTAMP`).Scan(&stats.ActiveTokens)
 	_ = d.QueryRow(`SELECT COUNT(*) FROM sessions WHERE created_at > datetime('now', '-24 hours')`).Scan(&stats.RecentLogins)
 	_ = d.QueryRow(`SELECT COUNT(*) FROM deletion_requests`).Scan(&stats.PendingDeletionRequests)
+	_ = d.QueryRow(`SELECT COUNT(*) FROM audit_logs WHERE event = 'login_failed' AND created_at > datetime('now', '-24 hours')`).Scan(&stats.FailedLogins24h)
+	_ = d.QueryRow(`SELECT COUNT(*) FROM users WHERE locked_until > CURRENT_TIMESTAMP AND deactivated_at IS NULL`).Scan(&stats.LockedAccounts)
 
 	utils.SuccessResponse(w, stats, http.StatusOK)
 }


### PR DESCRIPTION
## Summary
- Add **Failed Logins (24h)** stat card — counts `login_failed` audit events from the last 24 hours
- Add **Locked Accounts** stat card — counts users with active `locked_until` timestamps
- Both cards highlight red when non-zero to draw admin attention
- Lightweight: single indexed COUNT queries, no impact on dashboard load time

Closes #241

## Test plan
- [ ] Verify dashboard loads with the two new stat cards showing `0`
- [ ] Trigger failed logins and confirm the count increments
- [ ] Lock an account and confirm the locked accounts count increments
- [ ] Verify red highlighting appears only when counts are > 0
- [ ] Confirm auto-refresh (30s) picks up changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)