### PR TITLE
fix: increase MFA challenge expiration from 5 to 10 minutes

### DIFF
--- a/pkg/email/email_body_otp.html
+++ b/pkg/email/email_body_otp.html
@@ -1,3 +1,3 @@
-<p style="margin:0 0 32px 0;color:#3f3f46;">Use the code below to complete your sign-in. It expires in <strong>5 minutes</strong>.</p>
+<p style="margin:0 0 32px 0;color:#3f3f46;">Use the code below to complete your sign-in. It expires in <strong>10 minutes</strong>.</p>
 <p style="margin:0 0 32px 0;font-size:36px;font-weight:700;letter-spacing:10px;color:#3f3f46;font-family:'Courier New',Courier,monospace;">{{.Code}}</p>
 <p style="margin:0;font-size:13px;color:#3f3f46;">Do not share this code with anyone.</p>

--- a/pkg/email/send.go
+++ b/pkg/email/send.go
@@ -88,5 +88,5 @@ func SendEmailOTP(to, code string) error {
 	if err != nil {
 		return fmt.Errorf("failed to render email body: %w", err)
 	}
-	return SendEmail(to, "Your verification code", "Your sign-in verification code — expires in 5 minutes.", body)
+	return SendEmail(to, "Your verification code", "Your sign-in verification code — expires in 10 minutes.", body)
 }

--- a/pkg/email/send_test.go
+++ b/pkg/email/send_test.go
@@ -98,7 +98,7 @@ func TestRenderBody_OTPEmail(t *testing.T) {
 
 		html := string(body)
 		assert.Contains(t, html, "847291")
-		assert.Contains(t, html, "5 minutes")
+		assert.Contains(t, html, "10 minutes")
 		assert.Contains(t, html, "Do not share")
 	})
 }

--- a/pkg/login/handler.go
+++ b/pkg/login/handler.go
@@ -23,6 +23,8 @@ import (
 	"github.com/eugenioenko/autentico/pkg/utils"
 )
 
+const mfaChallengeExpiration = 10 * time.Minute
+
 // HandleLoginUser handles user login requests.
 // CSRF-protected form — not included in public API docs.
 //
@@ -204,7 +206,7 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 			UserID:     usr.ID,
 			Method:     method,
 			LoginState: string(stateJSON),
-			ExpiresAt:  time.Now().Add(5 * time.Minute),
+			ExpiresAt:  time.Now().Add(mfaChallengeExpiration),
 		}
 
 		if err := mfa.CreateMfaChallenge(challenge); err != nil {


### PR DESCRIPTION
## Summary

- Increase MFA challenge TTL from 5 to 10 minutes (industry standard for email OTP)
- Extract as named constant `mfaChallengeExpiration` in `pkg/login/handler.go`
- Update email body text and preheader to reflect 10 minutes

Closes #296

## Test plan

- [ ] Run `go test ./pkg/login/... ./pkg/email/... ./pkg/mfa/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)