### PR TITLE
feat: show theme_tagline on login, signup, and onboarding pages

### DIFF
--- a/pkg/authorize/handler.go
+++ b/pkg/authorize/handler.go
@@ -207,6 +207,7 @@ func renderLogin(w http.ResponseWriter, r *http.Request, request AuthorizeReques
 		csrf.TemplateTag:      csrf.TemplateField(r),
 		"ThemeTitle":          cfg.Theme.Title,
 		"ThemeLogoUrl":        cfg.Theme.LogoUrl,
+		"ThemeTagline":        cfg.Theme.Tagline,
 		"SmtpConfigured":      cfg.SmtpHost != "",
 		"FederatedProviders":  federatedProviders,
 	}

--- a/pkg/onboarding/handler.go
+++ b/pkg/onboarding/handler.go
@@ -108,6 +108,7 @@ func renderOnboard(w http.ResponseWriter, r *http.Request, params onboardParams,
 		csrf.TemplateTag:    csrf.TemplateField(r),
 		"ThemeTitle":        cfg.Theme.Title,
 		"ThemeLogoUrl":      cfg.Theme.LogoUrl,
+		"ThemeTagline":      cfg.Theme.Tagline,
 	}
 
 	if err = tmpl.ExecuteTemplate(w, "layout", data); err != nil {

--- a/pkg/signup/handler.go
+++ b/pkg/signup/handler.go
@@ -271,6 +271,7 @@ func RenderSignup(w http.ResponseWriter, r *http.Request, params SignupParams, e
 		csrf.TemplateTag:      csrf.TemplateField(r),
 		"ThemeTitle":          cfg.Theme.Title,
 		"ThemeLogoUrl":        cfg.Theme.LogoUrl,
+		"ThemeTagline":        cfg.Theme.Tagline,
 		// Profile field visibility
 		"ProfileFieldGivenName":  cfg.ProfileFieldGivenName,
 		"ProfileFieldFamilyName": cfg.ProfileFieldFamilyName,

--- a/view/login.html
+++ b/view/login.html
@@ -2,6 +2,7 @@
 <form class="auth-card" method="POST" action="{{authURL "/login"}}">
   {{template "logo" .}}
   <h1 class="auth-title">{{.ThemeTitle}}</h1>
+  {{if .ThemeTagline}}<p class="auth-tagline">{{.ThemeTagline}}</p>{{end}}
   {{ .csrfField }}
   <input type="hidden" name="state" value="{{.State}}" />
   <input type="hidden" name="redirect_uri" value="{{.RedirectURI}}" />

--- a/view/login.html
+++ b/view/login.html
@@ -1,8 +1,10 @@
 {{define "content"}}
 <form class="auth-card" method="POST" action="{{authURL "/login"}}">
-  {{template "logo" .}}
-  <h1 class="auth-title">{{.ThemeTitle}}</h1>
-  {{if .ThemeTagline}}<p class="auth-tagline">{{.ThemeTagline}}</p>{{end}}
+  <div class="auth-header">
+    {{template "logo" .}}
+    <h1 class="auth-title">{{.ThemeTitle}}</h1>
+    {{if .ThemeTagline}}<p class="auth-tagline">{{.ThemeTagline}}</p>{{end}}
+  </div>
   {{ .csrfField }}
   <input type="hidden" name="state" value="{{.State}}" />
   <input type="hidden" name="redirect_uri" value="{{.RedirectURI}}" />

--- a/view/onboard.html
+++ b/view/onboard.html
@@ -1,8 +1,10 @@
 {{define "content"}}
 <form class="auth-card" method="POST" action="{{.FormAction}}">
-  {{template "logo" .}}
-  <h1 class="auth-title" data-testid="onboard-title">Autentico Admin Setup</h1>
-  {{if .ThemeTagline}}<p class="auth-tagline">{{.ThemeTagline}}</p>{{end}}
+  <div class="auth-header">
+    {{template "logo" .}}
+    <h1 class="auth-title" data-testid="onboard-title">Autentico Admin Setup</h1>
+    {{if .ThemeTagline}}<p class="auth-tagline">{{.ThemeTagline}}</p>{{end}}
+  </div>
   <p class="auth-text-muted">Create the first administrator account to start using Auténtico.</p>
   {{ .csrfField }}
   <input type="hidden" name="state" value="{{.State}}" />

--- a/view/onboard.html
+++ b/view/onboard.html
@@ -2,6 +2,7 @@
 <form class="auth-card" method="POST" action="{{.FormAction}}">
   {{template "logo" .}}
   <h1 class="auth-title" data-testid="onboard-title">Autentico Admin Setup</h1>
+  {{if .ThemeTagline}}<p class="auth-tagline">{{.ThemeTagline}}</p>{{end}}
   <p class="auth-text-muted">Create the first administrator account to start using Auténtico.</p>
   {{ .csrfField }}
   <input type="hidden" name="state" value="{{.State}}" />

--- a/view/signup.html
+++ b/view/signup.html
@@ -1,8 +1,10 @@
 {{define "content"}}
 <form class="auth-card" method="POST" action="{{authURL "/signup"}}" data-auth-mode="{{.AuthMode}}" onsubmit="handleSignupSubmit(event)">
-  {{template "logo" .}}
-  <h1 class="auth-title">{{.ThemeTitle}}</h1>
-  {{if .ThemeTagline}}<p class="auth-tagline">{{.ThemeTagline}}</p>{{end}}
+  <div class="auth-header">
+    {{template "logo" .}}
+    <h1 class="auth-title">{{.ThemeTitle}}</h1>
+    {{if .ThemeTagline}}<p class="auth-tagline">{{.ThemeTagline}}</p>{{end}}
+  </div>
   {{ .csrfField }}
   <input type="hidden" name="state" value="{{.State}}" />
   <input type="hidden" name="redirect_uri" value="{{.RedirectURI}}" />

--- a/view/signup.html
+++ b/view/signup.html
@@ -2,6 +2,7 @@
 <form class="auth-card" method="POST" action="{{authURL "/signup"}}" data-auth-mode="{{.AuthMode}}" onsubmit="handleSignupSubmit(event)">
   {{template "logo" .}}
   <h1 class="auth-title">{{.ThemeTitle}}</h1>
+  {{if .ThemeTagline}}<p class="auth-tagline">{{.ThemeTagline}}</p>{{end}}
   {{ .csrfField }}
   <input type="hidden" name="state" value="{{.State}}" />
   <input type="hidden" name="redirect_uri" value="{{.RedirectURI}}" />

--- a/view/static/auth.css
+++ b/view/static/auth.css
@@ -144,6 +144,13 @@ body {
   color: var(--color-fg);
 }
 
+.auth-tagline {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 300;
+  color: var(--color-muted);
+}
+
 .auth-field {
   width: 100%;
   display: flex;

--- a/view/static/auth.css
+++ b/view/static/auth.css
@@ -136,6 +136,12 @@ body {
 
 /* ── Components ─────────────────────────────────────────── */
 
+.auth-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .auth-title {
   font-size: 1.875rem;
   line-height: 1.2;

--- a/view/static/auth.css
+++ b/view/static/auth.css
@@ -140,10 +140,11 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-bottom: 1.25rem;
 }
 
 .auth-header .logo {
-  margin-bottom: 0.75rem;
+  margin-bottom: 1.25rem;
 }
 
 .auth-title {

--- a/view/static/auth.css
+++ b/view/static/auth.css
@@ -142,6 +142,10 @@ body {
   align-items: center;
 }
 
+.auth-header .logo {
+  margin-bottom: 0.75rem;
+}
+
 .auth-title {
   font-size: 1.875rem;
   line-height: 1.2;


### PR DESCRIPTION
## Summary
- Pass `ThemeTagline` from runtime config to login, signup, and onboarding templates
- Render it conditionally below the title when set (non-empty)
- Add `.auth-tagline` CSS class for consistent styling

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)