### PR TITLE
feat: add loading state to auth form submit buttons

### DIFF
--- a/view/static/auth.css
+++ b/view/static/auth.css
@@ -238,6 +238,28 @@ body {
   scale: 0.98;
 }
 
+.auth-btn.is-loading {
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+.auth-btn.is-loading::after {
+  content: "";
+  display: inline-block;
+  width: 0.875rem;
+  height: 0.875rem;
+  margin-left: 0.5rem;
+  border: 2px solid transparent;
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: btn-spin 0.6s linear infinite;
+  vertical-align: middle;
+}
+
+@keyframes btn-spin {
+  to { transform: rotate(360deg); }
+}
+
 .auth-btn-secondary {
   width: 100%;
   display: flex;

--- a/view/static/main.js
+++ b/view/static/main.js
@@ -70,3 +70,10 @@
   }
   frame();
 })();
+
+document.querySelectorAll('.auth-card').forEach(function (form) {
+  form.addEventListener('submit', function () {
+    var btn = form.querySelector('.auth-btn[type="submit"]');
+    if (btn) btn.classList.add('is-loading');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `is-loading` CSS class with spinner animation and disabled pointer events
- On form submit, automatically add loading state to the `.auth-btn[type="submit"]` button
- Applies globally to all auth forms (login, signup, MFA, password reset, onboarding) via `main.js`

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)