### PR TITLE
feat: MFA method switching + OAuth2 consent screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,8 +185,9 @@ Redirect URI for all clients: `https://localhost.emobix.co.uk:8443/test/*/callba
 
 `main.go` delegates to `pkg/cli/`. Subcommands:
 - `autentico init` — generates a `.env` with fresh RSA key (base64 PEM), CSRF secret, and token signing secrets
-- `autentico start` — loads config, initializes DB, auto-applies pending migrations, seeds `autentico-admin` client, registers all routes, starts background cleanup, listens on `AppListenPort`; accepts `--no-auto-migrate` to skip automatic migrations, `--auto-setup` to generate `.env` if missing
+- `autentico start` — loads config, initializes DB, auto-applies pending migrations, seeds `autentico-admin` and `autentico-account` clients, registers all routes, starts background cleanup, listens on `AppListenPort`; accepts `--no-auto-migrate` to skip automatic migrations, `--auto-setup` to generate `.env` if missing
 - `autentico migrate` — interactive CLI to apply pending database schema migrations; prompts user to type the target version number to confirm (irreversible)
+- `autentico onboard` — headless alternative to the `/onboard` web wizard; creates the first admin account with `--username`, `--password`, `--email`; `--enable-admin-password-grant` adds ROPC grant to the admin client for CI/testing
 
 ### Package Structure
 
@@ -200,29 +201,45 @@ Each feature package in `pkg/` follows a consistent pattern:
 
 | Package | Purpose |
 |---------|---------|
+| `pkg/account` | Account UI API — profile, password change, TOTP setup, passkey management, session listing |
 | `pkg/admin` | Serves embedded React admin UI (from `pkg/admin/dist`) and `/admin/api/stats` |
+| `pkg/api` | API utilities shared across admin and account APIs |
 | `pkg/appsettings` | Settings CRUD — persists runtime config to `settings` table, checks onboarding status |
+| `pkg/audit` | Audit log recording and querying (`audit_logs` table) |
 | `pkg/auth_code` | Authorization code model (PKCE, nonce, single-use flag) |
 | `pkg/authorize` | `/oauth2/authorize` — validates client + redirect URI, renders login page |
+| `pkg/authzsig` | HMAC signatures for authorize-to-login parameter integrity |
+| `pkg/bearer` | Bearer token extraction utilities |
 | `pkg/cleanup` | Background goroutine purging expired tokens, sessions, MFA challenges, etc. |
-| `pkg/cli` | `init`, `start`, and `migrate` subcommand implementations |
+| `pkg/cli` | `init`, `start`, `migrate`, and `onboard` subcommand implementations |
 | `pkg/client` | OAuth2 client registration, CRUD, and authentication (`/oauth2/register`) |
 | `pkg/config` | Bootstrap config (env vars, immutable) and runtime config (DB, hot-reloadable) |
+| `pkg/consent` | OAuth2 consent screen — per-client `consent_required`, scope display, consent persistence |
 | `pkg/db` | SQLite initialization, schema DDL |
 | `pkg/db/migrations` | Migration system — `SchemaVersion` constant, `Migration` struct, `Check()` and `Run()` functions, ordered migrations slice |
+| `pkg/deletion` | Account deletion requests — user-initiated, admin-reviewed |
+| `pkg/email` | Email sending (SMTP) — OTP codes, password reset, email verification |
+| `pkg/emailverification` | Email verification flow — send verification link, confirm token |
+| `pkg/federation` | Federated/social login providers (external IdP integration) |
+| `pkg/group` | User groups — CRUD, membership management |
+| `pkg/health` | Health check endpoint (`/health`) |
 | `pkg/idpsession` | IdP-level SSO sessions — cross-request browser sessions, idle timeout enforcement |
 | `pkg/introspect` | `/oauth2/introspect` — token introspection (RFC 7662) |
 | `pkg/jwtutil` | JWT parsing, `AccessTokenClaims`, audience validation |
 | `pkg/key` | RSA key loading (from `AUTENTICO_PRIVATE_KEY` env var) or ephemeral fallback, JWK generation |
 | `pkg/login` | `/oauth2/login` — credential validation, MFA challenge creation, auth code issuance |
 | `pkg/mfa` | MFA challenge management (TOTP enrollment, TOTP/email OTP verification) |
-| `pkg/middleware` | CORS, CSRF, logging, admin bearer-token auth, audience validation |
+| `pkg/middleware` | CORS, CSRF, logging, admin bearer-token auth, audience validation, rate limiting |
 | `pkg/model` | Shared response types: `ApiResponse[T]`, `ApiError`, `AuthErrorResponse`, JWK/JWKS, WellKnownConfig |
 | `pkg/onboarding` | First-run admin account creation wizard |
 | `pkg/passkey` | WebAuthn registration + authentication ceremonies (`go-webauthn/webauthn v0.15.0`) |
+| `pkg/passwordreset` | Password reset flow — forgot password, reset token, new password |
+| `pkg/ratelimit` | Per-IP rate limiting for auth endpoints (token bucket) |
+| `pkg/reqid` | Request ID generation and context propagation |
+| `pkg/revoke` | `/oauth2/revoke` — token revocation (RFC 7009) |
 | `pkg/session` | OAuth session lifecycle (create, read, deactivate, logout) |
 | `pkg/signup` | Self-service user registration (enabled via `allow_self_signup` setting) |
-| `pkg/token` | `/oauth2/token` — code exchange, refresh token grant, ROPC, revocation |
+| `pkg/token` | `/oauth2/token` — code exchange, refresh token grant, ROPC, client credentials |
 | `pkg/trusteddevice` | Trusted device tokens — MFA bypass cookie management |
 | `pkg/user` | User CRUD, bcrypt password hashing, account lockout, TOTP secret storage |
 | `pkg/userinfo` | `/oauth2/userinfo` endpoint |
@@ -233,15 +250,16 @@ Each feature package in `pkg/` follows a consistent pattern:
 
 1. Client redirects to `/oauth2/authorize` → validates client, renders `view/login.html`
 2. Depending on `auth_mode`: user submits password to `/oauth2/login`, or initiates passkey ceremony at `/oauth2/passkey/login/begin` + `/oauth2/passkey/login/finish`
-3. If MFA is enabled: user is redirected to `/oauth2/mfa` for TOTP/email OTP verification (unless on a trusted device)
-4. Auth code is issued, client redirects back with `code`
-5. Client exchanges code at `/oauth2/token` → access token + id token + refresh token (RS256 JWTs)
-6. Tokens are signed with the RSA key from `AUTENTICO_PRIVATE_KEY` (base64-encoded PEM env var); if unset, an ephemeral key is used (tokens invalidated on restart)
+3. If MFA is enabled (`require_mfa` or user has TOTP enrolled): user is redirected to `/oauth2/mfa` for TOTP/email OTP verification (unless on a trusted device). When `mfa_method` is `both` and user has TOTP enrolled, TOTP is preferred with an option to switch to email.
+4. If client has `consent_required`: user is redirected to `/oauth2/consent` to approve requested scopes. Consent is remembered per user+client+scopes — subsequent logins skip this step unless scopes change.
+5. Auth code is issued, client redirects back with `code`
+6. Client exchanges code at `/oauth2/token` → access token + id token + refresh token (RS256 JWTs)
+7. Tokens are signed with the RSA key from `AUTENTICO_PRIVATE_KEY` (base64-encoded PEM env var); if unset, an ephemeral key is used (tokens invalidated on restart)
 
 ### View Templates
 
 HTML templates in `view/` rendered server-side for all interactive flows:
-`layout.html`, `login.html`, `signup.html`, `onboard.html`, `mfa.html`, `mfa_enroll.html`, `error.html`
+`layout.html`, `login.html`, `signup.html`, `onboard.html`, `mfa.html`, `mfa_enroll.html`, `consent.html`, `forgot_password.html`, `reset_password.html`, `verify_email.html`, `logout_success.html`, `error.html`
 
 ### Configuration (3 layers)
 
@@ -249,27 +267,32 @@ HTML templates in `view/` rendered server-side for all interactive flows:
 
 Key fields:
 - `AUTENTICO_APP_URL` — base URL (derives issuer, domain, port)
+- `AUTENTICO_APP_OAUTH_PATH` — override OAuth path (default: `/oauth2`)
+- `AUTENTICO_LISTEN_PORT` — override listen port independent of `APP_URL` (for reverse proxy setups)
 - `AUTENTICO_DB_FILE_PATH` — SQLite file path (default: `./autentico.db`)
+- `AUTENTICO_DB_READ_POOL_SIZE` — SQLite read connection pool (default: `min(CPUs, 4)`)
 - `AUTENTICO_PRIVATE_KEY` — base64-encoded RSA private key PEM
 - `AUTENTICO_ACCESS_TOKEN_SECRET`, `AUTENTICO_REFRESH_TOKEN_SECRET`, `AUTENTICO_CSRF_SECRET_KEY`
 - `AUTENTICO_CSRF_SECURE_COOKIE`, `AUTENTICO_REFRESH_TOKEN_SECURE`, `AUTENTICO_IDP_SESSION_SECURE`
 - `AUTENTICO_JWK_CERT_KEY_ID` (default: `autentico-key-1`)
+- `AUTENTICO_RATE_LIMIT_RPS`, `AUTENTICO_RATE_LIMIT_BURST`, `AUTENTICO_RATE_LIMIT_RPM`, `AUTENTICO_RATE_LIMIT_RPM_BURST` — per-IP rate limiting
+- `AUTENTICO_ANTI_TIMING_MIN_MS`, `AUTENTICO_ANTI_TIMING_MAX_MS` — anti-timing delay for auth responses
 
 Access via `config.GetBootstrap()`.
 
 **Runtime** (`pkg/config`, persisted in `settings` table, hot-reloadable via admin API)
 
-Key fields: token expiration durations, `auth_mode`, `mfa_enabled`, `mfa_method`, `allow_self_signup`, `sso_session_idle_timeout`, account lockout, passkey RP name, trusted device settings, cleanup intervals, SMTP settings, theme (CSS, logo, title), validation rules.
+Key fields: token expiration durations, `auth_mode`, `require_mfa`, `mfa_method`, `allow_self_signup`, `sso_session_idle_timeout`, account lockout, passkey RP name, trusted device settings, cleanup intervals, SMTP settings (host, port, username, password, from), CORS (`cors_allowed_origins`), theme (CSS, logo, title, tagline, footer links), profile field visibility, email verification, password reset, account deletion permissions, validation rules.
 
 Access via `config.Get()`. Updated via `appsettings.LoadIntoConfig()`.
 
 **Per-client overrides** (stored on `clients` table, nullable — unset means "use global")
 
-Overridable: token expiration times, `allowed_audiences`, `allow_self_signup`, `sso_session_idle_timeout`, `trust_device_enabled`, `trust_device_expiration`.
+Overridable: token expiration times, `allowed_audiences`, `allow_self_signup`, `sso_session_idle_timeout`, `trust_device_enabled`, `trust_device_expiration`, `consent_required`.
 
 ### Database
 
-Initialized by `db.InitDB()`. Schema in `pkg/db/db.go`. 11 tables:
+Initialized by `db.InitDB()`. Schema defined in `pkg/db/migrations/`. 20 tables (SchemaVersion 7):
 
 | Table | Purpose |
 |-------|---------|
@@ -282,8 +305,16 @@ Initialized by `db.InitDB()`. Schema in `pkg/db/db.go`. 11 tables:
 | `trusted_devices` | Trusted device tokens (MFA bypass) |
 | `passkey_challenges` | Pending WebAuthn ceremony state |
 | `passkey_credentials` | Registered WebAuthn credentials (JSON blob) |
-| `clients` | OAuth2 clients with per-client config overrides |
+| `clients` | OAuth2 clients with per-client config overrides (including `consent_required`) |
 | `settings` | Key-value runtime config |
+| `federation_providers` | External IdP configurations for federated/social login |
+| `federated_identities` | Links between local users and external IdP accounts |
+| `deletion_requests` | User-initiated account deletion requests (admin-reviewed) |
+| `password_reset_tokens` | Time-limited tokens for password reset flow (migration 002) |
+| `audit_logs` | Security event audit trail (migration 003) |
+| `groups` | User groups (migration 004) |
+| `user_groups` | Group membership join table (migration 004) |
+| `user_consents` | Stored OAuth2 consent decisions per user+client+scopes (migration 007) |
 
 **SQLite driver:** `modernc.org/sqlite` (NOT `mattn/go-sqlite3`). Scanning SQL NULL into a plain `string` causes an error — always use `*string` or provide explicit `""` in test fixtures for nullable string columns.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,65 @@ make docs                     # Serves Swagger UI at localhost:8888
 make generate-docs            # Regenerate swagger files from handler annotations
 ```
 
+## Headless Onboarding & Admin Token (CI / Testing)
+
+```bash
+# 1. Remove existing DB for a clean start (if needed)
+rm -f autentico.db
+
+# 2. Start the server (auto-generates .env if missing)
+./autentico start --auto-setup &
+sleep 2
+
+# 3. Create admin account with ROPC grant enabled (must run BEFORE start seeds the admin client,
+#    or on a fresh DB — seedAdminClient skips if autentico-admin already exists)
+./autentico onboard --username admin --password secret --email admin@test.com --enable-admin-password-grant
+
+# 4. Get an admin bearer token via ROPC
+TOKEN=$(curl -s http://localhost:9999/oauth2/token -X POST \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password&username=admin&password=secret&client_id=autentico-admin&scope=openid profile email" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
+
+# 5. Use the token for admin API calls
+curl -s http://localhost:9999/admin/api/clients \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Important:** `onboard` must run before the first `start` seeds the admin client, or on a fresh DB. The `--enable-admin-password-grant` flag adds the `password` grant type to `autentico-admin`. If the client already exists without it, delete the DB and re-onboard.
+
+## Playwright MCP (Browser Testing)
+
+The Playwright MCP server provides browser automation tools (`mcp__playwright__*`) for testing UI flows.
+
+**Setup:** The MCP server expects Chrome at `/opt/google/chrome/chrome`. If not installed, symlink the Playwright-managed Chromium:
+
+```bash
+# Install Playwright browsers (if not already cached)
+npx playwright install chromium
+
+# Symlink to the expected path (requires sudo)
+sudo mkdir -p /opt/google/chrome
+sudo ln -sf ~/.cache/ms-playwright/chromium-*/chrome-linux64/chrome /opt/google/chrome/chrome
+```
+
+**Debug UI as test client:** The `debug-ui/` directory contains a Vite+React app that acts as an OAuth2 client for manual testing. It runs on `http://localhost:5174` and uses client_id `autentico-debug`.
+
+```bash
+# Register the debug client (with consent_required for consent screen testing)
+curl -s -X POST http://localhost:9999/admin/api/clients \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"client_id":"autentico-debug","client_name":"Debug UI","redirect_uris":["http://localhost:5174/callback"],"grant_types":["authorization_code","refresh_token"],"response_types":["code"],"scopes":"openid profile email offline_access","client_type":"public","token_endpoint_auth_method":"none","consent_required":true}'
+
+# Add CORS origin for the debug UI
+curl -s -X PUT http://localhost:9999/admin/api/settings \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"cors_allowed_origins": "http://localhost:5174"}'
+
+# Start the debug UI dev server
+cd debug-ui && pnpm dev
+```
+
 ## Feature Development Workflow
 
 When implementing new features, follow the checklist in `WORKFLOW.md`. Key points:

--- a/admin-ui/src/components/clients/ClientCreateForm.tsx
+++ b/admin-ui/src/components/clients/ClientCreateForm.tsx
@@ -387,6 +387,15 @@ export default function ClientCreateForm({
                     >
                       <Input placeholder="Global default (e.g. 720h)" />
                     </Form.Item>
+
+                    <Form.Item
+                      label="Consent Required"
+                      name="consent_required"
+                      valuePropName="checked"
+                      tooltip={{ title: "When enabled, users must grant consent before this client can access their information", icon: <ExclamationCircleOutlined /> }}
+                    >
+                      <Switch />
+                    </Form.Item>
                   </Space>
                 ),
               },

--- a/admin-ui/src/components/clients/ClientEditForm.tsx
+++ b/admin-ui/src/components/clients/ClientEditForm.tsx
@@ -84,6 +84,7 @@ export default function ClientEditForm({
         sso_session_idle_timeout: client.sso_session_idle_timeout,
         trust_device_enabled: client.trust_device_enabled,
         trust_device_expiration: client.trust_device_expiration,
+        consent_required: client.consent_required,
       });
     }
   }, [client, open, form]);
@@ -362,6 +363,15 @@ export default function ClientEditForm({
                     tooltip={{ title: overrideTip("trust_device_expiration"), icon: <ExclamationCircleOutlined /> }}
                   >
                     <Input placeholder="Global default (e.g. 720h)" />
+                  </Form.Item>
+
+                  <Form.Item
+                    label="Consent Required"
+                    name="consent_required"
+                    valuePropName="checked"
+                    tooltip={{ title: "When enabled, users must grant consent before this client can access their information", icon: <ExclamationCircleOutlined /> }}
+                  >
+                    <Switch />
                   </Form.Item>
                 </Space>
               ),

--- a/admin-ui/src/types/client.ts
+++ b/admin-ui/src/types/client.ts
@@ -11,6 +11,7 @@ export type ClientCreateRequest =
     sso_session_idle_timeout?: string;
     trust_device_enabled?: boolean;
     trust_device_expiration?: string;
+    consent_required?: boolean;
   };
 
 export type ClientUpdateRequest =
@@ -23,6 +24,7 @@ export type ClientUpdateRequest =
     sso_session_idle_timeout?: string;
     trust_device_enabled?: boolean;
     trust_device_expiration?: string;
+    consent_required?: boolean;
   };
 
 export type ClientResponse = components["schemas"]["client.ClientResponse"];
@@ -37,4 +39,5 @@ export type ClientInfoResponse =
     sso_session_idle_timeout?: string;
     trust_device_enabled?: boolean;
     trust_device_expiration?: string;
+    consent_required?: boolean;
   };

--- a/pkg/authorize/handler.go
+++ b/pkg/authorize/handler.go
@@ -5,11 +5,13 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	authcode "github.com/eugenioenko/autentico/pkg/auth_code"
 	"github.com/eugenioenko/autentico/pkg/client"
 	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/consent"
 	"github.com/eugenioenko/autentico/pkg/federation"
 	"github.com/eugenioenko/autentico/pkg/idpsession"
 	"github.com/eugenioenko/autentico/pkg/reqid"
@@ -128,12 +130,34 @@ func HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	// OIDC Core §3.1.2.1: prompt=login requires fresh authentication — skip SSO auto-login
 	// OIDC Core §3.1.2.1: prompt=consent requires user consent — skip SSO auto-login
 	cfg := config.Get()
-	if redirectURL := tryAutoLogin(r, cfg, request); redirectURL != "" {
-		http.Redirect(w, r, redirectURL, http.StatusFound)
+	autoLoginResult := tryAutoLogin(r, cfg, request, registeredClient)
+	if autoLoginResult.redirectURL != "" {
+		http.Redirect(w, r, autoLoginResult.redirectURL, http.StatusFound)
+		return
+	}
+	if autoLoginResult.needsConsent {
+		consent.RedirectToConsent(w, r, consent.ConsentParams{
+			RedirectURI:         request.RedirectURI,
+			State:               request.State,
+			ClientID:            request.ClientID,
+			Scope:               request.Scope,
+			Nonce:               request.Nonce,
+			CodeChallenge:       request.CodeChallenge,
+			CodeChallengeMethod: request.CodeChallengeMethod,
+			Prompt:              request.Prompt,
+		})
 		return
 	}
 
+	// OIDC Core §3.1.2.1: prompt=none — return error if login or consent is required
 	if request.Prompt == "none" {
+		if autoLoginResult.hasSession {
+			// OIDC Core §3.1.2.1: consent_required if consent is needed but prompt=none
+			if consent.NeedsConsent(registeredClient.ConsentRequired, autoLoginResult.userID, request.ClientID, request.Scope, "") {
+				redirectWithError(w, r, request.RedirectURI, request.State, "consent_required", "")
+				return
+			}
+		}
 		redirectWithError(w, r, request.RedirectURI, request.State, "login_required", "")
 		return
 	}
@@ -199,6 +223,7 @@ func renderLogin(w http.ResponseWriter, r *http.Request, request AuthorizeReques
 		"Nonce":               request.Nonce,
 		"CodeChallenge":       request.CodeChallenge,
 		"CodeChallengeMethod": request.CodeChallengeMethod,
+		"Prompt":              request.Prompt,
 		"AuthorizeSig":        AuthorizeSignature(request),
 		"Error":               errorMsg,
 		"AuthMode":            cfg.AuthMode,
@@ -232,44 +257,68 @@ func redirectWithError(w http.ResponseWriter, r *http.Request, redirectURI, stat
 	http.Redirect(w, r, redirectURI+"?"+q.Encode(), http.StatusFound)
 }
 
+type autoLoginResult struct {
+	redirectURL  string
+	needsConsent bool
+	hasSession   bool
+	userID       string
+}
+
 // tryAutoLogin checks for a valid IdP session and returns a redirect URL with
-// an authorization code if SSO auto-login succeeds. Returns "" if auto-login
-// should not or cannot proceed, letting the caller fall through to the login form.
-func tryAutoLogin(r *http.Request, cfg *config.Config, request AuthorizeRequest) string {
-	if !cfg.AuthSsoEnabled || request.Prompt == "login" || request.Prompt == "consent" {
-		return ""
+// an authorization code if SSO auto-login succeeds. Returns empty redirectURL if
+// auto-login should not or cannot proceed.
+func tryAutoLogin(r *http.Request, cfg *config.Config, request AuthorizeRequest, registeredClient *client.Client) autoLoginResult {
+	promptValues := strings.Fields(request.Prompt)
+	hasLogin := false
+	hasConsent := false
+	for _, v := range promptValues {
+		if v == "login" {
+			hasLogin = true
+		}
+		if v == "consent" {
+			hasConsent = true
+		}
+	}
+
+	if !cfg.AuthSsoEnabled || hasLogin {
+		return autoLoginResult{}
 	}
 
 	sessionID := idpsession.ReadCookie(r)
 	if sessionID == "" {
-		return ""
+		return autoLoginResult{}
 	}
 
 	session, err := idpsession.IdpSessionByID(sessionID)
 	if err != nil {
-		return ""
+		return autoLoginResult{}
 	}
 
 	withinIdleTimeout := cfg.AuthSsoSessionIdleTimeout == 0 || time.Since(session.LastActivityAt) < cfg.AuthSsoSessionIdleTimeout
 	if !withinIdleTimeout {
-		return ""
+		return autoLoginResult{hasSession: true, userID: session.UserID}
 	}
 
 	withinMaxAge := cfg.AuthSsoSessionMaxAge == 0 || time.Since(session.CreatedAt) < cfg.AuthSsoSessionMaxAge
 	if !withinMaxAge {
-		return ""
+		return autoLoginResult{hasSession: true, userID: session.UserID}
 	}
 
 	maxAgeSecs := parseMaxAge(request.MaxAge)
 	if maxAgeSecs >= 0 && time.Since(session.CreatedAt) > time.Duration(maxAgeSecs)*time.Second {
-		return ""
+		return autoLoginResult{hasSession: true, userID: session.UserID}
 	}
 
 	_ = idpsession.UpdateLastActivity(session.ID)
 
+	// OIDC Core §3.1.2.4: check consent before issuing auth code
+	if hasConsent || consent.NeedsConsent(registeredClient.ConsentRequired, session.UserID, request.ClientID, request.Scope, request.Prompt) {
+		return autoLoginResult{needsConsent: true, hasSession: true, userID: session.UserID}
+	}
+
 	code, err := authcode.GenerateSecureCode()
 	if err != nil {
-		return ""
+		return autoLoginResult{hasSession: true, userID: session.UserID}
 	}
 
 	ac := authcode.AuthCode{
@@ -287,7 +336,7 @@ func tryAutoLogin(r *http.Request, cfg *config.Config, request AuthorizeRequest)
 		IdpSessionID:        session.ID,
 	}
 	if err := authcode.CreateAuthCode(ac); err != nil {
-		return ""
+		return autoLoginResult{hasSession: true, userID: session.UserID}
 	}
 
 	// RFC 6749 §4.1.2: authorization response MUST include code; state MUST be echoed unchanged if present
@@ -296,7 +345,7 @@ func tryAutoLogin(r *http.Request, cfg *config.Config, request AuthorizeRequest)
 	if request.State != "" {
 		redirectParams.Set("state", request.State)
 	}
-	return request.RedirectURI + "?" + redirectParams.Encode()
+	return autoLoginResult{redirectURL: request.RedirectURI + "?" + redirectParams.Encode(), hasSession: true, userID: session.UserID}
 }
 
 // parseMaxAge parses the max_age query parameter as seconds.

--- a/pkg/authorize/handler_test.go
+++ b/pkg/authorize/handler_test.go
@@ -666,14 +666,15 @@ func TestHandleAuthorize_PromptConsent_BypassesSSO(t *testing.T) {
 	}
 	_ = idpsession.CreateIdpSession(session)
 
-	// prompt=consent must force re-authentication even with an active SSO session
+	// OIDC Core §3.1.2.1: prompt=consent must redirect to consent screen, not auto-login with auth code
 	req := httptest.NewRequest(http.MethodGet, "/oauth2/authorize?response_type=code&client_id=test-client&redirect_uri=http://localhost/callback&state=s1&prompt=consent&code_challenge=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk&code_challenge_method=S256", nil)
 	req.AddCookie(&http.Cookie{Name: "autentico_idp_session", Value: "idp-consent-1"})
 	rr := httptest.NewRecorder()
 
 	HandleAuthorize(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code, "prompt=consent must show login form, not auto-login")
+	assert.Equal(t, http.StatusFound, rr.Code, "prompt=consent must redirect to consent screen")
+	assert.Contains(t, rr.Header().Get("Location"), "/consent", "must redirect to consent endpoint")
 	assert.NotContains(t, rr.Header().Get("Location"), "code=", "must not issue auth code via SSO bypass")
 }
 

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -23,6 +23,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/cleanup"
 	"github.com/eugenioenko/autentico/pkg/client"
 	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/consent"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/db/migrations"
 	"github.com/eugenioenko/autentico/pkg/deletion"
@@ -135,6 +136,7 @@ func RunStart(c *cli.Context) error {
 	mux.Handle("GET "+oauth+"/authorize", csrfProtected(authorize.HandleAuthorize))
 	mux.Handle("POST "+oauth+"/authorize", http.HandlerFunc(authorize.HandleAuthorize))
 	mux.Handle("POST "+oauth+"/login", rateLimited(csrfProtected(login.HandleLoginUser)))
+	mux.Handle(oauth+"/consent", csrfProtected(consent.HandleConsent))
 	mux.Handle(oauth+"/mfa", rateLimited(csrfProtected(mfa.HandleMfa)))
 	mux.Handle(oauth+"/mfa/", rateLimited(csrfProtected(mfa.HandleMfa)))
 	mux.Handle("GET "+oauth+"/passkey/login/begin", rateLimitedFunc(passkey.HandleLoginBegin))

--- a/pkg/client/admin_read.go
+++ b/pkg/client/admin_read.go
@@ -17,7 +17,7 @@ func ClientByClientIDIncludingDisabled(clientID string) (*Client, error) {
 			token_endpoint_auth_method, is_active, created_at, updated_at,
 			access_token_expiration, refresh_token_expiration, authorization_code_expiration,
 			allowed_audiences, allow_self_signup, sso_session_idle_timeout,
-			trust_device_enabled, trust_device_expiration
+			trust_device_enabled, trust_device_expiration, consent_required
 		FROM clients WHERE client_id = ?
 	`
 	var c Client
@@ -29,7 +29,7 @@ func ClientByClientIDIncludingDisabled(clientID string) (*Client, error) {
 		&c.TokenEndpointAuthMethod, &c.IsActive, &c.CreatedAt, &c.UpdatedAt,
 		&c.AccessTokenExpiration, &c.RefreshTokenExpiration, &c.AuthorizationCodeExpiration,
 		&audiences, &c.AllowSelfSignup, &c.SsoSessionIdleTimeout,
-		&c.TrustDeviceEnabled, &c.TrustDeviceExpiration,
+		&c.TrustDeviceEnabled, &c.TrustDeviceExpiration, &c.ConsentRequired,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -56,7 +56,7 @@ func ClientByIDIncludingDisabled(id string) (*Client, error) {
 			token_endpoint_auth_method, is_active, created_at, updated_at,
 			access_token_expiration, refresh_token_expiration, authorization_code_expiration,
 			allowed_audiences, allow_self_signup, sso_session_idle_timeout,
-			trust_device_enabled, trust_device_expiration
+			trust_device_enabled, trust_device_expiration, consent_required
 		FROM clients WHERE id = ?
 	`
 	var c Client
@@ -68,7 +68,7 @@ func ClientByIDIncludingDisabled(id string) (*Client, error) {
 		&c.TokenEndpointAuthMethod, &c.IsActive, &c.CreatedAt, &c.UpdatedAt,
 		&c.AccessTokenExpiration, &c.RefreshTokenExpiration, &c.AuthorizationCodeExpiration,
 		&audiences, &c.AllowSelfSignup, &c.SsoSessionIdleTimeout,
-		&c.TrustDeviceEnabled, &c.TrustDeviceExpiration,
+		&c.TrustDeviceEnabled, &c.TrustDeviceExpiration, &c.ConsentRequired,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/pkg/client/create.go
+++ b/pkg/client/create.go
@@ -96,12 +96,13 @@ func createClientInternal(clientID string, req ClientCreateRequest) (*ClientResp
 
 	query := `
 		INSERT INTO clients (
-			id, client_id, client_secret, client_name, client_type, redirect_uris, 
-			post_logout_redirect_uris, grant_types, response_types, scopes, 
+			id, client_id, client_secret, client_name, client_type, redirect_uris,
+			post_logout_redirect_uris, grant_types, response_types, scopes,
 			token_endpoint_auth_method, access_token_expiration, refresh_token_expiration,
 			authorization_code_expiration, allowed_audiences, allow_self_signup,
-			sso_session_idle_timeout, trust_device_enabled, trust_device_expiration
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			sso_session_idle_timeout, trust_device_enabled, trust_device_expiration,
+			consent_required
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	_, err := db.GetDB().Exec(query,
 		id, clientID, hashedSecret, req.ClientName, clientType, string(redirectURIs),
@@ -109,6 +110,7 @@ func createClientInternal(clientID string, req ClientCreateRequest) (*ClientResp
 		authMethod, req.AccessTokenExpiration, req.RefreshTokenExpiration,
 		req.AuthorizationCodeExpiration, audiences, req.AllowSelfSignup,
 		req.SsoSessionIdleTimeout, req.TrustDeviceEnabled, req.TrustDeviceExpiration,
+		req.ConsentRequired,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)

--- a/pkg/client/handler.go
+++ b/pkg/client/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/eugenioenko/autentico/pkg/api"
 	"github.com/eugenioenko/autentico/pkg/audit"
+	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/model"
 	"github.com/eugenioenko/autentico/pkg/utils"
 )
@@ -173,6 +174,7 @@ func HandleDeleteClient(w http.ResponseWriter, r *http.Request) {
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
 	}
+	_, _ = db.GetDB().Exec(`DELETE FROM user_consents WHERE client_id = ?`, clientID)
 	audit.Log(audit.EventClientDeleted, audit.ActorFromRequest(r), audit.TargetClient, clientID, nil, utils.GetClientIP(r))
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -40,6 +40,7 @@ type Client struct {
 	SsoSessionIdleTimeout       *string `db:"sso_session_idle_timeout"`
 	TrustDeviceEnabled          *bool   `db:"trust_device_enabled"`
 	TrustDeviceExpiration       *string `db:"trust_device_expiration"`
+	ConsentRequired             *bool   `db:"consent_required"`
 }
 
 // ClientCreateRequest represents the request body for client registration
@@ -63,6 +64,7 @@ type ClientCreateRequest struct {
 	SsoSessionIdleTimeout       *string  `json:"sso_session_idle_timeout,omitempty"`
 	TrustDeviceEnabled          *bool    `json:"trust_device_enabled,omitempty"`
 	TrustDeviceExpiration       *string  `json:"trust_device_expiration,omitempty"`
+	ConsentRequired             *bool    `json:"consent_required,omitempty"`
 }
 
 // ClientUpdateRequest represents the request body for updating a client
@@ -84,6 +86,7 @@ type ClientUpdateRequest struct {
 	SsoSessionIdleTimeout       *string  `json:"sso_session_idle_timeout,omitempty"`
 	TrustDeviceEnabled          *bool    `json:"trust_device_enabled,omitempty"`
 	TrustDeviceExpiration       *string  `json:"trust_device_expiration,omitempty"`
+	ConsentRequired             *bool    `json:"consent_required,omitempty"`
 }
 
 // ClientResponse represents the response for client operations
@@ -130,6 +133,7 @@ type ClientInfoResponse struct {
 	SsoSessionIdleTimeout       *string  `json:"sso_session_idle_timeout,omitempty"`
 	TrustDeviceEnabled          *bool    `json:"trust_device_enabled,omitempty"`
 	TrustDeviceExpiration       *string  `json:"trust_device_expiration,omitempty"`
+	ConsentRequired             *bool    `json:"consent_required,omitempty"`
 }
 
 // GetRedirectURIs parses and returns the redirect URIs as a slice
@@ -183,6 +187,7 @@ func (c *Client) ToInfoResponse() *ClientInfoResponse {
 		SsoSessionIdleTimeout:       c.SsoSessionIdleTimeout,
 		TrustDeviceEnabled:          c.TrustDeviceEnabled,
 		TrustDeviceExpiration:       c.TrustDeviceExpiration,
+		ConsentRequired:             c.ConsentRequired,
 	}
 	if c.AllowedAudiences != nil {
 		var aud []string

--- a/pkg/client/read.go
+++ b/pkg/client/read.go
@@ -31,7 +31,7 @@ var clientColumns = `id, client_id, client_secret, client_name, client_type, red
 	token_endpoint_auth_method, is_active, created_at, updated_at,
 	access_token_expiration, refresh_token_expiration, authorization_code_expiration,
 	allowed_audiences, allow_self_signup, sso_session_idle_timeout,
-	trust_device_enabled, trust_device_expiration`
+	trust_device_enabled, trust_device_expiration, consent_required`
 
 func scanClient(rows *sql.Rows) (*Client, error) {
 	var c Client
@@ -43,7 +43,7 @@ func scanClient(rows *sql.Rows) (*Client, error) {
 		&c.TokenEndpointAuthMethod, &c.IsActive, &c.CreatedAt, &c.UpdatedAt,
 		&c.AccessTokenExpiration, &c.RefreshTokenExpiration, &c.AuthorizationCodeExpiration,
 		&audiences, &c.AllowSelfSignup, &c.SsoSessionIdleTimeout,
-		&c.TrustDeviceEnabled, &c.TrustDeviceExpiration,
+		&c.TrustDeviceEnabled, &c.TrustDeviceExpiration, &c.ConsentRequired,
 	); err != nil {
 		return nil, err
 	}
@@ -91,12 +91,12 @@ func ListClientsWithParams(params api.ListParams) ([]*Client, int, error) {
 func ClientByClientID(clientID string) (*Client, error) {
 	query := `
 		SELECT 
-			id, client_id, client_secret, client_name, client_type, redirect_uris, 
-			post_logout_redirect_uris, grant_types, response_types, scopes, 
+			id, client_id, client_secret, client_name, client_type, redirect_uris,
+			post_logout_redirect_uris, grant_types, response_types, scopes,
 			token_endpoint_auth_method, is_active, created_at, updated_at,
 			access_token_expiration, refresh_token_expiration, authorization_code_expiration,
 			allowed_audiences, allow_self_signup, sso_session_idle_timeout,
-			trust_device_enabled, trust_device_expiration
+			trust_device_enabled, trust_device_expiration, consent_required
 		FROM clients WHERE client_id = ? AND is_active = 1
 	`
 	var c Client
@@ -108,7 +108,7 @@ func ClientByClientID(clientID string) (*Client, error) {
 		&c.TokenEndpointAuthMethod, &c.IsActive, &c.CreatedAt, &c.UpdatedAt,
 		&c.AccessTokenExpiration, &c.RefreshTokenExpiration, &c.AuthorizationCodeExpiration,
 		&audiences, &c.AllowSelfSignup, &c.SsoSessionIdleTimeout,
-		&c.TrustDeviceEnabled, &c.TrustDeviceExpiration,
+		&c.TrustDeviceEnabled, &c.TrustDeviceExpiration, &c.ConsentRequired,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -128,12 +128,12 @@ func ClientByClientID(clientID string) (*Client, error) {
 func ClientByID(id string) (*Client, error) {
 	query := `
 		SELECT 
-			id, client_id, client_secret, client_name, client_type, redirect_uris, 
-			post_logout_redirect_uris, grant_types, response_types, scopes, 
+			id, client_id, client_secret, client_name, client_type, redirect_uris,
+			post_logout_redirect_uris, grant_types, response_types, scopes,
 			token_endpoint_auth_method, is_active, created_at, updated_at,
 			access_token_expiration, refresh_token_expiration, authorization_code_expiration,
 			allowed_audiences, allow_self_signup, sso_session_idle_timeout,
-			trust_device_enabled, trust_device_expiration
+			trust_device_enabled, trust_device_expiration, consent_required
 		FROM clients WHERE id = ? AND is_active = 1
 	`
 	var c Client
@@ -145,7 +145,7 @@ func ClientByID(id string) (*Client, error) {
 		&c.TokenEndpointAuthMethod, &c.IsActive, &c.CreatedAt, &c.UpdatedAt,
 		&c.AccessTokenExpiration, &c.RefreshTokenExpiration, &c.AuthorizationCodeExpiration,
 		&audiences, &c.AllowSelfSignup, &c.SsoSessionIdleTimeout,
-		&c.TrustDeviceEnabled, &c.TrustDeviceExpiration,
+		&c.TrustDeviceEnabled, &c.TrustDeviceExpiration, &c.ConsentRequired,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/pkg/client/update.go
+++ b/pkg/client/update.go
@@ -67,6 +67,11 @@ func UpdateClient(clientID string, req ClientUpdateRequest) error {
 		audiences = c.AllowedAudiences
 	}
 
+	newConsentRequired := c.ConsentRequired
+	if req.ConsentRequired != nil {
+		newConsentRequired = req.ConsentRequired
+	}
+
 	query := `
 		UPDATE clients SET
 			client_name = ?,
@@ -85,6 +90,7 @@ func UpdateClient(clientID string, req ClientUpdateRequest) error {
 			sso_session_idle_timeout = ?,
 			trust_device_enabled = ?,
 			trust_device_expiration = ?,
+			consent_required = ?,
 			updated_at = CURRENT_TIMESTAMP
 		WHERE client_id = ?`
 	_, err = db.GetDB().Exec(query,
@@ -93,6 +99,7 @@ func UpdateClient(clientID string, req ClientUpdateRequest) error {
 		req.AccessTokenExpiration, req.RefreshTokenExpiration,
 		req.AuthorizationCodeExpiration, audiences, req.AllowSelfSignup,
 		req.SsoSessionIdleTimeout, req.TrustDeviceEnabled, req.TrustDeviceExpiration,
+		newConsentRequired,
 		clientID,
 	)
 	if err != nil {

--- a/pkg/consent/create.go
+++ b/pkg/consent/create.go
@@ -1,0 +1,28 @@
+package consent
+
+import (
+	"fmt"
+
+	authcode "github.com/eugenioenko/autentico/pkg/auth_code"
+	"github.com/eugenioenko/autentico/pkg/db"
+)
+
+func UpsertConsent(userID, clientID, scopes string) error {
+	id, err := authcode.GenerateSecureCode()
+	if err != nil {
+		return fmt.Errorf("failed to generate consent id: %w", err)
+	}
+
+	query := `
+		INSERT INTO user_consents (id, user_id, client_id, scopes, granted_at)
+		VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(user_id, client_id) DO UPDATE SET
+			scopes = excluded.scopes,
+			granted_at = CURRENT_TIMESTAMP
+	`
+	_, err = db.GetDB().Exec(query, id, userID, clientID, scopes)
+	if err != nil {
+		return fmt.Errorf("failed to upsert consent: %w", err)
+	}
+	return nil
+}

--- a/pkg/consent/create_test.go
+++ b/pkg/consent/create_test.go
@@ -1,0 +1,37 @@
+package consent
+
+import (
+	"testing"
+
+	testutils "github.com/eugenioenko/autentico/tests/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpsertConsent(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user-1")
+	testutils.InsertTestClient(t, "client-1", []string{"http://localhost/callback"})
+
+	err := UpsertConsent("user-1", "client-1", "openid profile")
+	require.NoError(t, err)
+
+	c, err := GetConsent("user-1", "client-1")
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	assert.Equal(t, "openid profile", c.Scopes)
+}
+
+func TestUpsertConsent_UpdatesExisting(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user-1")
+	testutils.InsertTestClient(t, "client-1", []string{"http://localhost/callback"})
+
+	require.NoError(t, UpsertConsent("user-1", "client-1", "openid"))
+	require.NoError(t, UpsertConsent("user-1", "client-1", "openid profile email"))
+
+	c, err := GetConsent("user-1", "client-1")
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	assert.Equal(t, "openid profile email", c.Scopes)
+}

--- a/pkg/consent/delete.go
+++ b/pkg/consent/delete.go
@@ -1,0 +1,31 @@
+package consent
+
+import (
+	"fmt"
+
+	"github.com/eugenioenko/autentico/pkg/db"
+)
+
+func DeleteConsent(id string) error {
+	_, err := db.GetDB().Exec(`DELETE FROM user_consents WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete consent: %w", err)
+	}
+	return nil
+}
+
+func DeleteConsentsByClient(clientID string) error {
+	_, err := db.GetDB().Exec(`DELETE FROM user_consents WHERE client_id = ?`, clientID)
+	if err != nil {
+		return fmt.Errorf("failed to delete consents by client: %w", err)
+	}
+	return nil
+}
+
+func DeleteConsentsByUser(userID string) error {
+	_, err := db.GetDB().Exec(`DELETE FROM user_consents WHERE user_id = ?`, userID)
+	if err != nil {
+		return fmt.Errorf("failed to delete consents by user: %w", err)
+	}
+	return nil
+}

--- a/pkg/consent/delete_test.go
+++ b/pkg/consent/delete_test.go
@@ -1,0 +1,43 @@
+package consent
+
+import (
+	"testing"
+
+	testutils "github.com/eugenioenko/autentico/tests/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteConsentsByClient(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user-1")
+	testutils.InsertTestUser(t, "user-2")
+	testutils.InsertTestClient(t, "client-1", []string{"http://localhost/callback"})
+
+	require.NoError(t, UpsertConsent("user-1", "client-1", "openid"))
+	require.NoError(t, UpsertConsent("user-2", "client-1", "openid profile"))
+
+	require.NoError(t, DeleteConsentsByClient("client-1"))
+
+	c1, _ := GetConsent("user-1", "client-1")
+	c2, _ := GetConsent("user-2", "client-1")
+	assert.Nil(t, c1)
+	assert.Nil(t, c2)
+}
+
+func TestDeleteConsentsByUser(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user-1")
+	testutils.InsertTestClient(t, "client-1", []string{"http://localhost/callback"})
+	testutils.InsertTestClient(t, "client-2", []string{"http://localhost/callback"})
+
+	require.NoError(t, UpsertConsent("user-1", "client-1", "openid"))
+	require.NoError(t, UpsertConsent("user-1", "client-2", "openid profile"))
+
+	require.NoError(t, DeleteConsentsByUser("user-1"))
+
+	c1, _ := GetConsent("user-1", "client-1")
+	c2, _ := GetConsent("user-1", "client-2")
+	assert.Nil(t, c1)
+	assert.Nil(t, c2)
+}

--- a/pkg/consent/handler.go
+++ b/pkg/consent/handler.go
@@ -1,0 +1,257 @@
+package consent
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	authcode "github.com/eugenioenko/autentico/pkg/auth_code"
+	"github.com/eugenioenko/autentico/pkg/client"
+	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/idpsession"
+	"github.com/eugenioenko/autentico/pkg/reqid"
+	"github.com/eugenioenko/autentico/pkg/utils"
+	"github.com/eugenioenko/autentico/view"
+	"github.com/gorilla/csrf"
+)
+
+type ConsentParams struct {
+	RedirectURI         string
+	State               string
+	ClientID            string
+	Scope               string
+	Nonce               string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	Prompt              string
+}
+
+func HandleConsent(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		handleConsentGet(w, r)
+	case http.MethodPost:
+		handleConsentPost(w, r)
+	default:
+		utils.WriteErrorResponse(w, http.StatusMethodNotAllowed, "invalid_request", "Method not allowed")
+	}
+}
+
+func handleConsentGet(w http.ResponseWriter, r *http.Request) {
+	params := parseConsentParams(r)
+
+	session, userID := validateSession(w, r)
+	if session == nil {
+		return
+	}
+
+	registeredClient, err := client.ClientByClientID(params.ClientID)
+	if err != nil {
+		slog.Warn("consent: unknown client_id", "request_id", reqid.Get(r.Context()), "client_id", params.ClientID)
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_client", "Unknown client_id")
+		return
+	}
+
+	renderConsentPage(w, r, params, registeredClient.ClientName, userID)
+}
+
+func handleConsentPost(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Invalid form data")
+		return
+	}
+
+	params := ConsentParams{
+		RedirectURI:         r.FormValue("redirect_uri"),
+		State:               r.FormValue("state"),
+		ClientID:            r.FormValue("client_id"),
+		Scope:               r.FormValue("scope"),
+		Nonce:               r.FormValue("nonce"),
+		CodeChallenge:       r.FormValue("code_challenge"),
+		CodeChallengeMethod: r.FormValue("code_challenge_method"),
+		Prompt:              r.FormValue("prompt"),
+	}
+
+	session, userID := validateSession(w, r)
+	if session == nil {
+		return
+	}
+
+	// Verify consent signature to prevent parameter tampering
+	consentSig := r.FormValue("consent_sig")
+	if !verifyConsentSignature(params, userID, consentSig) {
+		slog.Warn("consent: signature mismatch", "request_id", reqid.Get(r.Context()), "client_id", params.ClientID, "ip", utils.GetClientIP(r))
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Consent parameters have been tampered with")
+		return
+	}
+
+	registeredClient, err := client.ClientByClientID(params.ClientID)
+	if err != nil {
+		slog.Warn("consent: unknown client_id", "request_id", reqid.Get(r.Context()), "client_id", params.ClientID)
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_client", "Unknown client_id")
+		return
+	}
+
+	if !client.IsValidRedirectURI(registeredClient, params.RedirectURI) {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Redirect URI not allowed for this client")
+		return
+	}
+
+	action := r.FormValue("action")
+
+	// RFC 6749 §4.1.2.1: access_denied — the resource owner denied the request
+	if action == "deny" {
+		q := url.Values{}
+		q.Set("error", "access_denied")
+		q.Set("error_description", "The resource owner denied the request")
+		if params.State != "" {
+			q.Set("state", params.State)
+		}
+		http.Redirect(w, r, params.RedirectURI+"?"+q.Encode(), http.StatusFound)
+		return
+	}
+
+	// OIDC Core §3.1.2.4: store consent for this user+client+scopes
+	if err := UpsertConsent(userID, params.ClientID, params.Scope); err != nil {
+		slog.Error("consent: failed to store consent", "request_id", reqid.Get(r.Context()), "error", err)
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", "Failed to store consent")
+		return
+	}
+
+	// Generate authorization code and redirect
+	code, err := authcode.GenerateSecureCode()
+	if err != nil {
+		slog.Error("consent: failed to generate auth code", "request_id", reqid.Get(r.Context()), "error", err)
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", "Something went wrong")
+		return
+	}
+
+	cfg := config.Get()
+	ac := authcode.AuthCode{
+		Code:                code,
+		UserID:              userID,
+		ClientID:            params.ClientID,
+		RedirectURI:         params.RedirectURI,
+		Scope:               params.Scope,
+		Nonce:               params.Nonce,
+		CodeChallenge:       params.CodeChallenge,
+		CodeChallengeMethod: params.CodeChallengeMethod,
+		ExpiresAt:           time.Now().Add(cfg.AuthAuthorizationCodeExpiration),
+		Used:                false,
+		IdpSessionID:        session.ID,
+	}
+
+	if err := authcode.CreateAuthCode(ac); err != nil {
+		slog.Error("consent: failed to create auth code", "request_id", reqid.Get(r.Context()), "error", err)
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", "Something went wrong")
+		return
+	}
+
+	redirectParams := url.Values{}
+	redirectParams.Set("code", ac.Code)
+	if params.State != "" {
+		redirectParams.Set("state", params.State)
+	}
+	http.Redirect(w, r, params.RedirectURI+"?"+redirectParams.Encode(), http.StatusFound)
+}
+
+func renderConsentPage(w http.ResponseWriter, r *http.Request, params ConsentParams, clientName, userID string) {
+	cfg := config.Get()
+	tmpl, err := view.ParseTemplate("consent")
+	if err != nil {
+		slog.Error("consent: failed to parse template", "request_id", reqid.Get(r.Context()), "error", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	data := map[string]any{
+		"ClientName":          clientName,
+		"Scopes":              DescribeScopes(params.Scope),
+		"State":               params.State,
+		"RedirectURI":         params.RedirectURI,
+		"ClientID":            params.ClientID,
+		"Scope":               params.Scope,
+		"Nonce":               params.Nonce,
+		"CodeChallenge":       params.CodeChallenge,
+		"CodeChallengeMethod": params.CodeChallengeMethod,
+		"Prompt":              params.Prompt,
+		"ConsentSig":          signConsent(params, userID),
+		csrf.TemplateTag:      csrf.TemplateField(r),
+		"ThemeTitle":          cfg.Theme.Title,
+		"ThemeLogoUrl":        cfg.Theme.LogoUrl,
+	}
+
+	if err = tmpl.ExecuteTemplate(w, "layout", data); err != nil {
+		slog.Error("consent: failed to execute template", "request_id", reqid.Get(r.Context()), "error", err)
+		http.Error(w, "Template Execution Error", http.StatusInternalServerError)
+	}
+}
+
+// RedirectToConsent builds a redirect URL to the consent screen with all OAuth params preserved.
+func RedirectToConsent(w http.ResponseWriter, r *http.Request, params ConsentParams) {
+	q := url.Values{}
+	q.Set("client_id", params.ClientID)
+	q.Set("redirect_uri", params.RedirectURI)
+	q.Set("scope", params.Scope)
+	q.Set("state", params.State)
+	q.Set("nonce", params.Nonce)
+	q.Set("code_challenge", params.CodeChallenge)
+	q.Set("code_challenge_method", params.CodeChallengeMethod)
+	q.Set("prompt", params.Prompt)
+	consentURL := config.GetBootstrap().AppOAuthPath + "/consent?" + q.Encode()
+	http.Redirect(w, r, consentURL, http.StatusFound)
+}
+
+func parseConsentParams(r *http.Request) ConsentParams {
+	return ConsentParams{
+		RedirectURI:         r.URL.Query().Get("redirect_uri"),
+		State:               r.URL.Query().Get("state"),
+		ClientID:            r.URL.Query().Get("client_id"),
+		Scope:               r.URL.Query().Get("scope"),
+		Nonce:               r.URL.Query().Get("nonce"),
+		CodeChallenge:       r.URL.Query().Get("code_challenge"),
+		CodeChallengeMethod: r.URL.Query().Get("code_challenge_method"),
+		Prompt:              r.URL.Query().Get("prompt"),
+	}
+}
+
+func validateSession(w http.ResponseWriter, r *http.Request) (*idpsession.IdpSession, string) {
+	sessionID := idpsession.ReadCookie(r)
+	if sessionID == "" {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "login_required", "Authentication required")
+		return nil, ""
+	}
+	session, err := idpsession.IdpSessionByID(sessionID)
+	if err != nil || session.DeactivatedAt != nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "login_required", "Session expired")
+		return nil, ""
+	}
+	return session, session.UserID
+}
+
+func signConsent(params ConsentParams, userID string) string {
+	data := strings.Join([]string{
+		userID,
+		params.ClientID,
+		params.RedirectURI,
+		params.Scope,
+		params.Nonce,
+		params.CodeChallenge,
+		params.CodeChallengeMethod,
+		params.State,
+	}, "\n")
+	secret := []byte(config.GetBootstrap().AuthCSRFProtectionSecretKey)
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(data))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func verifyConsentSignature(params ConsentParams, userID, signature string) bool {
+	expected := signConsent(params, userID)
+	return hmac.Equal([]byte(expected), []byte(signature))
+}

--- a/pkg/consent/handler_test.go
+++ b/pkg/consent/handler_test.go
@@ -1,0 +1,355 @@
+package consent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/idpsession"
+	testutils "github.com/eugenioenko/autentico/tests/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupConsentClient(t *testing.T, clientID string) {
+	t.Helper()
+	testutils.InsertTestClient(t, clientID, []string{"http://localhost/callback"})
+}
+
+func createIdpSession(t *testing.T, userID string) string {
+	t.Helper()
+	testutils.InsertTestUser(t, userID)
+	sessionID := "session-" + userID
+	err := idpsession.CreateIdpSession(idpsession.IdpSession{
+		ID:        sessionID,
+		UserID:    userID,
+		UserAgent: "test-agent",
+		IPAddress: "127.0.0.1",
+	})
+	require.NoError(t, err)
+	return sessionID
+}
+
+const testCookieName = "autentico_idp_session"
+
+func TestHandleConsent_Get_NoSession_ReturnsUnauthorized(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AuthIdpSessionCookieName = testCookieName
+	})
+	setupConsentClient(t, "c1")
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/consent?client_id=c1&redirect_uri=http://localhost/callback&scope=openid", nil)
+	rr := httptest.NewRecorder()
+	HandleConsent(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Contains(t, rr.Body.String(), "login_required")
+}
+
+func TestHandleConsent_Get_InvalidClient_ReturnsBadRequest(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AuthIdpSessionCookieName = testCookieName
+	})
+	sessionID := createIdpSession(t, "user1")
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/consent?client_id=nonexistent&redirect_uri=http://localhost/callback&scope=openid", nil)
+	req.AddCookie(&http.Cookie{Name: testCookieName, Value: sessionID})
+	rr := httptest.NewRecorder()
+	HandleConsent(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "invalid_client")
+}
+
+func TestHandleConsent_Get_ValidRequest_RendersConsentPage(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AuthIdpSessionCookieName = testCookieName
+	})
+	setupConsentClient(t, "c1")
+	sessionID := createIdpSession(t, "user1")
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/consent?client_id=c1&redirect_uri=http://localhost/callback&scope=openid+profile&state=xyz", nil)
+	req.AddCookie(&http.Cookie{Name: testCookieName, Value: sessionID})
+	rr := httptest.NewRecorder()
+	HandleConsent(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	assert.Contains(t, body, "Authorize Access")
+	assert.Contains(t, body, "consent_sig")
+	assert.Contains(t, body, "Test Client")
+}
+
+func TestHandleConsent_Post_NoSession_ReturnsUnauthorized(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AuthIdpSessionCookieName = testCookieName
+	})
+
+	form := url.Values{}
+	form.Set("action", "allow")
+	form.Set("client_id", "c1")
+	form.Set("redirect_uri", "http://localhost/callback")
+	form.Set("consent_sig", "any")
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/consent", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	HandleConsent(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestHandleConsent_Post_TamperedSignature_ReturnsBadRequest(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AuthIdpSessionCookieName = testCookieName
+		config.Bootstrap.AuthCSRFProtectionSecretKey = "test-secret-key-for-consent-test!"
+	})
+	setupConsentClient(t, "c1")
+	sessionID := createIdpSession(t, "user1")
+
+	form := url.Values{}
+	form.Set("action", "allow")
+	form.Set("client_id", "c1")
+	form.Set("redirect_uri", "http://localhost/callback")
+	form.Set("scope", "openid")
+	form.Set("consent_sig", "bad-signature")
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/consent", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: testCookieName, Value: sessionID})
+	rr := httptest.NewRecorder()
+	HandleConsent(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "tampered")
+}
+
+func TestHandleConsent_Post_Deny_RedirectsWithAccessDenied(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AuthIdpSessionCookieName = testCookieName
+		config.Bootstrap.AuthCSRFProtectionSecretKey = "test-secret-key-for-consent-test!"
+	})
+	setupConsentClient(t, "c1")
+	sessionID := createIdpSession(t, "user1")
+
+	params := ConsentParams{
+		ClientID:    "c1",
+		RedirectURI: "http://localhost/callback",
+		Scope:       "openid",
+		State:       "xyz",
+	}
+	sig := signConsent(params, "user1")
+
+	form := url.Values{}
+	form.Set("action", "deny")
+	form.Set("client_id", "c1")
+	form.Set("redirect_uri", "http://localhost/callback")
+	form.Set("scope", "openid")
+	form.Set("state", "xyz")
+	form.Set("consent_sig", sig)
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/consent", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: testCookieName, Value: sessionID})
+	rr := httptest.NewRecorder()
+	HandleConsent(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+	loc, err := url.Parse(rr.Header().Get("Location"))
+	require.NoError(t, err)
+	assert.Equal(t, "access_denied", loc.Query().Get("error"))
+	assert.Equal(t, "xyz", loc.Query().Get("state"))
+	assert.Empty(t, loc.Query().Get("code"))
+}
+
+func TestHandleConsent_Post_Allow_StoresConsentAndRedirects(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AuthIdpSessionCookieName = testCookieName
+		config.Bootstrap.AuthCSRFProtectionSecretKey = "test-secret-key-for-consent-test!"
+	})
+	setupConsentClient(t, "c1")
+	sessionID := createIdpSession(t, "user1")
+
+	params := ConsentParams{
+		ClientID:            "c1",
+		RedirectURI:         "http://localhost/callback",
+		Scope:               "openid profile",
+		State:               "abc",
+		CodeChallenge:       "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+		CodeChallengeMethod: "S256",
+	}
+	sig := signConsent(params, "user1")
+
+	form := url.Values{}
+	form.Set("action", "allow")
+	form.Set("client_id", "c1")
+	form.Set("redirect_uri", "http://localhost/callback")
+	form.Set("scope", "openid profile")
+	form.Set("state", "abc")
+	form.Set("code_challenge", "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+	form.Set("code_challenge_method", "S256")
+	form.Set("consent_sig", sig)
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/consent", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: testCookieName, Value: sessionID})
+	rr := httptest.NewRecorder()
+	HandleConsent(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+	loc, err := url.Parse(rr.Header().Get("Location"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, loc.Query().Get("code"), "should issue auth code")
+	assert.Equal(t, "abc", loc.Query().Get("state"), "state should be preserved")
+
+	// Verify consent was stored
+	uc, err := GetConsent("user1", "c1")
+	require.NoError(t, err)
+	require.NotNil(t, uc)
+	assert.Equal(t, "openid profile", uc.Scopes)
+}
+
+func TestHandleConsent_Post_InvalidClient_ReturnsBadRequest(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AuthIdpSessionCookieName = testCookieName
+		config.Bootstrap.AuthCSRFProtectionSecretKey = "test-secret-key-for-consent-test!"
+	})
+	sessionID := createIdpSession(t, "user1")
+
+	params := ConsentParams{
+		ClientID:    "nonexistent",
+		RedirectURI: "http://localhost/callback",
+		Scope:       "openid",
+	}
+	sig := signConsent(params, "user1")
+
+	form := url.Values{}
+	form.Set("action", "allow")
+	form.Set("client_id", "nonexistent")
+	form.Set("redirect_uri", "http://localhost/callback")
+	form.Set("scope", "openid")
+	form.Set("consent_sig", sig)
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/consent", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: testCookieName, Value: sessionID})
+	rr := httptest.NewRecorder()
+	HandleConsent(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "invalid_client")
+}
+
+func TestHandleConsent_Post_InvalidRedirectURI_ReturnsBadRequest(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AuthIdpSessionCookieName = testCookieName
+		config.Bootstrap.AuthCSRFProtectionSecretKey = "test-secret-key-for-consent-test!"
+	})
+	setupConsentClient(t, "c1")
+	sessionID := createIdpSession(t, "user1")
+
+	params := ConsentParams{
+		ClientID:    "c1",
+		RedirectURI: "http://evil.com/callback",
+		Scope:       "openid",
+	}
+	sig := signConsent(params, "user1")
+
+	form := url.Values{}
+	form.Set("action", "allow")
+	form.Set("client_id", "c1")
+	form.Set("redirect_uri", "http://evil.com/callback")
+	form.Set("scope", "openid")
+	form.Set("consent_sig", sig)
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/consent", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: testCookieName, Value: sessionID})
+	rr := httptest.NewRecorder()
+	HandleConsent(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Redirect URI not allowed")
+}
+
+func TestHandleConsent_MethodNotAllowed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodDelete, "/oauth2/consent", nil)
+	rr := httptest.NewRecorder()
+	HandleConsent(rr, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+func TestSignConsent_DifferentParams_DifferentSignatures(t *testing.T) {
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AuthIdpSessionCookieName = testCookieName
+		config.Bootstrap.AuthCSRFProtectionSecretKey = "test-secret-key-for-consent-test!"
+	})
+
+	p1 := ConsentParams{ClientID: "c1", RedirectURI: "http://localhost/cb", Scope: "openid"}
+	p2 := ConsentParams{ClientID: "c2", RedirectURI: "http://localhost/cb", Scope: "openid"}
+
+	sig1 := signConsent(p1, "user1")
+	sig2 := signConsent(p2, "user1")
+	assert.NotEqual(t, sig1, sig2)
+
+	sig3 := signConsent(p1, "user2")
+	assert.NotEqual(t, sig1, sig3)
+}
+
+func TestVerifyConsentSignature_ValidSignature(t *testing.T) {
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AuthIdpSessionCookieName = testCookieName
+		config.Bootstrap.AuthCSRFProtectionSecretKey = "test-secret-key-for-consent-test!"
+	})
+
+	params := ConsentParams{ClientID: "c1", RedirectURI: "http://localhost/cb", Scope: "openid", State: "s1"}
+	sig := signConsent(params, "user1")
+
+	assert.True(t, verifyConsentSignature(params, "user1", sig))
+	assert.False(t, verifyConsentSignature(params, "user1", "tampered"))
+	assert.False(t, verifyConsentSignature(params, "user2", sig))
+}
+
+func TestRedirectToConsent_BuildsCorrectURL(t *testing.T) {
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AppOAuthPath = "/oauth2"
+	})
+
+	params := ConsentParams{
+		ClientID:            "c1",
+		RedirectURI:         "http://localhost/cb",
+		Scope:               "openid profile",
+		State:               "xyz",
+		Nonce:               "n1",
+		CodeChallenge:       "challenge",
+		CodeChallengeMethod: "S256",
+		Prompt:              "consent",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	RedirectToConsent(rr, req, params)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+	loc := rr.Header().Get("Location")
+	assert.Contains(t, loc, "/oauth2/consent?")
+	parsed, _ := url.Parse(loc)
+	assert.Equal(t, "c1", parsed.Query().Get("client_id"))
+	assert.Equal(t, "openid profile", parsed.Query().Get("scope"))
+	assert.Equal(t, "xyz", parsed.Query().Get("state"))
+	assert.Equal(t, "n1", parsed.Query().Get("nonce"))
+	assert.Equal(t, "consent", parsed.Query().Get("prompt"))
+}

--- a/pkg/consent/model.go
+++ b/pkg/consent/model.go
@@ -1,0 +1,80 @@
+package consent
+
+import (
+	"strings"
+	"time"
+)
+
+type UserConsent struct {
+	ID        string    `db:"id"`
+	UserID    string    `db:"user_id"`
+	ClientID  string    `db:"client_id"`
+	Scopes    string    `db:"scopes"`
+	GrantedAt time.Time `db:"granted_at"`
+}
+
+type ScopeInfo struct {
+	Name        string
+	Description string
+}
+
+var scopeDescriptions = map[string]string{
+	"openid":         "Verify your identity",
+	"profile":        "View your profile information",
+	"email":          "View your email address",
+	"address":        "View your address",
+	"phone":          "View your phone number",
+	"offline_access": "Maintain access when you're not using the app",
+}
+
+func DescribeScopes(scopeStr string) []ScopeInfo {
+	scopes := strings.Fields(scopeStr)
+	result := make([]ScopeInfo, 0, len(scopes))
+	for _, s := range scopes {
+		desc, ok := scopeDescriptions[s]
+		if !ok {
+			desc = s
+		}
+		result = append(result, ScopeInfo{Name: s, Description: desc})
+	}
+	return result
+}
+
+// NeedsConsent returns true if the user must be shown a consent screen.
+// OIDC Core §3.1.2.4: AS MUST obtain consent before releasing info; MAY skip if previously obtained.
+func NeedsConsent(consentRequired *bool, userID, clientID, requestedScopes, prompt string) bool {
+	if consentRequired == nil || !*consentRequired {
+		return false
+	}
+	// OIDC Core §3.1.2.1: prompt=consent MUST re-prompt even if consent was previously granted
+	if containsPromptValue(prompt, "consent") {
+		return true
+	}
+	existing, err := GetConsent(userID, clientID)
+	if err != nil || existing == nil {
+		return true
+	}
+	return !scopesCovered(existing.Scopes, requestedScopes)
+}
+
+func containsPromptValue(prompt, value string) bool {
+	for _, v := range strings.Fields(prompt) {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}
+
+func scopesCovered(grantedScopes, requestedScopes string) bool {
+	granted := make(map[string]bool)
+	for _, s := range strings.Fields(grantedScopes) {
+		granted[s] = true
+	}
+	for _, s := range strings.Fields(requestedScopes) {
+		if !granted[s] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/consent/model.go
+++ b/pkg/consent/model.go
@@ -24,7 +24,7 @@ var scopeDescriptions = map[string]string{
 	"email":          "View your email address",
 	"address":        "View your address",
 	"phone":          "View your phone number",
-	"offline_access": "Maintain access when you're not using the app",
+	"offline_access": "Stay signed in between sessions",
 }
 
 func DescribeScopes(scopeStr string) []ScopeInfo {

--- a/pkg/consent/model_test.go
+++ b/pkg/consent/model_test.go
@@ -1,0 +1,79 @@
+package consent
+
+import "testing"
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestNeedsConsent_NotRequired(t *testing.T) {
+	if NeedsConsent(nil, "u1", "c1", "openid", "") {
+		t.Error("expected false when consentRequired is nil")
+	}
+	if NeedsConsent(boolPtr(false), "u1", "c1", "openid", "") {
+		t.Error("expected false when consentRequired is false")
+	}
+}
+
+func TestNeedsConsent_PromptConsent(t *testing.T) {
+	if !NeedsConsent(boolPtr(true), "u1", "c1", "openid", "consent") {
+		t.Error("expected true when prompt=consent")
+	}
+	if !NeedsConsent(boolPtr(true), "u1", "c1", "openid", "login consent") {
+		t.Error("expected true when prompt contains consent")
+	}
+}
+
+func TestScopesCovered(t *testing.T) {
+	tests := []struct {
+		granted   string
+		requested string
+		covered   bool
+	}{
+		{"openid profile email", "openid profile", true},
+		{"openid profile email", "openid profile email", true},
+		{"openid profile", "openid profile email", false},
+		{"openid", "profile", false},
+		{"openid profile email", "openid", true},
+		{"", "openid", false},
+		{"openid", "", true},
+	}
+	for _, tt := range tests {
+		if got := scopesCovered(tt.granted, tt.requested); got != tt.covered {
+			t.Errorf("scopesCovered(%q, %q) = %v, want %v", tt.granted, tt.requested, got, tt.covered)
+		}
+	}
+}
+
+func TestDescribeScopes(t *testing.T) {
+	scopes := DescribeScopes("openid email custom_scope")
+	if len(scopes) != 3 {
+		t.Fatalf("expected 3 scopes, got %d", len(scopes))
+	}
+	if scopes[0].Name != "openid" || scopes[0].Description != "Verify your identity" {
+		t.Errorf("unexpected scope[0]: %+v", scopes[0])
+	}
+	if scopes[1].Name != "email" || scopes[1].Description != "View your email address" {
+		t.Errorf("unexpected scope[1]: %+v", scopes[1])
+	}
+	if scopes[2].Name != "custom_scope" || scopes[2].Description != "custom_scope" {
+		t.Errorf("unknown scopes should use name as description: %+v", scopes[2])
+	}
+}
+
+func TestContainsPromptValue(t *testing.T) {
+	tests := []struct {
+		prompt string
+		value  string
+		want   bool
+	}{
+		{"consent", "consent", true},
+		{"login consent", "consent", true},
+		{"login", "consent", false},
+		{"", "consent", false},
+		{"consent login", "login", true},
+	}
+	for _, tt := range tests {
+		if got := containsPromptValue(tt.prompt, tt.value); got != tt.want {
+			t.Errorf("containsPromptValue(%q, %q) = %v, want %v", tt.prompt, tt.value, got, tt.want)
+		}
+	}
+}

--- a/pkg/consent/read.go
+++ b/pkg/consent/read.go
@@ -1,0 +1,21 @@
+package consent
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/eugenioenko/autentico/pkg/db"
+)
+
+func GetConsent(userID, clientID string) (*UserConsent, error) {
+	query := `SELECT id, user_id, client_id, scopes, granted_at FROM user_consents WHERE user_id = ? AND client_id = ?`
+	var c UserConsent
+	err := db.GetDB().QueryRow(query, userID, clientID).Scan(&c.ID, &c.UserID, &c.ClientID, &c.Scopes, &c.GrantedAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get consent: %w", err)
+	}
+	return &c, nil
+}

--- a/pkg/consent/read_test.go
+++ b/pkg/consent/read_test.go
@@ -1,0 +1,32 @@
+package consent
+
+import (
+	"testing"
+
+	testutils "github.com/eugenioenko/autentico/tests/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetConsent_NotFound(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	c, err := GetConsent("nonexistent", "nonexistent")
+	require.NoError(t, err)
+	assert.Nil(t, c)
+}
+
+func TestGetConsent_Found(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user-1")
+	testutils.InsertTestClient(t, "client-1", []string{"http://localhost/callback"})
+
+	require.NoError(t, UpsertConsent("user-1", "client-1", "openid"))
+
+	c, err := GetConsent("user-1", "client-1")
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	assert.Equal(t, "user-1", c.UserID)
+	assert.Equal(t, "client-1", c.ClientID)
+	assert.Equal(t, "openid", c.Scopes)
+}

--- a/pkg/db/migrations/007_user_consents.go
+++ b/pkg/db/migrations/007_user_consents.go
@@ -1,0 +1,16 @@
+package migrations
+
+const migration007 = `
+ALTER TABLE clients ADD COLUMN consent_required INTEGER DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS user_consents (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    client_id TEXT NOT NULL,
+    scopes TEXT NOT NULL,
+    granted_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, client_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_consents_user_client ON user_consents(user_id, client_id);
+`

--- a/pkg/db/migrations/migrations.go
+++ b/pkg/db/migrations/migrations.go
@@ -7,7 +7,7 @@ import (
 
 // SchemaVersion is the schema version this binary expects.
 // Increment this and add a new Migration entry each time the schema changes.
-var SchemaVersion = 6
+var SchemaVersion = 7
 
 // Migration represents a single schema change.
 type Migration struct {
@@ -23,6 +23,7 @@ var migrations = []Migration{
 	{Version: 4, SQL: migration004},
 	{Version: 5, SQL: migration005},
 	{Version: 6, SQL: migration006},
+	{Version: 7, SQL: migration007},
 }
 
 func getUserVersion(db *sql.DB) (int, error) {

--- a/pkg/login/handler.go
+++ b/pkg/login/handler.go
@@ -13,6 +13,7 @@ import (
 	authcode "github.com/eugenioenko/autentico/pkg/auth_code"
 	"github.com/eugenioenko/autentico/pkg/authzsig"
 	"github.com/eugenioenko/autentico/pkg/client"
+	"github.com/eugenioenko/autentico/pkg/consent"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/emailverification"
 	"github.com/eugenioenko/autentico/pkg/idpsession"
@@ -61,6 +62,7 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 		Nonce:               r.FormValue("nonce"),
 		CodeChallenge:       r.FormValue("code_challenge"),
 		CodeChallengeMethod: r.FormValue("code_challenge_method"),
+		Prompt:              r.FormValue("prompt"),
 	}
 
 	if config.Get().AuthMode == "passkey_only" {
@@ -186,6 +188,7 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 			Nonce:               request.Nonce,
 			CodeChallenge:       request.CodeChallenge,
 			CodeChallengeMethod: request.CodeChallengeMethod,
+			Prompt:              request.Prompt,
 		}
 		stateJSON, err := json.Marshal(loginState)
 		if err != nil {
@@ -221,6 +224,21 @@ func HandleLoginUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	idpSessionID := idpsession.FinalizeLogin(w, r, usr.ID)
+
+	// OIDC Core §3.1.2.4: check if consent is needed before issuing auth code
+	if consent.NeedsConsent(registeredClient.ConsentRequired, usr.ID, request.ClientID, request.Scope, request.Prompt) {
+		consent.RedirectToConsent(w, r, consent.ConsentParams{
+			RedirectURI:         request.RedirectURI,
+			State:               request.State,
+			ClientID:            request.ClientID,
+			Scope:               request.Scope,
+			Nonce:               request.Nonce,
+			CodeChallenge:       request.CodeChallenge,
+			CodeChallengeMethod: request.CodeChallengeMethod,
+			Prompt:              request.Prompt,
+		})
+		return
+	}
 
 	authCode, err := authcode.GenerateSecureCode()
 	if err != nil {

--- a/pkg/login/model.go
+++ b/pkg/login/model.go
@@ -19,6 +19,7 @@ type LoginRequest struct {
 	Nonce               string `json:"nonce"`
 	CodeChallenge       string `json:"code_challenge"`
 	CodeChallengeMethod string `json:"code_challenge_method"`
+	Prompt              string `json:"prompt"`
 }
 
 func ValidateLoginRequest(input LoginRequest) error {

--- a/pkg/mfa/handler.go
+++ b/pkg/mfa/handler.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/eugenioenko/autentico/pkg/audit"
 	authcode "github.com/eugenioenko/autentico/pkg/auth_code"
+	"github.com/eugenioenko/autentico/pkg/client"
 	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/consent"
 	"github.com/eugenioenko/autentico/pkg/email"
 	"github.com/eugenioenko/autentico/pkg/idpsession"
 	"github.com/eugenioenko/autentico/pkg/reqid"
@@ -245,6 +247,22 @@ func handleMfaPost(w http.ResponseWriter, r *http.Request) {
 
 	idpSessionID := idpsession.FinalizeLogin(w, r, usr.ID)
 
+	// OIDC Core §3.1.2.4: check if consent is needed before issuing auth code
+	registeredClient, clientErr := client.ClientByClientID(loginState.ClientID)
+	if clientErr == nil && consent.NeedsConsent(registeredClient.ConsentRequired, usr.ID, loginState.ClientID, loginState.Scope, loginState.Prompt) {
+		consent.RedirectToConsent(w, r, consent.ConsentParams{
+			RedirectURI:         loginState.RedirectURI,
+			State:               loginState.State,
+			ClientID:            loginState.ClientID,
+			Scope:               loginState.Scope,
+			Nonce:               loginState.Nonce,
+			CodeChallenge:       loginState.CodeChallenge,
+			CodeChallengeMethod: loginState.CodeChallengeMethod,
+			Prompt:              loginState.Prompt,
+		})
+		return
+	}
+
 	authorizationCode, err := authcode.GenerateSecureCode()
 	if err != nil {
 		slog.Error("mfa: failed to generate authorization code", "request_id", reqid.Get(r.Context()), "error", err)
@@ -306,15 +324,15 @@ func handleMethodSwitch(w http.ResponseWriter, r *http.Request, challenge *MfaCh
 		return false
 	}
 
+	if err := MarkChallengeUsed(challenge.ID); err != nil {
+		slog.Error("mfa: failed to mark old challenge as used during switch", "request_id", reqid.Get(r.Context()), "error", err)
+		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
+		return true
+	}
 	newChallengeID, err := authcode.GenerateSecureCode()
 	if err != nil {
 		slog.Error("mfa: failed to generate challenge ID for switch", "request_id", reqid.Get(r.Context()), "error", err)
 		renderVerifyPage(w, r, challenge, cfg, "Something went wrong. Please try again.", "")
-		return true
-	}
-	if err := MarkChallengeUsed(challenge.ID); err != nil {
-		slog.Error("mfa: failed to mark old challenge as used during switch", "request_id", reqid.Get(r.Context()), "error", err)
-		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
 		return true
 	}
 	newChallenge := MfaChallenge{

--- a/pkg/mfa/handler.go
+++ b/pkg/mfa/handler.go
@@ -334,6 +334,7 @@ func handleMethodSwitch(w http.ResponseWriter, r *http.Request, challenge *MfaCh
 	return true
 }
 
+
 func renderVerifyPage(w http.ResponseWriter, r *http.Request, challenge *MfaChallenge, cfg *config.Config, errorMsg string, infoMsg string) {
 	tmpl, err := view.ParseTemplate("mfa")
 	if err != nil {

--- a/pkg/mfa/handler.go
+++ b/pkg/mfa/handler.go
@@ -335,6 +335,7 @@ func handleMethodSwitch(w http.ResponseWriter, r *http.Request, challenge *MfaCh
 }
 
 
+
 func renderVerifyPage(w http.ResponseWriter, r *http.Request, challenge *MfaChallenge, cfg *config.Config, errorMsg string, infoMsg string) {
 	tmpl, err := view.ParseTemplate("mfa")
 	if err != nil {

--- a/pkg/mfa/model.go
+++ b/pkg/mfa/model.go
@@ -23,4 +23,5 @@ type LoginState struct {
 	Nonce               string `json:"nonce"`
 	CodeChallenge       string `json:"code_challenge"`
 	CodeChallengeMethod string `json:"code_challenge_method"`
+	Prompt              string `json:"prompt"`
 }

--- a/tests/e2e/consent_test.go
+++ b/tests/e2e/consent_test.go
@@ -1,0 +1,286 @@
+package e2e
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/autentico/pkg/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// postConsentForm reads hidden fields from the consent page HTML and POSTs them back.
+func postConsentForm(t *testing.T, ts *TestServer, htmlBody, action string) *http.Response {
+	t.Helper()
+	csrfToken := getCSRFToken(htmlBody)
+	require.NotEmpty(t, csrfToken)
+	consentSig := getConsentSig(htmlBody)
+	require.NotEmpty(t, consentSig)
+
+	form := url.Values{}
+	form.Set("action", action)
+	form.Set("redirect_uri", getHiddenField(htmlBody, "redirect_uri"))
+	form.Set("state", getHiddenField(htmlBody, "state"))
+	form.Set("client_id", getHiddenField(htmlBody, "client_id"))
+	form.Set("scope", getHiddenField(htmlBody, "scope"))
+	form.Set("nonce", getHiddenField(htmlBody, "nonce"))
+	form.Set("code_challenge", getHiddenField(htmlBody, "code_challenge"))
+	form.Set("code_challenge_method", getHiddenField(htmlBody, "code_challenge_method"))
+	form.Set("prompt", getHiddenField(htmlBody, "prompt"))
+	form.Set("consent_sig", consentSig)
+	form.Set("gorilla.csrf.Token", csrfToken)
+
+	req, err := http.NewRequest("POST", ts.BaseURL+"/oauth2/consent", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Referer", ts.BaseURL+"/oauth2/consent")
+
+	resp, err := ts.Client.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// followToConsentPage follows the consent redirect and returns the consent HTML body.
+func followToConsentPage(t *testing.T, ts *TestServer, location string) string {
+	t.Helper()
+	consentResp, err := ts.Client.Get(ts.BaseURL + location)
+	require.NoError(t, err)
+	consentBody, err := io.ReadAll(consentResp.Body)
+	_ = consentResp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, consentResp.StatusCode)
+	return string(consentBody)
+}
+
+func seedConsentClient(t *testing.T) {
+	t.Helper()
+	_, err := db.GetDB().Exec(`
+		INSERT INTO clients (id, client_id, client_name, client_type, redirect_uris, post_logout_redirect_uris,
+			grant_types, response_types, scopes, is_active, consent_required)
+		VALUES ('consent-client-id', 'consent-client', 'Consent Test Client', 'public',
+			'["http://localhost:3000/callback"]', '[]',
+			'["authorization_code","password","refresh_token"]', '["code"]',
+			'openid profile email', TRUE, 1)
+	`)
+	require.NoError(t, err)
+}
+
+// performAuthFlowUntilConsent drives authorize → login and returns the consent page redirect location.
+func performAuthFlowUntilConsent(t *testing.T, ts *TestServer, clientID, redirectURI, username, password, state string) string {
+	t.Helper()
+
+	authorizeURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"state":                 {state},
+		"scope":                 {"openid profile email"},
+		"code_challenge":        {testCodeChallenge},
+		"code_challenge_method": {"S256"},
+	}.Encode()
+
+	resp, err := ts.Client.Get(authorizeURL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	htmlBody := string(body)
+	csrfToken := getCSRFToken(htmlBody)
+	require.NotEmpty(t, csrfToken)
+	authorizeSig := getAuthorizeSig(htmlBody)
+
+	form := url.Values{}
+	form.Set("username", username)
+	form.Set("password", password)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("state", state)
+	form.Set("client_id", clientID)
+	form.Set("scope", getHiddenField(htmlBody, "scope"))
+	form.Set("code_challenge", testCodeChallenge)
+	form.Set("code_challenge_method", "S256")
+	form.Set("gorilla.csrf.Token", csrfToken)
+	form.Set("authorize_sig", authorizeSig)
+
+	loginReq, err := http.NewRequest("POST", ts.BaseURL+"/oauth2/login", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	loginReq.Header.Set("Referer", ts.BaseURL+"/oauth2/authorize")
+
+	loginResp, err := ts.Client.Do(loginReq)
+	require.NoError(t, err)
+	defer func() { _ = loginResp.Body.Close() }()
+
+	require.Equal(t, http.StatusFound, loginResp.StatusCode)
+	return loginResp.Header.Get("Location")
+}
+
+func TestConsentFlow_ConsentRequired_ShowsConsentScreen(t *testing.T) {
+	ts := startTestServer(t)
+	seedConsentClient(t)
+	createTestUser(t, "consent-user", "password123", "consent@test.com")
+
+	location := performAuthFlowUntilConsent(t, ts, "consent-client", "http://localhost:3000/callback", "consent-user", "password123", "s1")
+
+	assert.Contains(t, location, "/consent", "login should redirect to consent screen")
+	assert.NotContains(t, location, "code=", "should not issue auth code before consent")
+}
+
+func TestConsentFlow_ConsentNotRequired_SkipsConsent(t *testing.T) {
+	ts := startTestServer(t)
+	createTestUser(t, "noconsent-user", "password123", "noconsent@test.com")
+
+	// test-client does not have consent_required set
+	code := performAuthorizationCodeFlow(t, ts, "test-client", "http://localhost:3000/callback", "noconsent-user", "password123", "s1")
+	assert.NotEmpty(t, code, "should issue auth code without consent")
+}
+
+func TestConsentFlow_Allow_IssuesAuthCode(t *testing.T) {
+	ts := startTestServer(t)
+	seedConsentClient(t)
+	createTestUser(t, "allow-user", "password123", "allow@test.com")
+
+	location := performAuthFlowUntilConsent(t, ts, "consent-client", "http://localhost:3000/callback", "allow-user", "password123", "s1")
+	require.Contains(t, location, "/consent")
+
+	htmlBody := followToConsentPage(t, ts, location)
+	assert.Contains(t, htmlBody, "Consent Test Client", "consent page should show client name")
+	assert.Contains(t, htmlBody, "Authorize Access", "consent page should show authorization title")
+
+	allowResp := postConsentForm(t, ts, htmlBody, "allow")
+	defer func() { _ = allowResp.Body.Close() }()
+
+	require.Equal(t, http.StatusFound, allowResp.StatusCode)
+	redirectURL, err := url.Parse(allowResp.Header.Get("Location"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, redirectURL.Query().Get("code"), "consent allow should issue auth code")
+	assert.Equal(t, "s1", redirectURL.Query().Get("state"), "state should be preserved")
+}
+
+func TestConsentFlow_Deny_ReturnsAccessDenied(t *testing.T) {
+	ts := startTestServer(t)
+	seedConsentClient(t)
+	createTestUser(t, "deny-user", "password123", "deny@test.com")
+
+	location := performAuthFlowUntilConsent(t, ts, "consent-client", "http://localhost:3000/callback", "deny-user", "password123", "s1")
+	require.Contains(t, location, "/consent")
+
+	htmlBody := followToConsentPage(t, ts, location)
+
+	denyResp := postConsentForm(t, ts, htmlBody, "deny")
+	defer func() { _ = denyResp.Body.Close() }()
+
+	require.Equal(t, http.StatusFound, denyResp.StatusCode)
+	redirectURL, err := url.Parse(denyResp.Header.Get("Location"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "access_denied", redirectURL.Query().Get("error"), "deny should return access_denied error")
+	assert.Empty(t, redirectURL.Query().Get("code"), "deny should not issue auth code")
+	assert.Equal(t, "s1", redirectURL.Query().Get("state"), "state should be preserved")
+}
+
+func TestConsentFlow_PreviousConsent_SkipsScreen(t *testing.T) {
+	ts := startTestServer(t)
+	seedConsentClient(t)
+	createTestUser(t, "repeat-user", "password123", "repeat@test.com")
+
+	// First flow: consent required, redirect to consent screen
+	location := performAuthFlowUntilConsent(t, ts, "consent-client", "http://localhost:3000/callback", "repeat-user", "password123", "s1")
+	require.Contains(t, location, "/consent")
+
+	// Follow and allow consent
+	htmlBody := followToConsentPage(t, ts, location)
+
+	allowResp := postConsentForm(t, ts, htmlBody, "allow")
+	_ = allowResp.Body.Close()
+	require.Equal(t, http.StatusFound, allowResp.StatusCode)
+
+	// Second flow with same scopes: SSO session active + consent already granted → direct code
+	authorizeURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"consent-client"},
+		"redirect_uri":          {"http://localhost:3000/callback"},
+		"state":                 {"s2"},
+		"scope":                 {"openid profile email"},
+		"code_challenge":        {testCodeChallenge},
+		"code_challenge_method": {"S256"},
+	}.Encode()
+	resp, err := ts.Client.Get(authorizeURL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+	redirectURL, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+	code := redirectURL.Query().Get("code")
+	assert.NotEmpty(t, code, "second flow with same scopes should skip consent and issue code directly")
+	assert.NotContains(t, resp.Header.Get("Location"), "/consent", "should not redirect to consent")
+}
+
+func TestConsentFlow_PromptNone_ConsentRequired_ReturnsError(t *testing.T) {
+	ts := startTestServer(t)
+	seedConsentClient(t)
+	createTestUser(t, "promptnone-user", "password123", "promptnone@test.com")
+
+	// OIDC Core §3.1.2.1: prompt=none with consent needed should return consent_required
+	authorizeURL := ts.BaseURL + "/oauth2/authorize?" + url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"consent-client"},
+		"redirect_uri":          {"http://localhost:3000/callback"},
+		"state":                 {"s1"},
+		"prompt":                {"none"},
+		"code_challenge":        {testCodeChallenge},
+		"code_challenge_method": {"S256"},
+	}.Encode()
+
+	resp, err := ts.Client.Get(authorizeURL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	// prompt=none should redirect with error (no session = login_required)
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+	location := resp.Header.Get("Location")
+	redirectURL, _ := url.Parse(location)
+	errParam := redirectURL.Query().Get("error")
+	assert.Contains(t, []string{"login_required", "consent_required"}, errParam)
+}
+
+func TestConsentFlow_ConsentSignatureTampering_Rejected(t *testing.T) {
+	ts := startTestServer(t)
+	seedConsentClient(t)
+	createTestUser(t, "tamper-user", "password123", "tamper@test.com")
+
+	location := performAuthFlowUntilConsent(t, ts, "consent-client", "http://localhost:3000/callback", "tamper-user", "password123", "s1")
+	require.Contains(t, location, "/consent")
+
+	htmlBody := followToConsentPage(t, ts, location)
+	csrfToken := getCSRFToken(htmlBody)
+
+	// POST with tampered consent_sig — all other fields from page
+	form := url.Values{}
+	form.Set("action", "allow")
+	form.Set("redirect_uri", getHiddenField(htmlBody, "redirect_uri"))
+	form.Set("state", getHiddenField(htmlBody, "state"))
+	form.Set("client_id", getHiddenField(htmlBody, "client_id"))
+	form.Set("scope", getHiddenField(htmlBody, "scope"))
+	form.Set("nonce", getHiddenField(htmlBody, "nonce"))
+	form.Set("code_challenge", getHiddenField(htmlBody, "code_challenge"))
+	form.Set("code_challenge_method", getHiddenField(htmlBody, "code_challenge_method"))
+	form.Set("consent_sig", "tampered-signature-value")
+	form.Set("gorilla.csrf.Token", csrfToken)
+
+	allowReq, _ := http.NewRequest("POST", ts.BaseURL+"/oauth2/consent", strings.NewReader(form.Encode()))
+	allowReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	allowReq.Header.Set("Referer", ts.BaseURL+"/oauth2/consent")
+
+	allowResp, err := ts.Client.Do(allowReq)
+	require.NoError(t, err)
+	defer func() { _ = allowResp.Body.Close() }()
+
+	assert.Equal(t, http.StatusBadRequest, allowResp.StatusCode, "tampered signature should be rejected")
+}

--- a/tests/e2e/test_server_test.go
+++ b/tests/e2e/test_server_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/authorize"
 	"github.com/eugenioenko/autentico/pkg/client"
 	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/consent"
 	"github.com/eugenioenko/autentico/pkg/group"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/introspect"
@@ -140,6 +141,7 @@ func startTestServer(t *testing.T) *TestServer {
 	// CSRF-protected routes (using plaintext wrapper for HTTP test server)
 	mux.Handle(oauth+"/authorize", plaintextCSRF(http.HandlerFunc(authorize.HandleAuthorize)))
 	mux.Handle(oauth+"/login", plaintextCSRF(http.HandlerFunc(login.HandleLoginUser)))
+	mux.Handle(oauth+"/consent", plaintextCSRF(http.HandlerFunc(consent.HandleConsent)))
 	mux.Handle(oauth+"/signup", plaintextCSRF(http.HandlerFunc(signup.HandleSignup)))
 
 	// OAuth2 client registration (admin-protected)
@@ -250,6 +252,21 @@ func getCSRFToken(body string) string {
 // getAuthorizeSig extracts the authorize_sig hidden field value from the rendered HTML body.
 func getAuthorizeSig(body string) string {
 	re := regexp.MustCompile(`<input type="hidden" name="authorize_sig" value="([^"]*)"`)
+	matches := re.FindStringSubmatch(body)
+	if len(matches) < 2 {
+		return ""
+	}
+	return matches[1]
+}
+
+// getConsentSig extracts the consent_sig hidden field value from the rendered consent HTML body.
+func getConsentSig(body string) string {
+	return getHiddenField(body, "consent_sig")
+}
+
+// getHiddenField extracts the value of a hidden input field by name from rendered HTML.
+func getHiddenField(body, name string) string {
+	re := regexp.MustCompile(`<input type="hidden" name="` + regexp.QuoteMeta(name) + `" value="([^"]*)"`)
 	matches := re.FindStringSubmatch(body)
 	if len(matches) < 2 {
 		return ""

--- a/view/consent.html
+++ b/view/consent.html
@@ -1,0 +1,29 @@
+{{define "title"}}{{.ThemeTitle}} - Authorization{{end}}
+
+{{define "content"}}
+<form class="auth-card" method="POST" action="{{authURL "/consent"}}">
+  {{template "logo" .}}
+  <h1 class="auth-title">Authorize Access</h1>
+  <p class="auth-text-muted"><strong>{{.ClientName}}</strong> is requesting access to your account</p>
+  {{ .csrfField }}
+  <input type="hidden" name="state" value="{{.State}}" />
+  <input type="hidden" name="redirect_uri" value="{{.RedirectURI}}" />
+  <input type="hidden" name="client_id" value="{{.ClientID}}" />
+  <input type="hidden" name="scope" value="{{.Scope}}" />
+  <input type="hidden" name="nonce" value="{{.Nonce}}" />
+  <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}" />
+  <input type="hidden" name="code_challenge_method" value="{{.CodeChallengeMethod}}" />
+  <input type="hidden" name="prompt" value="{{.Prompt}}" />
+  <input type="hidden" name="consent_sig" value="{{.ConsentSig}}" />
+  <div class="auth-info" role="status">
+    This application would like to:
+  </div>
+  <ul class="consent-scopes">
+    {{range .Scopes}}
+    <li class="consent-scope-item">{{.Description}}</li>
+    {{end}}
+  </ul>
+  <button class="auth-btn" type="submit" name="action" value="allow">Allow</button>
+  <button class="auth-btn-secondary" type="submit" name="action" value="deny" style="margin-top:0.75rem;">Deny</button>
+</form>
+{{end}}

--- a/view/consent.html
+++ b/view/consent.html
@@ -15,9 +15,6 @@
   <input type="hidden" name="code_challenge_method" value="{{.CodeChallengeMethod}}" />
   <input type="hidden" name="prompt" value="{{.Prompt}}" />
   <input type="hidden" name="consent_sig" value="{{.ConsentSig}}" />
-  <div class="auth-info" role="status">
-    This application would like to:
-  </div>
   <ul class="consent-scopes">
     {{range .Scopes}}
     <li class="consent-scope-item">{{.Description}}</li>

--- a/view/login.html
+++ b/view/login.html
@@ -13,6 +13,7 @@
   <input type="hidden" name="nonce" value="{{.Nonce}}" />
   <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}" />
   <input type="hidden" name="code_challenge_method" value="{{.CodeChallengeMethod}}" />
+  <input type="hidden" name="prompt" value="{{.Prompt}}" />
   <input type="hidden" name="authorize_sig" value="{{.AuthorizeSig}}" />
   <div class="auth-field">
     {{if eq .ProfileFieldEmail "is_username"}}

--- a/view/static/auth.css
+++ b/view/static/auth.css
@@ -478,3 +478,19 @@ footer a:hover {
   inset: 0;
   z-index: 0;
 }
+
+.consent-scopes {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.consent-scope-item {
+  padding: 0.625rem 1rem;
+  border-radius: var(--radius);
+  background: color-mix(in oklab, var(--color-fg) 4%, transparent);
+  font-size: 0.9rem;
+}

--- a/view/static/auth.css
+++ b/view/static/auth.css
@@ -483,14 +483,14 @@ footer a:hover {
   list-style: none;
   padding: 0;
   margin: 0.75rem 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  width: 100%;
 }
 
 .consent-scope-item {
-  padding: 0.625rem 1rem;
-  border-radius: var(--radius);
-  background: color-mix(in oklab, var(--color-fg) 4%, transparent);
+  padding: 0.5rem 0;
   font-size: 0.9rem;
+}
+
+.consent-scope-item + .consent-scope-item {
+  border-top: 1px solid color-mix(in oklab, var(--color-fg) 8%, transparent);
 }


### PR DESCRIPTION
## Summary

- **MFA method switching**: When `mfa_method=both`, users can switch between TOTP and email OTP during login via "Verify using email/authenticator app" links. Includes resend code button with cooldown, enrollment guard (unenrolled users get email OTP instead of forced TOTP setup), and method switch helper extraction.
- **OAuth2 consent screen** (#290): Per-client `consent_required` flag and `user_consents` table gate auth code issuance per OIDC Core §3.1.2.4. Consent screen shows client name, scope descriptions, and Allow/Deny buttons. Supports `prompt=consent` (force re-prompt), `prompt=none` (returns `consent_required` error), and remembered consent (skips on repeat with same scopes). HMAC-signed form params prevent tampering.
- **Admin UI**: Consent Required toggle in client create/edit Configuration Overrides section.

## Test plan

- [x] 22 unit tests for consent package (model, CRUD, handler, signature)
- [x] 7 E2E tests covering consent enabled/disabled, allow/deny, repeat consent skip, prompt=none error, signature tampering
- [x] 10 unit tests for MFA method switching (switch to email/totp, enrollment guard, switch link visibility)
- [x] Full test suite passes (`go test -p 1 ./...` — 45 packages, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)