### PR TITLE
fix: add offline_access to admin-ui and fix logout redirect

### DIFF
--- a/account-ui/src/components/AccountDeletion.tsx
+++ b/account-ui/src/components/AccountDeletion.tsx
@@ -28,7 +28,7 @@ const AccountDeletionModal: React.FC<AccountDeletionModalProps> = ({ onClose }) 
       api.post('/deletion-request', reason.trim() ? { reason: reason.trim() } : {}),
     onSuccess: () => {
       if (settings.allow_self_service_deletion) {
-        actions.logout();
+        window.location.href = '/oauth2/logout';
         return;
       }
       queryClient.invalidateQueries({ queryKey: ['deletion-request'] });

--- a/account-ui/src/components/AccountDeletion.tsx
+++ b/account-ui/src/components/AccountDeletion.tsx
@@ -14,7 +14,7 @@ interface AccountDeletionModalProps {
 
 const AccountDeletionModal: React.FC<AccountDeletionModalProps> = ({ onClose }) => {
   const settings = useSettings();
-  const { actions, user } = useAuth();
+  const { user } = useAuth();
   const queryClient = useQueryClient();
   const [confirmUsername, setConfirmUsername] = useState('');
   const [reason, setReason] = useState('');

--- a/account-ui/src/components/Layout.tsx
+++ b/account-ui/src/components/Layout.tsx
@@ -45,7 +45,7 @@ const Layout: React.FC = () => {
         onClose={() => setMobileMenuOpen(false)}
         username={(user?.claims?.preferred_username as string) ?? ''}
         initials={initials}
-        onLogout={actions.logout}
+        onLogout={() => { window.location.href = '/oauth2/logout'; }}
       />
 
       <main className="flex-1 flex flex-col min-w-0">

--- a/account-ui/src/components/Layout.tsx
+++ b/account-ui/src/components/Layout.tsx
@@ -23,7 +23,7 @@ const pageTitles: Record<string, string> = {
 };
 
 const Layout: React.FC = () => {
-  const { user, actions } = useAuth();
+  const { user } = useAuth();
   const location = useLocation();
   const [mobileMenuOpen, setMobileMenuOpen] = React.useState(false);
 

--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -33,7 +33,6 @@ const oidcConfig: OidcConfig = {
   clientId: "autentico-admin",
   redirectUri: window.location.origin + BASENAME + "/callback",
   scopes: ["openid", "profile", "email", "offline_access"],
-  postLogoutRedirectUri: window.location.origin + BASENAME + "/login",
   expiryBuffer: 0,
 };
 

--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -32,7 +32,8 @@ const oidcConfig: OidcConfig = {
   issuer: window.location.origin + "/oauth2",
   clientId: "autentico-admin",
   redirectUri: window.location.origin + BASENAME + "/callback",
-  scopes: ["openid", "profile", "email"],
+  scopes: ["openid", "profile", "email", "offline_access"],
+  postLogoutRedirectUri: window.location.origin + BASENAME + "/login",
   expiryBuffer: 0,
 };
 

--- a/admin-ui/src/layouts/AdminLayout.tsx
+++ b/admin-ui/src/layouts/AdminLayout.tsx
@@ -65,7 +65,7 @@ export default function AdminLayout() {
     )?.key ?? "/";
 
   const handleLogout = () => {
-    actions.logout();
+    window.location.href = "/oauth2/logout";
   };
 
   const userDropdownItems = [

--- a/admin-ui/src/layouts/AdminLayout.tsx
+++ b/admin-ui/src/layouts/AdminLayout.tsx
@@ -51,7 +51,7 @@ const menuItems: any[] = [
 
 export default function AdminLayout() {
   const [collapsed, setCollapsed] = useState(false);
-  const { user, actions } = useAuth();
+  const { user } = useAuth();
   const { mode } = useTheme();
   const location = useLocation();
   const navigate = useNavigate();

--- a/tests/browser/tests/auth-flow.spec.ts
+++ b/tests/browser/tests/auth-flow.spec.ts
@@ -42,7 +42,12 @@ test("admin UI logout requires re-authentication", async ({ page }) => {
   await page.getByTestId("user-menu").click();
   await page.click('text=Logout');
 
-  // Should redirect to login page
+  // Should land on the logout success page
+  await page.waitForURL("**/oauth2/logout**", { timeout: TIMEOUT });
+  await expect(page.getByText("You have been signed out.")).toBeVisible({ timeout: TIMEOUT });
+
+  // Navigating back should require re-authentication
+  await page.goto("/admin/");
   await page.waitForURL("**/oauth2/authorize**", { timeout: TIMEOUT });
   await expect(page.locator("#username")).toBeVisible({ timeout: TIMEOUT });
   await expect(page.locator("#password")).toBeVisible({ timeout: TIMEOUT });
@@ -123,7 +128,12 @@ test("account UI logout requires re-authentication", async ({ page }) => {
   // Logout
   await page.getByTestId("sign-out").click();
 
-  // Should redirect to login page
+  // Should land on the logout success page
+  await page.waitForURL("**/oauth2/logout**", { timeout: TIMEOUT });
+  await expect(page.getByText("You have been signed out.")).toBeVisible({ timeout: TIMEOUT });
+
+  // Navigating back should require re-authentication
+  await page.goto("/account/");
   await page.waitForURL("**/oauth2/authorize**", { timeout: TIMEOUT });
   await expect(page.locator("#username")).toBeVisible({ timeout: TIMEOUT });
   await expect(page.locator("#password")).toBeVisible({ timeout: TIMEOUT });


### PR DESCRIPTION
## Summary
- Add `offline_access` scope to admin-ui OIDC config so it receives a refresh token — enables proactive token refresh via `RequireAuth` instead of relying on 401 → refresh → retry loops
- Replace `actions.logout()` with direct `window.location.href = '/oauth2/logout'` in both admin-ui and account-ui — workaround for oidc-js logout race condition (eugenioenko/oidc-js#71) where clearing auth state triggers a login redirect that wins over the logout redirect

## Test plan
- [ ] Admin-ui: verify token refresh happens proactively (no 401 before /token on tab switch)
- [ ] Admin-ui: verify logout navigates to the "you have been logged out" page
- [ ] Account-ui: verify logout navigates to the "you have been logged out" page
- [ ] Account-ui: verify account deletion with self-service enabled logs out correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)