### PR TITLE
refactor: pass validated auth state via request context

### DIFF
--- a/pkg/account/common_test.go
+++ b/pkg/account/common_test.go
@@ -66,24 +66,22 @@ func setupTestUserAndSession(t *testing.T) (string, *user.User, *middleware.Auth
 	return tokenString, usr, info
 }
 
-func mockAuthRequest(_ *testing.T, body, method, url string, handler http.HandlerFunc, info *middleware.AuthInfo) *httptest.ResponseRecorder {
+func mockAuthRequest(t *testing.T, body, method, url string, handler http.HandlerFunc, info *middleware.AuthInfo) *httptest.ResponseRecorder {
+	t.Helper()
 	req := httptest.NewRequest(method, url, bytes.NewBuffer([]byte(body)))
 	req.Header.Set("Content-Type", "application/json")
 	if info != nil {
+		if usr, err := user.UserByID(info.User.ID); err == nil {
+			info = &middleware.AuthInfo{
+				User:    usr,
+				Token:   info.Token,
+				Claims:  info.Claims,
+				Session: info.Session,
+			}
+		}
 		req = middleware.WithAuthInfo(req, info)
 	}
 	rr := httptest.NewRecorder()
 	handler(rr, req)
 	return rr
-}
-
-func refreshAuthInfo(t *testing.T, info *middleware.AuthInfo) *middleware.AuthInfo {
-	usr, err := user.UserByID(info.User.ID)
-	assert.NoError(t, err)
-	return &middleware.AuthInfo{
-		User:    usr,
-		Token:   info.Token,
-		Claims:  info.Claims,
-		Session: info.Session,
-	}
 }

--- a/pkg/account/common_test.go
+++ b/pkg/account/common_test.go
@@ -1,6 +1,9 @@
 package account
 
 import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -8,6 +11,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/jwtutil"
 	"github.com/eugenioenko/autentico/pkg/key"
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/session"
 	"github.com/eugenioenko/autentico/pkg/user"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
@@ -15,16 +19,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func setupTestUserAndSession(t *testing.T) (string, *user.User) {
+func setupTestUserAndSession(t *testing.T) (string, *user.User, *middleware.AuthInfo) {
 	userID := uuid.New().String()
 	testutils.InsertTestUser(t, userID)
-	
+
 	usr, err := user.UserByID(userID)
 	assert.NoError(t, err)
 
 	sessionID := uuid.New().String()
-	
-	// Create a valid JWT token signed with the ephemeral test key
+
 	claims := &jwtutil.AccessTokenClaims{
 		UserID:    usr.ID,
 		SessionID: sessionID,
@@ -45,8 +48,6 @@ func setupTestUserAndSession(t *testing.T) (string, *user.User) {
 	err = session.CreateSession(sess)
 	assert.NoError(t, err)
 
-	// Persist the matching tokens row so bearer.ValidateBearer's
-	// revocation check sees an active row (not sql.ErrNoRows).
 	now := time.Now().UTC()
 	_, err = db.GetDB().Exec(`
 		INSERT INTO tokens (id, user_id, access_token, refresh_token, access_token_type,
@@ -55,5 +56,34 @@ func setupTestUserAndSession(t *testing.T) (string, *user.User) {
 	`, "tok-"+sessionID[:8], usr.ID, tokenString, "refresh-"+sessionID[:8], now.Add(time.Hour), now.Add(time.Hour), now)
 	assert.NoError(t, err)
 
-	return tokenString, usr
+	info := &middleware.AuthInfo{
+		User:    usr,
+		Token:   tokenString,
+		Claims:  claims,
+		Session: &sess,
+	}
+
+	return tokenString, usr, info
+}
+
+func mockAuthRequest(_ *testing.T, body, method, url string, handler http.HandlerFunc, info *middleware.AuthInfo) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, url, bytes.NewBuffer([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	if info != nil {
+		req = middleware.WithAuthInfo(req, info)
+	}
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+	return rr
+}
+
+func refreshAuthInfo(t *testing.T, info *middleware.AuthInfo) *middleware.AuthInfo {
+	usr, err := user.UserByID(info.User.ID)
+	assert.NoError(t, err)
+	return &middleware.AuthInfo{
+		User:    usr,
+		Token:   info.Token,
+		Claims:  info.Claims,
+		Session: info.Session,
+	}
 }

--- a/pkg/account/federation.go
+++ b/pkg/account/federation.go
@@ -3,8 +3,8 @@ package account
 import (
 	"net/http"
 
-	"github.com/eugenioenko/autentico/pkg/bearer"
 	"github.com/eugenioenko/autentico/pkg/federation"
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/utils"
 )
 
@@ -18,9 +18,9 @@ import (
 // @Failure 401 {object} model.ApiError
 // @Router /account/api/connected-providers [get]
 func HandleListConnectedProviders(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 
@@ -65,9 +65,9 @@ func HandleListConnectedProviders(w http.ResponseWriter, r *http.Request) {
 // @Failure 403 {object} model.ApiError
 // @Router /account/api/connected-providers/{id} [delete]
 func HandleDisconnectProvider(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 

--- a/pkg/account/federation_test.go
+++ b/pkg/account/federation_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/federation"
 	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/model"
+	"github.com/eugenioenko/autentico/pkg/user"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -69,12 +70,14 @@ func TestHandleDisconnectProvider_Lockout(t *testing.T) {
 
 	// No password
 	_, _ = db.GetDB().Exec("UPDATE users SET password = '' WHERE id = ?", usr.ID)
-	info = refreshAuthInfo(t, info)
 
 	_, _ = db.GetDB().Exec(`INSERT INTO federation_providers (id, name, issuer, client_id, client_secret) VALUES ('p1', 'Google', 'iss', 'c1', 's1')`)
 	_ = federation.CreateFederatedIdentity(federation.FederatedIdentity{ProviderID: "p1", ProviderUserID: "sub1", UserID: usr.ID})
 	identities, _ := federation.FederatedIdentitiesByUserID(usr.ID)
 	fiID := identities[0].ID
+
+	freshUsr, _ := user.UserByID(usr.ID)
+	info.User = freshUsr
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /account/api/connected-providers/{id}", HandleDisconnectProvider)

--- a/pkg/account/federation_test.go
+++ b/pkg/account/federation_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/federation"
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/model"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
 	"github.com/stretchr/testify/assert"
@@ -16,29 +17,29 @@ import (
 
 func TestHandleListConnectedProviders(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	_, _ = db.GetDB().Exec(`INSERT INTO federation_providers (id, name, issuer, client_id, client_secret) VALUES ('p1', 'Google', 'iss', 'c1', 's1')`)
 	_ = federation.CreateFederatedIdentity(federation.FederatedIdentity{ProviderID: "p1", ProviderUserID: "sub1", UserID: usr.ID})
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "GET", "/account/api/connected-providers", HandleListConnectedProviders, token)
+	rr := mockAuthRequest(t, "", "GET", "/account/api/connected-providers", HandleListConnectedProviders, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestHandleListConnectedProviders_Partial(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	// Provider doesn't exist in federation_providers table
 	_ = federation.CreateFederatedIdentity(federation.FederatedIdentity{ProviderID: "nonexistent", ProviderUserID: "sub1", UserID: usr.ID})
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "GET", "/account/api/connected-providers", HandleListConnectedProviders, token)
+	rr := mockAuthRequest(t, "", "GET", "/account/api/connected-providers", HandleListConnectedProviders, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestHandleDisconnectProvider_Success(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	_, _ = db.GetDB().Exec(`INSERT INTO federation_providers (id, name, issuer, client_id, client_secret) VALUES ('p1', 'Google', 'iss', 'c1', 's1')`)
 	_ = federation.CreateFederatedIdentity(federation.FederatedIdentity{ProviderID: "p1", ProviderUserID: "sub1", UserID: usr.ID})
@@ -49,14 +50,14 @@ func TestHandleDisconnectProvider_Success(t *testing.T) {
 	mux.HandleFunc("DELETE /account/api/connected-providers/{id}", HandleDisconnectProvider)
 
 	req := httptest.NewRequest("DELETE", "/account/api/connected-providers/"+fiID, nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// Not owned
 	req = httptest.NewRequest("DELETE", "/account/api/connected-providers/other", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr = httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusForbidden, rr.Code)
@@ -64,11 +65,12 @@ func TestHandleDisconnectProvider_Success(t *testing.T) {
 
 func TestHandleDisconnectProvider_Lockout(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	// No password
 	_, _ = db.GetDB().Exec("UPDATE users SET password = '' WHERE id = ?", usr.ID)
-	
+	info = refreshAuthInfo(t, info)
+
 	_, _ = db.GetDB().Exec(`INSERT INTO federation_providers (id, name, issuer, client_id, client_secret) VALUES ('p1', 'Google', 'iss', 'c1', 's1')`)
 	_ = federation.CreateFederatedIdentity(federation.FederatedIdentity{ProviderID: "p1", ProviderUserID: "sub1", UserID: usr.ID})
 	identities, _ := federation.FederatedIdentitiesByUserID(usr.ID)
@@ -78,7 +80,7 @@ func TestHandleDisconnectProvider_Lockout(t *testing.T) {
 	mux.HandleFunc("DELETE /account/api/connected-providers/{id}", HandleDisconnectProvider)
 
 	req := httptest.NewRequest("DELETE", "/account/api/connected-providers/"+fiID, nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
@@ -87,23 +89,17 @@ func TestHandleDisconnectProvider_Lockout(t *testing.T) {
 
 func TestHandleDisconnectProvider_InvalidPath(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
-	
-	req := httptest.NewRequest("DELETE", "/account/api/connected-providers/", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	rr := httptest.NewRecorder()
-	HandleDisconnectProvider(rr, req)
+	_, _, info := setupTestUserAndSession(t)
+
+	rr := mockAuthRequest(t, "", "DELETE", "/account/api/connected-providers/", HandleDisconnectProvider, info)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
 func TestHandleDisconnectProvider_MissingID(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
-	req := httptest.NewRequest("DELETE", "/account/api/connected-providers/", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	rr := httptest.NewRecorder()
-	HandleDisconnectProvider(rr, req)
+	rr := mockAuthRequest(t, "", "DELETE", "/account/api/connected-providers/", HandleDisconnectProvider, info)
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 	assert.Contains(t, rr.Body.String(), "Missing identity ID")
@@ -111,7 +107,7 @@ func TestHandleDisconnectProvider_MissingID(t *testing.T) {
 
 func TestHandleDisconnectProvider_Success_Extra(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, u := setupTestUserAndSession(t)
+	_, u, info := setupTestUserAndSession(t)
 
 	// Must create provider first due to FK
 	_, err := db.GetDB().Exec(`INSERT INTO federation_providers (id, name, issuer, client_id, client_secret) VALUES ('p1', 'P1', 'http://iss', 'c1', 's1')`)
@@ -124,7 +120,7 @@ func TestHandleDisconnectProvider_Success_Extra(t *testing.T) {
 	mux.HandleFunc("DELETE /account/api/connected-providers/{id}", HandleDisconnectProvider)
 
 	req := httptest.NewRequest("DELETE", "/account/api/connected-providers/fi1", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 
@@ -133,16 +129,13 @@ func TestHandleDisconnectProvider_Success_Extra(t *testing.T) {
 
 func TestHandleListConnectedProviders_Extra(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, u := setupTestUserAndSession(t)
+	_, u, info := setupTestUserAndSession(t)
 
 	// Create provider and identity
 	_, _ = db.GetDB().Exec(`INSERT INTO federation_providers (id, name, issuer, client_id, client_secret) VALUES ('p1', 'P1', 'http://iss', 'c1', 's1')`)
 	_, _ = db.GetDB().Exec(`INSERT INTO federated_identities (id, provider_id, provider_user_id, user_id, email) VALUES ('fi1', 'p1', 'sub1', ?, 'e1@test.com')`, u.ID)
 
-	req := httptest.NewRequest("GET", "/account/api/connected-providers", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	rr := httptest.NewRecorder()
-	HandleListConnectedProviders(rr, req)
+	rr := mockAuthRequest(t, "", "GET", "/account/api/connected-providers", HandleListConnectedProviders, info)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 	var listResp model.ApiResponse[[]ConnectedProviderResponse]

--- a/pkg/account/mfa.go
+++ b/pkg/account/mfa.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 
 	"github.com/eugenioenko/autentico/pkg/audit"
-	"github.com/eugenioenko/autentico/pkg/bearer"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/mfa"
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/user"
 	"github.com/eugenioenko/autentico/pkg/utils"
 )
@@ -23,9 +23,9 @@ import (
 // @Failure 401 {object} model.ApiError
 // @Router /account/api/mfa [get]
 func HandleGetMfaStatus(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 
@@ -45,9 +45,9 @@ func HandleGetMfaStatus(w http.ResponseWriter, r *http.Request) {
 // @Failure 409 {object} model.ApiError
 // @Router /account/api/mfa/totp/setup [post]
 func HandleSetupTotp(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 
@@ -87,9 +87,9 @@ func HandleSetupTotp(w http.ResponseWriter, r *http.Request) {
 // @Failure 401 {object} model.ApiError
 // @Router /account/api/mfa/totp/verify [post]
 func HandleVerifyTotp(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 
@@ -99,8 +99,11 @@ func HandleVerifyTotp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fetch user again to get the unverified secret
-	currUser, _ := user.UserByID(usr.ID)
+	currUser, err := user.UserByID(usr.ID)
+	if err != nil {
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", "Failed to load user")
+		return
+	}
 	if currUser.TotpSecret == "" {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "TOTP not initiated")
 		return
@@ -134,9 +137,9 @@ func HandleVerifyTotp(w http.ResponseWriter, r *http.Request) {
 // @Failure 403 {object} model.ApiError
 // @Router /account/api/mfa/totp [delete]
 func HandleDeleteMfa(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 

--- a/pkg/account/mfa_test.go
+++ b/pkg/account/mfa_test.go
@@ -3,7 +3,6 @@ package account
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -19,129 +18,138 @@ import (
 
 func TestHandleGetMfaStatus(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	// Enabled
 	_, _ = db.GetDB().Exec("UPDATE users SET totp_verified = TRUE WHERE id = ?", usr.ID)
+	info = refreshAuthInfo(t, info)
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "GET", "/account/mfa/status", HandleGetMfaStatus, token)
+	rr := mockAuthRequest(t, "", "GET", "/account/mfa/status", HandleGetMfaStatus, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestHandleVerifyTotp(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
-	_ = testutils.MockApiRequestWithAuth(t, "", "POST", "/account/mfa/totp/setup", HandleSetupTotp, token)
-	
+	_ = mockAuthRequest(t, "", "POST", "/account/mfa/totp/setup", HandleSetupTotp, info)
+
 	currUser, _ := user.UserByID(usr.ID)
 	secret := currUser.TotpSecret
 	code, _ := totp.GenerateCode(secret, time.Now())
 
+	info = refreshAuthInfo(t, info)
 	verifyReq := TotpVerifyRequest{Code: code}
 	body, _ := json.Marshal(verifyReq)
-	rr := testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/mfa/totp/verify", HandleVerifyTotp, token)
+	rr := mockAuthRequest(t, string(body), "POST", "/account/mfa/totp/verify", HandleVerifyTotp, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestHandleVerifyTotp_Errors(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	// TOTP not initiated
 	verifyReq := TotpVerifyRequest{Code: "000000"}
 	body, _ := json.Marshal(verifyReq)
-	rr := testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/mfa/totp/verify", HandleVerifyTotp, token)
+	rr := mockAuthRequest(t, string(body), "POST", "/account/mfa/totp/verify", HandleVerifyTotp, info)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 
 	// Invalid code
 	_ = user.StoreTotpSecretPending(usr.ID, "dummy")
-	rr = testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/mfa/totp/verify", HandleVerifyTotp, token)
+	info = refreshAuthInfo(t, info)
+	rr = mockAuthRequest(t, string(body), "POST", "/account/mfa/totp/verify", HandleVerifyTotp, info)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
 func TestHandleDeleteMfa(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)
 	secret := "JBSWY3DPEHPK3PXP"
 	_, _ = db.GetDB().Exec("UPDATE users SET password = ?, totp_secret = ?, totp_verified = TRUE WHERE id = ?", string(hashedPassword), secret, usr.ID)
+	info = refreshAuthInfo(t, info)
 
 	code, _ := totp.GenerateCode(secret, time.Now())
 	deleteReq := DisableMfaRequest{CurrentPassword: "password", Code: code}
 	body, _ := json.Marshal(deleteReq)
-	rr := testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/mfa/delete", HandleDeleteMfa, token)
+	rr := mockAuthRequest(t, string(body), "POST", "/account/mfa/delete", HandleDeleteMfa, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestHandleDeleteMfa_NoCode(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)
 	_, _ = db.GetDB().Exec("UPDATE users SET password = ?, totp_secret = 'JBSWY3DPEHPK3PXP', totp_verified = TRUE WHERE id = ?", string(hashedPassword), usr.ID)
+	info = refreshAuthInfo(t, info)
 
 	deleteReq := DisableMfaRequest{CurrentPassword: "password"}
 	body, _ := json.Marshal(deleteReq)
-	rr := testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/mfa/delete", HandleDeleteMfa, token)
+	rr := mockAuthRequest(t, string(body), "POST", "/account/mfa/delete", HandleDeleteMfa, info)
 	assert.Equal(t, http.StatusForbidden, rr.Code)
 }
 
 func TestHandleDeleteMfa_InvalidCode(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)
 	_, _ = db.GetDB().Exec("UPDATE users SET password = ?, totp_secret = 'JBSWY3DPEHPK3PXP', totp_verified = TRUE WHERE id = ?", string(hashedPassword), usr.ID)
+	info = refreshAuthInfo(t, info)
 
 	deleteReq := DisableMfaRequest{CurrentPassword: "password", Code: "000000"}
 	body, _ := json.Marshal(deleteReq)
-	rr := testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/mfa/delete", HandleDeleteMfa, token)
+	rr := mockAuthRequest(t, string(body), "POST", "/account/mfa/delete", HandleDeleteMfa, info)
 	assert.Equal(t, http.StatusForbidden, rr.Code)
 }
 
 func TestHandleDeleteMfa_NoPassword(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	// User has no password (passkey-only) but has TOTP
 	secret := "JBSWY3DPEHPK3PXP"
 	_, _ = db.GetDB().Exec("UPDATE users SET password = '', totp_secret = ?, totp_verified = TRUE WHERE id = ?", secret, usr.ID)
+	info = refreshAuthInfo(t, info)
 
 	code, _ := totp.GenerateCode(secret, time.Now())
 	deleteReq := DisableMfaRequest{Code: code}
 	body, _ := json.Marshal(deleteReq)
-	rr := testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/mfa/delete", HandleDeleteMfa, token)
+	rr := mockAuthRequest(t, string(body), "POST", "/account/mfa/delete", HandleDeleteMfa, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestHandleDeleteMfa_InvalidJSON(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
-	rr := testutils.MockApiRequestWithAuth(t, "{invalid", "POST", "/account/api/mfa/delete", HandleDeleteMfa, token)
+	_, _, info := setupTestUserAndSession(t)
+	rr := mockAuthRequest(t, "{invalid", "POST", "/account/api/mfa/delete", HandleDeleteMfa, info)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
 func TestHandleDeleteMfa_WrongPassword(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)
 	_, _ = db.GetDB().Exec("UPDATE users SET password = ?, totp_secret = 'JBSWY3DPEHPK3PXP', totp_verified = TRUE WHERE id = ?", string(hashedPassword), usr.ID)
+	info = refreshAuthInfo(t, info)
 
 	req := DisableMfaRequest{CurrentPassword: "wrong"}
 	body, _ := json.Marshal(req)
-	rr := testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/api/mfa/delete", HandleDeleteMfa, token)
+	rr := mockAuthRequest(t, string(body), "POST", "/account/api/mfa/delete", HandleDeleteMfa, info)
 	assert.Equal(t, http.StatusForbidden, rr.Code)
 }
 
 func TestHandleDeleteMfa_UniformErrorResponse(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)
 	_, _ = db.GetDB().Exec("UPDATE users SET password = ?, totp_secret = 'JBSWY3DPEHPK3PXP', totp_verified = TRUE WHERE id = ?", string(hashedPassword), usr.ID)
+	info = refreshAuthInfo(t, info)
 
 	cases := []DisableMfaRequest{
 		{CurrentPassword: "wrong", Code: "000000"},
@@ -152,7 +160,7 @@ func TestHandleDeleteMfa_UniformErrorResponse(t *testing.T) {
 	var responses []string
 	for _, c := range cases {
 		body, _ := json.Marshal(c)
-		rr := testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/api/mfa/delete", HandleDeleteMfa, token)
+		rr := mockAuthRequest(t, string(body), "POST", "/account/api/mfa/delete", HandleDeleteMfa, info)
 		assert.Equal(t, http.StatusForbidden, rr.Code)
 		responses = append(responses, rr.Body.String())
 	}
@@ -163,56 +171,52 @@ func TestHandleDeleteMfa_UniformErrorResponse(t *testing.T) {
 
 func TestHandleDeleteMfa_NotEnrolled(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
 	req := DisableMfaRequest{CurrentPassword: "anything"}
 	body, _ := json.Marshal(req)
-	rr := testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/api/mfa/delete", HandleDeleteMfa, token)
+	rr := mockAuthRequest(t, string(body), "POST", "/account/api/mfa/delete", HandleDeleteMfa, info)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
 func TestHandleMfaFlow(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, u := setupTestUserAndSession(t)
+	_, u, info := setupTestUserAndSession(t)
 
 	// Set a valid hashed password for AuthenticateUser to work
 	hashed, _ := bcrypt.GenerateFromPassword([]byte("password123"), bcrypt.DefaultCost)
 	_, _ = db.GetDB().Exec("UPDATE users SET password = ? WHERE id = ?", string(hashed), u.ID)
+	info = refreshAuthInfo(t, info)
 
 	// 1. Get MFA Status
-	req := httptest.NewRequest("GET", "/account/api/mfa/status", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	rr := httptest.NewRecorder()
-	HandleGetMfaStatus(rr, req)
+	rr := mockAuthRequest(t, "", "GET", "/account/api/mfa/status", HandleGetMfaStatus, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
-	
+
 	var statusResp model.ApiResponse[MfaStatusResponse]
 	err := json.Unmarshal(rr.Body.Bytes(), &statusResp)
 	require.NoError(t, err)
 	assert.False(t, statusResp.Data.TotpEnabled)
 
 	// 2. Setup TOTP
-	req = httptest.NewRequest("POST", "/account/api/mfa/totp/setup", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	rr = httptest.NewRecorder()
-	HandleSetupTotp(rr, req)
+	rr = mockAuthRequest(t, "", "POST", "/account/api/mfa/totp/setup", HandleSetupTotp, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
-	
+
 	var setupResp model.ApiResponse[TotpSetupResponse]
 	err = json.Unmarshal(rr.Body.Bytes(), &setupResp)
 	require.NoError(t, err)
 	assert.NotEmpty(t, setupResp.Data.Secret)
 
 	// 3. Verify TOTP (valid code)
+	info = refreshAuthInfo(t, info)
 	code, _ := totp.GenerateCode(setupResp.Data.Secret, time.Now())
 	verifyReq := TotpVerifyRequest{Code: code}
 	body, _ := json.Marshal(verifyReq)
-	rr = testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/api/mfa/totp/verify", HandleVerifyTotp, token)
+	rr = mockAuthRequest(t, string(body), "POST", "/account/api/mfa/totp/verify", HandleVerifyTotp, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// 4. Verify status again
-	rr = httptest.NewRecorder()
-	HandleGetMfaStatus(rr, req) // reusing req
+	info = refreshAuthInfo(t, info)
+	rr = mockAuthRequest(t, "", "GET", "/account/api/mfa/status", HandleGetMfaStatus, info)
 	err = json.Unmarshal(rr.Body.Bytes(), &statusResp)
 	require.NoError(t, err)
 	assert.True(t, statusResp.Data.TotpEnabled)
@@ -222,55 +226,56 @@ func TestHandleMfaFlow(t *testing.T) {
 	disableCode, _ := totp.GenerateCode(currUser.TotpSecret, time.Now())
 	deleteReq := DisableMfaRequest{CurrentPassword: "password123", Code: disableCode}
 	body, _ = json.Marshal(deleteReq)
-	rr = testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/api/mfa/delete", HandleDeleteMfa, token)
+	rr = mockAuthRequest(t, string(body), "POST", "/account/api/mfa/delete", HandleDeleteMfa, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestHandleSetupTotp_AlreadyEnrolled(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	// Mark TOTP as verified
 	_, _ = db.GetDB().Exec("UPDATE users SET totp_secret = 'JBSWY3DPEHPK3PXP', totp_verified = TRUE WHERE id = ?", usr.ID)
+	info = refreshAuthInfo(t, info)
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "POST", "/account/api/mfa/totp/setup", HandleSetupTotp, token)
+	rr := mockAuthRequest(t, "", "POST", "/account/api/mfa/totp/setup", HandleSetupTotp, info)
 	assert.Equal(t, http.StatusConflict, rr.Code)
 	assert.Contains(t, rr.Body.String(), "already_enrolled")
 }
 
 func TestHandleVerifyTotp_InvalidCode(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
 	verifyReq := TotpVerifyRequest{Code: "000000"}
 	body, _ := json.Marshal(verifyReq)
-	rr := testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/api/mfa/totp/verify", HandleVerifyTotp, token)
+	rr := mockAuthRequest(t, string(body), "POST", "/account/api/mfa/totp/verify", HandleVerifyTotp, info)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
 func TestHandleVerifyTotp_DbError(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
 	verifyReq := TotpVerifyRequest{Code: "123456"}
 	body, _ := json.Marshal(verifyReq)
-	
+
 	// Close DB to trigger error
 	db.CloseDB()
 
-	rr := testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/api/mfa/totp/verify", HandleVerifyTotp, token)
-	
-	// GetUserFromRequest returns 401 if user lookup fails (e.g. DB closed)
-	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	rr := mockAuthRequest(t, string(body), "POST", "/account/api/mfa/totp/verify", HandleVerifyTotp, info)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 }
 
 func TestHandleDeleteMfa_DbError(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, u := setupTestUserAndSession(t)
+	_, u, info := setupTestUserAndSession(t)
 
-	// Set a valid hashed password
+	// Set a valid hashed password and TOTP so the handler proceeds past validation
 	hashed, _ := bcrypt.GenerateFromPassword([]byte("password123"), bcrypt.DefaultCost)
-	_, _ = db.GetDB().Exec("UPDATE users SET password = ? WHERE id = ?", string(hashed), u.ID)
+	_, _ = db.GetDB().Exec("UPDATE users SET password = ?, totp_secret = 'JBSWY3DPEHPK3PXP', totp_verified = TRUE WHERE id = ?", string(hashed), u.ID)
+	info = refreshAuthInfo(t, info)
 
 	deleteReq := DisableMfaRequest{CurrentPassword: "password123"}
 	body, _ := json.Marshal(deleteReq)
@@ -278,8 +283,9 @@ func TestHandleDeleteMfa_DbError(t *testing.T) {
 	// Close DB to trigger error in DisableMfa
 	db.CloseDB()
 
-	rr := testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/api/mfa/delete", HandleDeleteMfa, token)
-	
-	// GetUserFromRequest returns 401 if user lookup fails
-	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	rr := mockAuthRequest(t, string(body), "POST", "/account/api/mfa/delete", HandleDeleteMfa, info)
+
+	// With auth context, user is loaded from context; DB error hits during
+	// VerifyPassword or DisableMfa — returns 403 (password verify fails) or 500
+	assert.True(t, rr.Code == http.StatusForbidden || rr.Code == http.StatusInternalServerError)
 }

--- a/pkg/account/mfa_test.go
+++ b/pkg/account/mfa_test.go
@@ -22,7 +22,6 @@ func TestHandleGetMfaStatus(t *testing.T) {
 
 	// Enabled
 	_, _ = db.GetDB().Exec("UPDATE users SET totp_verified = TRUE WHERE id = ?", usr.ID)
-	info = refreshAuthInfo(t, info)
 
 	rr := mockAuthRequest(t, "", "GET", "/account/mfa/status", HandleGetMfaStatus, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
@@ -38,7 +37,7 @@ func TestHandleVerifyTotp(t *testing.T) {
 	secret := currUser.TotpSecret
 	code, _ := totp.GenerateCode(secret, time.Now())
 
-	info = refreshAuthInfo(t, info)
+
 	verifyReq := TotpVerifyRequest{Code: code}
 	body, _ := json.Marshal(verifyReq)
 	rr := mockAuthRequest(t, string(body), "POST", "/account/mfa/totp/verify", HandleVerifyTotp, info)
@@ -57,7 +56,7 @@ func TestHandleVerifyTotp_Errors(t *testing.T) {
 
 	// Invalid code
 	_ = user.StoreTotpSecretPending(usr.ID, "dummy")
-	info = refreshAuthInfo(t, info)
+
 	rr = mockAuthRequest(t, string(body), "POST", "/account/mfa/totp/verify", HandleVerifyTotp, info)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
@@ -69,7 +68,7 @@ func TestHandleDeleteMfa(t *testing.T) {
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)
 	secret := "JBSWY3DPEHPK3PXP"
 	_, _ = db.GetDB().Exec("UPDATE users SET password = ?, totp_secret = ?, totp_verified = TRUE WHERE id = ?", string(hashedPassword), secret, usr.ID)
-	info = refreshAuthInfo(t, info)
+
 
 	code, _ := totp.GenerateCode(secret, time.Now())
 	deleteReq := DisableMfaRequest{CurrentPassword: "password", Code: code}
@@ -84,7 +83,7 @@ func TestHandleDeleteMfa_NoCode(t *testing.T) {
 
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)
 	_, _ = db.GetDB().Exec("UPDATE users SET password = ?, totp_secret = 'JBSWY3DPEHPK3PXP', totp_verified = TRUE WHERE id = ?", string(hashedPassword), usr.ID)
-	info = refreshAuthInfo(t, info)
+
 
 	deleteReq := DisableMfaRequest{CurrentPassword: "password"}
 	body, _ := json.Marshal(deleteReq)
@@ -98,7 +97,7 @@ func TestHandleDeleteMfa_InvalidCode(t *testing.T) {
 
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)
 	_, _ = db.GetDB().Exec("UPDATE users SET password = ?, totp_secret = 'JBSWY3DPEHPK3PXP', totp_verified = TRUE WHERE id = ?", string(hashedPassword), usr.ID)
-	info = refreshAuthInfo(t, info)
+
 
 	deleteReq := DisableMfaRequest{CurrentPassword: "password", Code: "000000"}
 	body, _ := json.Marshal(deleteReq)
@@ -113,7 +112,7 @@ func TestHandleDeleteMfa_NoPassword(t *testing.T) {
 	// User has no password (passkey-only) but has TOTP
 	secret := "JBSWY3DPEHPK3PXP"
 	_, _ = db.GetDB().Exec("UPDATE users SET password = '', totp_secret = ?, totp_verified = TRUE WHERE id = ?", secret, usr.ID)
-	info = refreshAuthInfo(t, info)
+
 
 	code, _ := totp.GenerateCode(secret, time.Now())
 	deleteReq := DisableMfaRequest{Code: code}
@@ -135,7 +134,7 @@ func TestHandleDeleteMfa_WrongPassword(t *testing.T) {
 
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)
 	_, _ = db.GetDB().Exec("UPDATE users SET password = ?, totp_secret = 'JBSWY3DPEHPK3PXP', totp_verified = TRUE WHERE id = ?", string(hashedPassword), usr.ID)
-	info = refreshAuthInfo(t, info)
+
 
 	req := DisableMfaRequest{CurrentPassword: "wrong"}
 	body, _ := json.Marshal(req)
@@ -149,7 +148,7 @@ func TestHandleDeleteMfa_UniformErrorResponse(t *testing.T) {
 
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)
 	_, _ = db.GetDB().Exec("UPDATE users SET password = ?, totp_secret = 'JBSWY3DPEHPK3PXP', totp_verified = TRUE WHERE id = ?", string(hashedPassword), usr.ID)
-	info = refreshAuthInfo(t, info)
+
 
 	cases := []DisableMfaRequest{
 		{CurrentPassword: "wrong", Code: "000000"},
@@ -186,7 +185,7 @@ func TestHandleMfaFlow(t *testing.T) {
 	// Set a valid hashed password for AuthenticateUser to work
 	hashed, _ := bcrypt.GenerateFromPassword([]byte("password123"), bcrypt.DefaultCost)
 	_, _ = db.GetDB().Exec("UPDATE users SET password = ? WHERE id = ?", string(hashed), u.ID)
-	info = refreshAuthInfo(t, info)
+
 
 	// 1. Get MFA Status
 	rr := mockAuthRequest(t, "", "GET", "/account/api/mfa/status", HandleGetMfaStatus, info)
@@ -207,7 +206,7 @@ func TestHandleMfaFlow(t *testing.T) {
 	assert.NotEmpty(t, setupResp.Data.Secret)
 
 	// 3. Verify TOTP (valid code)
-	info = refreshAuthInfo(t, info)
+
 	code, _ := totp.GenerateCode(setupResp.Data.Secret, time.Now())
 	verifyReq := TotpVerifyRequest{Code: code}
 	body, _ := json.Marshal(verifyReq)
@@ -215,7 +214,7 @@ func TestHandleMfaFlow(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// 4. Verify status again
-	info = refreshAuthInfo(t, info)
+
 	rr = mockAuthRequest(t, "", "GET", "/account/api/mfa/status", HandleGetMfaStatus, info)
 	err = json.Unmarshal(rr.Body.Bytes(), &statusResp)
 	require.NoError(t, err)
@@ -236,7 +235,7 @@ func TestHandleSetupTotp_AlreadyEnrolled(t *testing.T) {
 
 	// Mark TOTP as verified
 	_, _ = db.GetDB().Exec("UPDATE users SET totp_secret = 'JBSWY3DPEHPK3PXP', totp_verified = TRUE WHERE id = ?", usr.ID)
-	info = refreshAuthInfo(t, info)
+
 
 	rr := mockAuthRequest(t, "", "POST", "/account/api/mfa/totp/setup", HandleSetupTotp, info)
 	assert.Equal(t, http.StatusConflict, rr.Code)
@@ -275,7 +274,10 @@ func TestHandleDeleteMfa_DbError(t *testing.T) {
 	// Set a valid hashed password and TOTP so the handler proceeds past validation
 	hashed, _ := bcrypt.GenerateFromPassword([]byte("password123"), bcrypt.DefaultCost)
 	_, _ = db.GetDB().Exec("UPDATE users SET password = ?, totp_secret = 'JBSWY3DPEHPK3PXP', totp_verified = TRUE WHERE id = ?", string(hashed), u.ID)
-	info = refreshAuthInfo(t, info)
+
+	// Refresh before closing DB so context has the updated user
+	freshUsr, _ := user.UserByID(u.ID)
+	info.User = freshUsr
 
 	deleteReq := DisableMfaRequest{CurrentPassword: "password123"}
 	body, _ := json.Marshal(deleteReq)

--- a/pkg/account/passkey.go
+++ b/pkg/account/passkey.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/eugenioenko/autentico/pkg/audit"
-	"github.com/eugenioenko/autentico/pkg/bearer"
 	authcode "github.com/eugenioenko/autentico/pkg/auth_code"
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/passkey"
 	"github.com/eugenioenko/autentico/pkg/reqid"
 	"github.com/eugenioenko/autentico/pkg/utils"
@@ -27,9 +27,9 @@ import (
 // @Failure 401 {object} model.ApiError
 // @Router /account/api/passkeys [get]
 func HandleListPasskeys(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 
@@ -65,9 +65,9 @@ func HandleListPasskeys(w http.ResponseWriter, r *http.Request) {
 // @Failure 403 {object} model.ApiError
 // @Router /account/api/passkeys/{id} [delete]
 func HandleDeletePasskey(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 
@@ -107,9 +107,9 @@ func HandleDeletePasskey(w http.ResponseWriter, r *http.Request) {
 // @Failure 403 {object} model.ApiError
 // @Router /account/api/passkeys/{id} [patch]
 func HandleRenamePasskey(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 
@@ -150,9 +150,9 @@ func HandleRenamePasskey(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} model.ApiError
 // @Router /account/api/passkeys/register/begin [post]
 func HandleAddPasskeyBegin(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 
@@ -221,9 +221,9 @@ func HandleAddPasskeyBegin(w http.ResponseWriter, r *http.Request) {
 // @Failure 403 {object} model.ApiError
 // @Router /account/api/passkeys/register/finish [post]
 func HandleAddPasskeyFinish(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 

--- a/pkg/account/passkey_test.go
+++ b/pkg/account/passkey_test.go
@@ -5,22 +5,23 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/model"
 	"github.com/eugenioenko/autentico/pkg/passkey"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"strings"
 )
 
 func TestHandleListPasskeys(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	_ = passkey.CreatePasskeyCredential(passkey.PasskeyCredential{
 		ID:         "pk1",
@@ -29,13 +30,13 @@ func TestHandleListPasskeys(t *testing.T) {
 		Credential: "{}",
 	})
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "GET", "/account/api/passkeys", HandleListPasskeys, token)
+	rr := mockAuthRequest(t, "", "GET", "/account/api/passkeys", HandleListPasskeys, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestHandleDeletePasskey(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	_ = passkey.CreatePasskeyCredential(passkey.PasskeyCredential{
 		ID:         "pk1",
@@ -48,14 +49,14 @@ func TestHandleDeletePasskey(t *testing.T) {
 	mux.HandleFunc("DELETE /account/api/passkeys/{id}", HandleDeletePasskey)
 
 	req := httptest.NewRequest("DELETE", "/account/api/passkeys/pk1", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// Not owned
 	req = httptest.NewRequest("DELETE", "/account/api/passkeys/otherpk", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr = httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusForbidden, rr.Code)
@@ -63,7 +64,7 @@ func TestHandleDeletePasskey(t *testing.T) {
 
 func TestHandleRenamePasskey(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	_ = passkey.CreatePasskeyCredential(passkey.PasskeyCredential{
 		ID:         "pk1",
@@ -78,14 +79,14 @@ func TestHandleRenamePasskey(t *testing.T) {
 	renameReq := PasskeyRenameRequest{Name: "New Name"}
 	body, _ := json.Marshal(renameReq)
 	req := httptest.NewRequest("PUT", "/account/api/passkeys/pk1", bytes.NewBuffer(body))
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// Not owned
 	req = httptest.NewRequest("PUT", "/account/api/passkeys/otherpk", bytes.NewBuffer(body))
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr = httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusForbidden, rr.Code)
@@ -93,24 +94,24 @@ func TestHandleRenamePasskey(t *testing.T) {
 
 func TestHandleAddPasskeyBegin(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 	testutils.WithConfigOverride(t, func() {
 		config.Bootstrap.AppDomain = "localhost"
 		config.Bootstrap.AppURL = "http://localhost"
 		config.Values.PasskeyRPName = "Test"
 	})
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "POST", "/account/api/passkeys/add/begin", HandleAddPasskeyBegin, token)
+	rr := mockAuthRequest(t, "", "POST", "/account/api/passkeys/add/begin", HandleAddPasskeyBegin, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestHandleAddPasskeyFinish_Errors(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
 	// Missing challenge_id
 	req := httptest.NewRequest("POST", "/account/api/passkeys/add/finish?challenge_id=invalid", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	HandleAddPasskeyFinish(rr, req)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
@@ -126,7 +127,7 @@ func TestHandleAddPasskeyFinish_Errors(t *testing.T) {
 	}
 	_ = passkey.CreatePasskeyChallenge(challenge)
 	req = httptest.NewRequest("POST", "/account/api/passkeys/add/finish?challenge_id=chall1", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr = httptest.NewRecorder()
 	HandleAddPasskeyFinish(rr, req)
 	assert.Equal(t, http.StatusForbidden, rr.Code)
@@ -134,7 +135,7 @@ func TestHandleAddPasskeyFinish_Errors(t *testing.T) {
 
 func TestHandleAddPasskeyFinish_InvalidChallengeData(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	challenge := passkey.PasskeyChallenge{
 		ID:            "chall1",
@@ -146,7 +147,7 @@ func TestHandleAddPasskeyFinish_InvalidChallengeData(t *testing.T) {
 	_ = passkey.CreatePasskeyChallenge(challenge)
 
 	req := httptest.NewRequest("POST", "/account/api/passkeys/add/finish?challenge_id=chall1", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	HandleAddPasskeyFinish(rr, req)
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
@@ -154,13 +155,13 @@ func TestHandleAddPasskeyFinish_InvalidChallengeData(t *testing.T) {
 
 func TestHandleRenamePasskey_InvalidJSON(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
-	
+	_, _, info := setupTestUserAndSession(t)
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /account/api/passkeys/{id}", HandleRenamePasskey)
-	
+
 	req := httptest.NewRequest("PUT", "/account/api/passkeys/pk1", nil) // No body
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
@@ -168,10 +169,10 @@ func TestHandleRenamePasskey_InvalidJSON(t *testing.T) {
 
 func TestHandleAddPasskeyFinish_MissingChallengeID(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
 	req := httptest.NewRequest("POST", "/account/api/passkeys/add/finish", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	HandleAddPasskeyFinish(rr, req)
 
@@ -181,30 +182,30 @@ func TestHandleAddPasskeyFinish_MissingChallengeID(t *testing.T) {
 
 func TestHandleAddPasskeyBegin_Success(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
 	req := httptest.NewRequest("POST", "/account/api/passkeys/add/begin", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	HandleAddPasskeyBegin(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	
+
 	var resp model.ApiResponse[map[string]any]
 	err := json.Unmarshal(rr.Body.Bytes(), &resp)
 	require.NoError(t, err)
-	
+
 	assert.NotEmpty(t, resp.Data["challenge_id"])
 	assert.NotNil(t, resp.Data["options"])
 }
 
 func TestHandleAddPasskeyFinish_InvalidChallenge(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
 	// No challenge created in DB
 	req := httptest.NewRequest("POST", "/account/api/passkeys/add/finish?challenge_id=nonexistent", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	HandleAddPasskeyFinish(rr, req)
 
@@ -214,7 +215,7 @@ func TestHandleAddPasskeyFinish_InvalidChallenge(t *testing.T) {
 
 func TestHandleAddPasskeyFinish_ChallengeExpired(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, u := setupTestUserAndSession(t)
+	_, u, info := setupTestUserAndSession(t)
 
 	// Create an expired challenge with CORRECT type: account-registration
 	_, _ = db.GetDB().Exec(`
@@ -223,7 +224,7 @@ func TestHandleAddPasskeyFinish_ChallengeExpired(t *testing.T) {
 	`, u.ID)
 
 	req := httptest.NewRequest("POST", "/account/api/passkeys/add/finish?challenge_id=expired", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	HandleAddPasskeyFinish(rr, req)
 
@@ -233,7 +234,7 @@ func TestHandleAddPasskeyFinish_ChallengeExpired(t *testing.T) {
 
 func TestHandleAddPasskeyFinish_InvalidBody(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, u := setupTestUserAndSession(t)
+	_, u, info := setupTestUserAndSession(t)
 
 	// Create a valid challenge
 	_, _ = db.GetDB().Exec(`
@@ -242,7 +243,7 @@ func TestHandleAddPasskeyFinish_InvalidBody(t *testing.T) {
 	`, u.ID)
 
 	req := httptest.NewRequest("POST", "/account/api/passkeys/add/finish?challenge_id=valid", strings.NewReader("{invalid"))
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	HandleAddPasskeyFinish(rr, req)
 
@@ -251,7 +252,7 @@ func TestHandleAddPasskeyFinish_InvalidBody(t *testing.T) {
 
 func TestHandleAddPasskeyFinish_WrongUser(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t) // token for u1
+	_, _, info := setupTestUserAndSession(t) // info for u1
 
 	// Create a challenge for OTHER user
 	testutils.InsertTestUser(t, "other")
@@ -261,7 +262,7 @@ func TestHandleAddPasskeyFinish_WrongUser(t *testing.T) {
 	`)
 
 	req := httptest.NewRequest("POST", "/account/api/passkeys/add/finish?challenge_id=other-chall", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	HandleAddPasskeyFinish(rr, req)
 
@@ -271,7 +272,7 @@ func TestHandleAddPasskeyFinish_WrongUser(t *testing.T) {
 
 func TestHandleRenamePasskey_Success_Extra(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, u := setupTestUserAndSession(t)
+	_, u, info := setupTestUserAndSession(t)
 
 	// Create a passkey in the CORRECT table: passkey_credentials
 	_, _ = db.GetDB().Exec(`
@@ -285,12 +286,12 @@ func TestHandleRenamePasskey_Success_Extra(t *testing.T) {
 	renameReq := PasskeyRenameRequest{Name: "New Name"}
 	body, _ := json.Marshal(renameReq)
 	req := httptest.NewRequest("PATCH", "/account/api/passkeys/pk1", bytes.NewBuffer(body))
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	
+
 	// Verify renamed
 	var name string
 	_ = db.GetDB().QueryRow("SELECT name FROM passkey_credentials WHERE id = 'pk1'").Scan(&name)
@@ -299,13 +300,13 @@ func TestHandleRenamePasskey_Success_Extra(t *testing.T) {
 
 func TestHandleDeletePasskey_Extra(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /account/api/passkeys/{id}", HandleDeletePasskey)
 
 	req := httptest.NewRequest("DELETE", "/account/api/passkeys/none", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusForbidden, rr.Code)

--- a/pkg/account/profile.go
+++ b/pkg/account/profile.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/eugenioenko/autentico/pkg/audit"
-	"github.com/eugenioenko/autentico/pkg/bearer"
 	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/user"
 	"github.com/eugenioenko/autentico/pkg/utils"
 )
@@ -23,9 +23,9 @@ import (
 // @Failure 401 {object} model.ApiError
 // @Router /account/api/profile [get]
 func HandleGetProfile(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 	utils.SuccessResponse(w, usr.ToResponse(), http.StatusOK)
@@ -46,9 +46,9 @@ func HandleGetProfile(w http.ResponseWriter, r *http.Request) {
 // @Failure 409 {object} model.ApiError
 // @Router /account/api/profile [put]
 func HandleUpdateProfile(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 
@@ -145,16 +145,12 @@ func HandleUpdateProfile(w http.ResponseWriter, r *http.Request) {
 // @Failure 403 {object} model.ApiError
 // @Router /account/api/password [post]
 func HandleUpdatePassword(w http.ResponseWriter, r *http.Request) {
-	v, err := bearer.ValidateBearer(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	info := middleware.AuthInfoFromContext(r.Context())
+	if info == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
-	usr, err := user.UserByID(v.Claims.UserID)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
-		return
-	}
+	usr := info.User
 
 	var req UpdatePasswordRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -184,7 +180,7 @@ func HandleUpdatePassword(w http.ResponseWriter, r *http.Request) {
 
 	// Revoke all other sessions — a password change invalidates all sessions
 	// except the one that initiated the change.
-	if err := user.RevokeOtherUserAccess(usr.ID, v.Token); err != nil {
+	if err := user.RevokeOtherUserAccess(usr.ID, info.Token); err != nil {
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
 	}

--- a/pkg/account/profile_test.go
+++ b/pkg/account/profile_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/model"
 	"github.com/eugenioenko/autentico/pkg/user"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
@@ -19,12 +20,12 @@ import (
 
 func TestHandleGetProfile(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "GET", "/account/profile", HandleGetProfile, token)
+	rr := mockAuthRequest(t, "", "GET", "/account/profile", HandleGetProfile, info)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	
+
 	var resp model.ApiResponse[user.UserResponse]
 	err := json.Unmarshal(rr.Body.Bytes(), &resp)
 	assert.NoError(t, err)
@@ -33,13 +34,13 @@ func TestHandleGetProfile(t *testing.T) {
 
 func TestHandleGetProfile_Unauthorized(t *testing.T) {
 	testutils.WithTestDB(t)
-	rr := testutils.MockApiRequestWithAuth(t, "", "GET", "/account/profile", HandleGetProfile, "invalid-token")
+	rr := mockAuthRequest(t, "", "GET", "/account/profile", HandleGetProfile, nil)
 	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 }
 
 func TestHandleUpdateProfile_AllFields(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
 	updateReq := user.UserUpdateRequest{
 		GivenName:         "John",
@@ -55,20 +56,20 @@ func TestHandleUpdateProfile_AllFields(t *testing.T) {
 		AddressCountry:    "USA",
 	}
 	body, _ := json.Marshal(updateReq)
-	rr := testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/profile", HandleUpdateProfile, token)
+	rr := mockAuthRequest(t, string(body), "POST", "/account/profile", HandleUpdateProfile, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestHandleUpdateProfile_Errors(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
 	// Username change not allowed
 	testutils.WithConfigOverride(t, func() {
 		config.Values.AllowUsernameChange = false
 		req := user.UserUpdateRequest{Username: "newusername"}
 		b, _ := json.Marshal(req)
-		rr := testutils.MockApiRequestWithAuth(t, string(b), "POST", "/account/profile", HandleUpdateProfile, token)
+		rr := mockAuthRequest(t, string(b), "POST", "/account/profile", HandleUpdateProfile, info)
 		assert.Equal(t, http.StatusForbidden, rr.Code)
 	})
 
@@ -79,12 +80,12 @@ func TestHandleUpdateProfile_Errors(t *testing.T) {
 		_, _ = db.GetDB().Exec("INSERT INTO users (id, username, email) VALUES (?, ?, ?)", otherUserID, "other", "other@test.com")
 		req := user.UserUpdateRequest{Email: "other@test.com"}
 		b, _ := json.Marshal(req)
-		rr := testutils.MockApiRequestWithAuth(t, string(b), "POST", "/account/profile", HandleUpdateProfile, token)
+		rr := mockAuthRequest(t, string(b), "POST", "/account/profile", HandleUpdateProfile, info)
 		assert.Equal(t, http.StatusConflict, rr.Code)
 	})
-	
+
 	// Invalid JSON
-	rr := testutils.MockApiRequestWithAuth(t, "{invalid", "POST", "/account/profile", HandleUpdateProfile, token)
+	rr := mockAuthRequest(t, "{invalid", "POST", "/account/profile", HandleUpdateProfile, info)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 
 	// Validation error
@@ -92,14 +93,14 @@ func TestHandleUpdateProfile_Errors(t *testing.T) {
 		config.Values.AllowUsernameChange = true
 		req := user.UserUpdateRequest{Username: "a"} // too short
 		b, _ := json.Marshal(req)
-		rr := testutils.MockApiRequestWithAuth(t, string(b), "POST", "/account/profile", HandleUpdateProfile, token)
+		rr := mockAuthRequest(t, string(b), "POST", "/account/profile", HandleUpdateProfile, info)
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
 	})
 }
 
 func TestHandleUpdatePassword(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("current-password"), bcrypt.DefaultCost)
 	_, _ = db.GetDB().Exec("UPDATE users SET password = ? WHERE id = ?", string(hashedPassword), usr.ID)
@@ -109,26 +110,26 @@ func TestHandleUpdatePassword(t *testing.T) {
 		NewPassword:     "new-secure-password123",
 	}
 	body, _ := json.Marshal(updateReq)
-	rr := testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/password", HandleUpdatePassword, token)
+	rr := mockAuthRequest(t, string(body), "POST", "/account/password", HandleUpdatePassword, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// Invalid current password (returns 403)
 	updateReq.CurrentPassword = "wrong"
 	body, _ = json.Marshal(updateReq)
-	rr = testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/password", HandleUpdatePassword, token)
+	rr = mockAuthRequest(t, string(body), "POST", "/account/password", HandleUpdatePassword, info)
 	assert.Equal(t, http.StatusForbidden, rr.Code)
 
 	// Invalid new password (too short) — must pass current password check first
 	updateReq.CurrentPassword = "current-password"
 	updateReq.NewPassword = "short"
 	body, _ = json.Marshal(updateReq)
-	rr = testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/password", HandleUpdatePassword, token)
+	rr = mockAuthRequest(t, string(body), "POST", "/account/password", HandleUpdatePassword, info)
 	assert.Contains(t, []int{http.StatusBadRequest, http.StatusForbidden}, rr.Code)
 }
 
 func TestHandleUpdatePassword_NoPassword(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	// User has no password (passkey user)
 	_, _ = db.GetDB().Exec("UPDATE users SET password = '' WHERE id = ?", usr.ID)
@@ -138,21 +139,21 @@ func TestHandleUpdatePassword_NoPassword(t *testing.T) {
 		NewPassword:     "new-password",
 	}
 	body, _ := json.Marshal(updateReq)
-	rr := testutils.MockApiRequestWithAuth(t, string(body), "POST", "/account/password", HandleUpdatePassword, token)
+	rr := mockAuthRequest(t, string(body), "POST", "/account/password", HandleUpdatePassword, info)
 	assert.Equal(t, http.StatusForbidden, rr.Code)
 }
 
 func TestHandleGetProfile_Success(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, u := setupTestUserAndSession(t)
+	_, u, info := setupTestUserAndSession(t)
 
 	req := httptest.NewRequest("GET", "/account/api/profile", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	HandleGetProfile(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	
+
 	var resp model.ApiResponse[user.User]
 	err := json.Unmarshal(rr.Body.Bytes(), &resp)
 	require.NoError(t, err)
@@ -164,14 +165,14 @@ func TestHandleUpdateProfile_DbError(t *testing.T) {
 	testutils.WithConfigOverride(t, func() {
 		config.Values.AllowEmailChange = true
 	})
-	token, _ := setupTestUserAndSession(t)
-	
+	_, _, info := setupTestUserAndSession(t)
+
 	req := user.UserUpdateRequest{GivenName: "New Name"}
 	body, _ := json.Marshal(req)
-	
+
 	// Close DB to trigger error in UpdateUser
 	db.CloseDB()
 
-	rr := testutils.MockApiRequestWithAuth(t, string(body), "PUT", "/account/api/profile", HandleUpdateProfile, token)
-	assert.Equal(t, http.StatusUnauthorized, rr.Code) // GetUserFromRequest fails with 401 if DB closed
+	rr := mockAuthRequest(t, string(body), "PUT", "/account/api/profile", HandleUpdateProfile, info)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code) // Auth from context succeeds, UpdateUser fails with DB closed
 }

--- a/pkg/account/sessions.go
+++ b/pkg/account/sessions.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/eugenioenko/autentico/pkg/api"
-	"github.com/eugenioenko/autentico/pkg/bearer"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/idpsession"
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/model"
 	"github.com/eugenioenko/autentico/pkg/user"
 	"github.com/eugenioenko/autentico/pkg/utils"
@@ -35,9 +35,9 @@ func currentIdpSessionID(r *http.Request) string {
 // @Failure 401 {object} model.ApiError
 // @Router /account/api/sessions [get]
 func HandleListSessions(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 
@@ -92,9 +92,9 @@ func HandleListSessions(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} model.ApiError
 // @Router /account/api/sessions/{id} [delete]
 func HandleRevokeSession(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 
@@ -143,13 +143,13 @@ func HandleRevokeSession(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} model.ApiError
 // @Router /account/api/sessions/revoke-others [post]
 func HandleRevokeOtherSessions(w http.ResponseWriter, r *http.Request) {
-	v, err := bearer.ValidateBearer(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	info := middleware.AuthInfoFromContext(r.Context())
+	if info == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 
-	if err := user.RevokeOtherUserAccess(v.Session.UserID, v.Token); err != nil {
+	if err := user.RevokeOtherUserAccess(info.User.ID, info.Token); err != nil {
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
 	}

--- a/pkg/account/sessions_test.go
+++ b/pkg/account/sessions_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/idpsession"
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/model"
 	"github.com/eugenioenko/autentico/pkg/user"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
@@ -44,14 +45,14 @@ func linkOAuthSessionToIdp(t *testing.T, usr *user.User, idpSessionID, accessTok
 
 func TestHandleListSessions_ReturnsIdpSessions(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	idpA := createIdpSessionFor(t, usr)
 	_ = linkOAuthSessionToIdp(t, usr, idpA, "at-a1")
 	_ = linkOAuthSessionToIdp(t, usr, idpA, "at-a2")
 	idpB := createIdpSessionFor(t, usr)
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "GET", "/account/api/sessions", HandleListSessions, token)
+	rr := mockAuthRequest(t, "", "GET", "/account/api/sessions", HandleListSessions, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	var resp model.ApiResponse[model.ListResponse[SessionResponse]]
@@ -68,7 +69,7 @@ func TestHandleListSessions_ReturnsIdpSessions(t *testing.T) {
 
 func TestHandleListSessions_ExcludesDeactivatedAndOtherUsers(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	// Active IdP session for this user — must appear.
 	mine := createIdpSessionFor(t, usr)
@@ -86,7 +87,7 @@ func TestHandleListSessions_ExcludesDeactivatedAndOtherUsers(t *testing.T) {
 	require.NoError(t, err)
 	_ = createIdpSessionFor(t, other)
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "GET", "/account/api/sessions", HandleListSessions, token)
+	rr := mockAuthRequest(t, "", "GET", "/account/api/sessions", HandleListSessions, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	var resp model.ApiResponse[model.ListResponse[SessionResponse]]
@@ -97,12 +98,12 @@ func TestHandleListSessions_ExcludesDeactivatedAndOtherUsers(t *testing.T) {
 
 func TestHandleListSessions_MarksCurrentSessionFromCookie(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 	current := createIdpSessionFor(t, usr)
 	other := createIdpSessionFor(t, usr)
 
 	req := httptest.NewRequest("GET", "/account/api/sessions", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	req.AddCookie(&http.Cookie{
 		Name:  config.GetBootstrap().AuthIdpSessionCookieName,
 		Value: current,
@@ -125,7 +126,7 @@ func TestHandleListSessions_MarksCurrentSessionFromCookie(t *testing.T) {
 
 func TestHandleListSessions_ExcludesIdleExpired(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 	testutils.WithConfigOverride(t, func() {
 		config.Values.AuthSsoSessionIdleTimeout = 30 * time.Minute
 	})
@@ -140,7 +141,7 @@ func TestHandleListSessions_ExcludesIdleExpired(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "GET", "/account/api/sessions", HandleListSessions, token)
+	rr := mockAuthRequest(t, "", "GET", "/account/api/sessions", HandleListSessions, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	var resp model.ApiResponse[model.ListResponse[SessionResponse]]
@@ -151,13 +152,13 @@ func TestHandleListSessions_ExcludesIdleExpired(t *testing.T) {
 
 func TestHandleListSessions_Unauthorized(t *testing.T) {
 	testutils.WithTestDB(t)
-	rr := testutils.MockApiRequestWithAuth(t, "", "GET", "/account/api/sessions", HandleListSessions, "invalid-token")
+	rr := mockAuthRequest(t, "", "GET", "/account/api/sessions", HandleListSessions, nil)
 	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 }
 
 func TestHandleRevokeSession_CascadesChildSessionsAndTokens(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	target := createIdpSessionFor(t, usr)
 	childSession := linkOAuthSessionToIdp(t, usr, target, "at-child")
@@ -175,7 +176,7 @@ func TestHandleRevokeSession_CascadesChildSessionsAndTokens(t *testing.T) {
 	mux.HandleFunc("DELETE /account/api/sessions/{id}", HandleRevokeSession)
 
 	req := httptest.NewRequest("DELETE", "/account/api/sessions/"+target, nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
@@ -204,14 +205,14 @@ func TestHandleRevokeSession_CascadesChildSessionsAndTokens(t *testing.T) {
 
 func TestHandleRevokeSession_CurrentDevice_ClearsCookie(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 	current := createIdpSessionFor(t, usr)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /account/api/sessions/{id}", HandleRevokeSession)
 
 	req := httptest.NewRequest("DELETE", "/account/api/sessions/"+current, nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	req.AddCookie(&http.Cookie{
 		Name:  config.GetBootstrap().AuthIdpSessionCookieName,
 		Value: current,
@@ -234,13 +235,13 @@ func TestHandleRevokeSession_CurrentDevice_ClearsCookie(t *testing.T) {
 
 func TestHandleRevokeSession_NotFound(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /account/api/sessions/{id}", HandleRevokeSession)
 
 	req := httptest.NewRequest("DELETE", "/account/api/sessions/nonexistent", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusNotFound, rr.Code)
@@ -248,7 +249,7 @@ func TestHandleRevokeSession_NotFound(t *testing.T) {
 
 func TestHandleRevokeSession_Forbidden_NotOwner(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
 	testutils.InsertTestUser(t, "other-user-id")
 	other, err := user.UserByID("other-user-id")
@@ -259,7 +260,7 @@ func TestHandleRevokeSession_Forbidden_NotOwner(t *testing.T) {
 	mux.HandleFunc("DELETE /account/api/sessions/{id}", HandleRevokeSession)
 
 	req := httptest.NewRequest("DELETE", "/account/api/sessions/"+otherIdp, nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 
@@ -268,10 +269,10 @@ func TestHandleRevokeSession_Forbidden_NotOwner(t *testing.T) {
 
 func TestHandleRevokeSession_MissingID(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
 	req := httptest.NewRequest("DELETE", "/account/api/sessions/", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	HandleRevokeSession(rr, req)
 
@@ -281,7 +282,7 @@ func TestHandleRevokeSession_MissingID(t *testing.T) {
 
 func TestHandleRevokeOtherSessions_RevokesOthersKeepsCurrent(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	// Create two other IdP sessions with child OAuth sessions + tokens.
 	idpOther1 := createIdpSessionFor(t, usr)
@@ -306,7 +307,7 @@ func TestHandleRevokeOtherSessions_RevokesOthersKeepsCurrent(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "POST", "/account/api/sessions/revoke-others", HandleRevokeOtherSessions, token)
+	rr := mockAuthRequest(t, "", "POST", "/account/api/sessions/revoke-others", HandleRevokeOtherSessions, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "All other sessions revoked")
 
@@ -318,13 +319,13 @@ func TestHandleRevokeOtherSessions_RevokesOthersKeepsCurrent(t *testing.T) {
 	assert.NotNil(t, revoked2)
 
 	// Current session's token should NOT be revoked — verify by re-listing sessions.
-	rr2 := testutils.MockApiRequestWithAuth(t, "", "GET", "/account/api/sessions", HandleListSessions, token)
+	rr2 := mockAuthRequest(t, "", "GET", "/account/api/sessions", HandleListSessions, info)
 	assert.Equal(t, http.StatusOK, rr2.Code, "current session must remain valid after revoking others")
 }
 
 func TestHandleRevokeOtherSessions_Unauthorized(t *testing.T) {
 	testutils.WithTestDB(t)
-	rr := testutils.MockApiRequestWithAuth(t, "", "POST", "/account/api/sessions/revoke-others", HandleRevokeOtherSessions, "bad-token")
+	rr := mockAuthRequest(t, "", "POST", "/account/api/sessions/revoke-others", HandleRevokeOtherSessions, nil)
 	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 }
 

--- a/pkg/account/trusted_devices.go
+++ b/pkg/account/trusted_devices.go
@@ -3,7 +3,7 @@ package account
 import (
 	"net/http"
 
-	"github.com/eugenioenko/autentico/pkg/bearer"
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/trusteddevice"
 	"github.com/eugenioenko/autentico/pkg/utils"
 )
@@ -18,9 +18,9 @@ import (
 // @Failure 401 {object} model.ApiError
 // @Router /account/api/trusted-devices [get]
 func HandleListTrustedDevices(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 
@@ -57,9 +57,9 @@ func HandleListTrustedDevices(w http.ResponseWriter, r *http.Request) {
 // @Failure 403 {object} model.ApiError
 // @Router /account/api/trusted-devices/{id} [delete]
 func HandleRevokeTrustedDevice(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 

--- a/pkg/account/trusted_devices_test.go
+++ b/pkg/account/trusted_devices_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/trusteddevice"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
 	"github.com/stretchr/testify/assert"
@@ -13,7 +14,7 @@ import (
 
 func TestHandleListTrustedDevices(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	_ = trusteddevice.CreateTrustedDevice(trusteddevice.TrustedDevice{
 		ID:         "td1",
@@ -22,13 +23,13 @@ func TestHandleListTrustedDevices(t *testing.T) {
 		ExpiresAt:  time.Now().Add(time.Hour),
 	})
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "GET", "/account/api/trusted-devices", HandleListTrustedDevices, token)
+	rr := mockAuthRequest(t, "", "GET", "/account/api/trusted-devices", HandleListTrustedDevices, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestHandleRevokeTrustedDevice(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	_ = trusteddevice.CreateTrustedDevice(trusteddevice.TrustedDevice{
 		ID:         "td1",
@@ -41,14 +42,14 @@ func TestHandleRevokeTrustedDevice(t *testing.T) {
 	mux.HandleFunc("DELETE /account/api/trusted-devices/{id}", HandleRevokeTrustedDevice)
 
 	req := httptest.NewRequest("DELETE", "/account/api/trusted-devices/td1", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// Not owned
 	req = httptest.NewRequest("DELETE", "/account/api/trusted-devices/other", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr = httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusForbidden, rr.Code)
@@ -56,27 +57,24 @@ func TestHandleRevokeTrustedDevice(t *testing.T) {
 
 func TestHandleRevokeTrustedDevice_MissingID(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
-	req := httptest.NewRequest("DELETE", "/account/api/trusted-devices/", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	rr := httptest.NewRecorder()
-	HandleRevokeTrustedDevice(rr, req)
+	rr := mockAuthRequest(t, "", "DELETE", "/account/api/trusted-devices/", HandleRevokeTrustedDevice, info)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
 func TestHandleRevokeTrustedDevice_Extra(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /account/api/trusted-devices/{id}", HandleRevokeTrustedDevice)
 
 	// Revoke nonexistent
 	req := httptest.NewRequest("DELETE", "/account/api/trusted-devices/none", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req = middleware.WithAuthInfo(req, info)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
-	
+
 	assert.Equal(t, http.StatusForbidden, rr.Code)
 }

--- a/pkg/appsettings/handler.go
+++ b/pkg/appsettings/handler.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/eugenioenko/autentico/pkg/audit"
-	"github.com/eugenioenko/autentico/pkg/bearer"
 	"github.com/eugenioenko/autentico/pkg/email"
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/utils"
 )
 
@@ -249,9 +249,9 @@ func HandleImportApply(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} model.ApiError
 // @Router /admin/api/settings/test-smtp [post]
 func HandleTestSmtp(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 

--- a/pkg/deletion/handler.go
+++ b/pkg/deletion/handler.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/eugenioenko/autentico/pkg/api"
 	"github.com/eugenioenko/autentico/pkg/audit"
-	"github.com/eugenioenko/autentico/pkg/bearer"
 	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/model"
 	"github.com/eugenioenko/autentico/pkg/utils"
 )
@@ -28,9 +28,9 @@ import (
 // @Failure 500 {object} model.ApiError
 // @Router /account/api/deletion-request [post]
 func HandleRequestDeletion(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 
@@ -79,9 +79,9 @@ func HandleRequestDeletion(w http.ResponseWriter, r *http.Request) {
 // @Failure 401 {object} model.ApiError
 // @Router /account/api/deletion-request [get]
 func HandleGetDeletionRequest(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 
@@ -107,9 +107,9 @@ func HandleGetDeletionRequest(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} model.ApiError
 // @Router /account/api/deletion-request [delete]
 func HandleCancelDeletionRequest(w http.ResponseWriter, r *http.Request) {
-	usr, err := bearer.UserFromRequest(r)
-	if err != nil {
-		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", err.Error())
+	usr := middleware.UserFromContext(r.Context())
+	if usr == nil {
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "unauthorized", "authentication required")
 		return
 	}
 

--- a/pkg/deletion/handler_test.go
+++ b/pkg/deletion/handler_test.go
@@ -1,6 +1,7 @@
 package deletion
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/jwtutil"
 	"github.com/eugenioenko/autentico/pkg/key"
+	"github.com/eugenioenko/autentico/pkg/middleware"
 	"github.com/eugenioenko/autentico/pkg/model"
 	"github.com/eugenioenko/autentico/pkg/session"
 	"github.com/eugenioenko/autentico/pkg/user"
@@ -21,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupTestUserAndSession(t *testing.T) (string, *user.User) {
+func setupTestUserAndSession(t *testing.T) (string, *user.User, *middleware.AuthInfo) {
 	t.Helper()
 	userID := uuid.New().String()
 	testutils.InsertTestUser(t, userID)
@@ -59,16 +61,35 @@ func setupTestUserAndSession(t *testing.T) (string, *user.User) {
 	`, "tok-"+sessionID[:8], usr.ID, tokenString, "refresh-"+sessionID[:8], now.Add(time.Hour), now.Add(time.Hour), now)
 	require.NoError(t, err)
 
-	return tokenString, usr
+	info := &middleware.AuthInfo{
+		User:    usr,
+		Token:   tokenString,
+		Claims:  claims,
+		Session: &sess,
+	}
+
+	return tokenString, usr, info
+}
+
+func mockAuthRequest(t *testing.T, body, method, url string, handler http.HandlerFunc, info *middleware.AuthInfo) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, url, bytes.NewBuffer([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	if info != nil {
+		req = middleware.WithAuthInfo(req, info)
+	}
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+	return rr
 }
 
 // --- HandleRequestDeletion ---
 
 func TestHandleRequestDeletion_AdminApprovalMode(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
-	rr := testutils.MockApiRequestWithAuth(t, `{}`, "POST", "/account/api/deletion-request", HandleRequestDeletion, token)
+	rr := mockAuthRequest(t, `{}`, "POST", "/account/api/deletion-request", HandleRequestDeletion, info)
 	assert.Equal(t, http.StatusCreated, rr.Code)
 
 	var resp model.ApiResponse[DeletionRequestResponse]
@@ -78,9 +99,9 @@ func TestHandleRequestDeletion_AdminApprovalMode(t *testing.T) {
 
 func TestHandleRequestDeletion_WithReason(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
-	rr := testutils.MockApiRequestWithAuth(t, `{"reason":"no longer needed"}`, "POST", "/account/api/deletion-request", HandleRequestDeletion, token)
+	rr := mockAuthRequest(t, `{"reason":"no longer needed"}`, "POST", "/account/api/deletion-request", HandleRequestDeletion, info)
 	assert.Equal(t, http.StatusCreated, rr.Code)
 
 	var resp model.ApiResponse[DeletionRequestResponse]
@@ -92,13 +113,13 @@ func TestHandleRequestDeletion_WithReason(t *testing.T) {
 
 func TestHandleRequestDeletion_SelfServiceMode(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	testutils.WithConfigOverride(t, func() {
 		config.Values.AllowSelfServiceDeletion = true
 	})
 
-	rr := testutils.MockApiRequestWithAuth(t, `{}`, "POST", "/account/api/deletion-request", HandleRequestDeletion, token)
+	rr := mockAuthRequest(t, `{}`, "POST", "/account/api/deletion-request", HandleRequestDeletion, info)
 	assert.Equal(t, http.StatusNoContent, rr.Code)
 
 	deleted, err := user.UserByID(usr.ID)
@@ -108,18 +129,18 @@ func TestHandleRequestDeletion_SelfServiceMode(t *testing.T) {
 
 func TestHandleRequestDeletion_AlreadyPending(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	_, err := CreateDeletionRequest(usr.ID, nil)
 	require.NoError(t, err)
 
-	rr := testutils.MockApiRequestWithAuth(t, `{}`, "POST", "/account/api/deletion-request", HandleRequestDeletion, token)
+	rr := mockAuthRequest(t, `{}`, "POST", "/account/api/deletion-request", HandleRequestDeletion, info)
 	assert.Equal(t, http.StatusConflict, rr.Code)
 }
 
 func TestHandleRequestDeletion_Unauthorized(t *testing.T) {
 	testutils.WithTestDB(t)
-	rr := testutils.MockApiRequestWithAuth(t, `{}`, "POST", "/account/api/deletion-request", HandleRequestDeletion, "bad-token")
+	rr := mockAuthRequest(t, `{}`, "POST", "/account/api/deletion-request", HandleRequestDeletion, nil)
 	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 }
 
@@ -127,21 +148,21 @@ func TestHandleRequestDeletion_Unauthorized(t *testing.T) {
 
 func TestHandleGetDeletionRequest_NoPendingRequest(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "GET", "/account/api/deletion-request", HandleGetDeletionRequest, token)
+	rr := mockAuthRequest(t, "", "GET", "/account/api/deletion-request", HandleGetDeletionRequest, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestHandleGetDeletionRequest_Found(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	reason := "testing"
 	_, err := CreateDeletionRequest(usr.ID, &reason)
 	require.NoError(t, err)
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "GET", "/account/api/deletion-request", HandleGetDeletionRequest, token)
+	rr := mockAuthRequest(t, "", "GET", "/account/api/deletion-request", HandleGetDeletionRequest, info)
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	var resp model.ApiResponse[DeletionRequestResponse]
@@ -153,7 +174,7 @@ func TestHandleGetDeletionRequest_Found(t *testing.T) {
 
 func TestHandleGetDeletionRequest_Unauthorized(t *testing.T) {
 	testutils.WithTestDB(t)
-	rr := testutils.MockApiRequestWithAuth(t, "", "GET", "/account/api/deletion-request", HandleGetDeletionRequest, "bad-token")
+	rr := mockAuthRequest(t, "", "GET", "/account/api/deletion-request", HandleGetDeletionRequest, nil)
 	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 }
 
@@ -161,12 +182,12 @@ func TestHandleGetDeletionRequest_Unauthorized(t *testing.T) {
 
 func TestHandleCancelDeletionRequest_Success(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, usr := setupTestUserAndSession(t)
+	_, usr, info := setupTestUserAndSession(t)
 
 	_, err := CreateDeletionRequest(usr.ID, nil)
 	require.NoError(t, err)
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "DELETE", "/account/api/deletion-request", HandleCancelDeletionRequest, token)
+	rr := mockAuthRequest(t, "", "DELETE", "/account/api/deletion-request", HandleCancelDeletionRequest, info)
 	assert.Equal(t, http.StatusNoContent, rr.Code)
 
 	req, err := DeletionRequestByUserID(usr.ID)
@@ -176,15 +197,15 @@ func TestHandleCancelDeletionRequest_Success(t *testing.T) {
 
 func TestHandleCancelDeletionRequest_NotFound(t *testing.T) {
 	testutils.WithTestDB(t)
-	token, _ := setupTestUserAndSession(t)
+	_, _, info := setupTestUserAndSession(t)
 
-	rr := testutils.MockApiRequestWithAuth(t, "", "DELETE", "/account/api/deletion-request", HandleCancelDeletionRequest, token)
+	rr := mockAuthRequest(t, "", "DELETE", "/account/api/deletion-request", HandleCancelDeletionRequest, info)
 	assert.Equal(t, http.StatusNotFound, rr.Code)
 }
 
 func TestHandleCancelDeletionRequest_Unauthorized(t *testing.T) {
 	testutils.WithTestDB(t)
-	rr := testutils.MockApiRequestWithAuth(t, "", "DELETE", "/account/api/deletion-request", HandleCancelDeletionRequest, "bad-token")
+	rr := mockAuthRequest(t, "", "DELETE", "/account/api/deletion-request", HandleCancelDeletionRequest, nil)
 	assert.Equal(t, http.StatusUnauthorized, rr.Code)
 }
 
@@ -206,8 +227,8 @@ func TestHandleListDeletionRequests_Empty(t *testing.T) {
 
 func TestHandleListDeletionRequests_WithRequests(t *testing.T) {
 	testutils.WithTestDB(t)
-	_, usr1 := setupTestUserAndSession(t)
-	_, usr2 := setupTestUserAndSession(t)
+	_, usr1, _ := setupTestUserAndSession(t)
+	_, usr2, _ := setupTestUserAndSession(t)
 
 	_, err := CreateDeletionRequest(usr1.ID, nil)
 	require.NoError(t, err)
@@ -230,8 +251,8 @@ func TestHandleListDeletionRequests_WithRequests(t *testing.T) {
 
 func TestHandleListDeletionRequests_Search(t *testing.T) {
 	testutils.WithTestDB(t)
-	_, usr1 := setupTestUserAndSession(t)
-	_, usr2 := setupTestUserAndSession(t)
+	_, usr1, _ := setupTestUserAndSession(t)
+	_, usr2, _ := setupTestUserAndSession(t)
 
 	_, err := CreateDeletionRequest(usr1.ID, nil)
 	require.NoError(t, err)
@@ -252,8 +273,8 @@ func TestHandleListDeletionRequests_Search(t *testing.T) {
 
 func TestHandleListDeletionRequests_SortByUsername(t *testing.T) {
 	testutils.WithTestDB(t)
-	_, usr1 := setupTestUserAndSession(t)
-	_, usr2 := setupTestUserAndSession(t)
+	_, usr1, _ := setupTestUserAndSession(t)
+	_, usr2, _ := setupTestUserAndSession(t)
 
 	_, err := CreateDeletionRequest(usr1.ID, nil)
 	require.NoError(t, err)
@@ -273,8 +294,8 @@ func TestHandleListDeletionRequests_SortByUsername(t *testing.T) {
 
 func TestHandleListDeletionRequests_Pagination(t *testing.T) {
 	testutils.WithTestDB(t)
-	_, usr1 := setupTestUserAndSession(t)
-	_, usr2 := setupTestUserAndSession(t)
+	_, usr1, _ := setupTestUserAndSession(t)
+	_, usr2, _ := setupTestUserAndSession(t)
 
 	_, err := CreateDeletionRequest(usr1.ID, nil)
 	require.NoError(t, err)
@@ -296,7 +317,7 @@ func TestHandleListDeletionRequests_Pagination(t *testing.T) {
 
 func TestHandleApproveDeletionRequest_Success(t *testing.T) {
 	testutils.WithTestDB(t)
-	_, usr := setupTestUserAndSession(t)
+	_, usr, _ := setupTestUserAndSession(t)
 
 	dr, err := CreateDeletionRequest(usr.ID, nil)
 	require.NoError(t, err)
@@ -332,7 +353,7 @@ func TestHandleApproveDeletionRequest_NotFound(t *testing.T) {
 
 func TestHandleAdminCancelDeletionRequest_Success(t *testing.T) {
 	testutils.WithTestDB(t)
-	_, usr := setupTestUserAndSession(t)
+	_, usr, _ := setupTestUserAndSession(t)
 
 	dr, err := CreateDeletionRequest(usr.ID, nil)
 	require.NoError(t, err)

--- a/pkg/middleware/account_auth.go
+++ b/pkg/middleware/account_auth.go
@@ -76,6 +76,12 @@ func AccountAuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
+		r = setAuthInfo(r, &AuthInfo{
+			User:    usr,
+			Token:   tokenString,
+			Claims:  claims,
+			Session: sess,
+		})
 		next.ServeHTTP(w, r)
 	})
 }

--- a/pkg/middleware/admin_auth.go
+++ b/pkg/middleware/admin_auth.go
@@ -82,6 +82,12 @@ func AdminAuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
+		r = setAuthInfo(r, &AuthInfo{
+			User:    usr,
+			Token:   tokenString,
+			Claims:  claims,
+			Session: sess,
+		})
 		next.ServeHTTP(w, r)
 	})
 }

--- a/pkg/middleware/auth_context.go
+++ b/pkg/middleware/auth_context.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/eugenioenko/autentico/pkg/jwtutil"
+	"github.com/eugenioenko/autentico/pkg/session"
+	"github.com/eugenioenko/autentico/pkg/user"
+)
+
+type authContextKey string
+
+const authInfoKey authContextKey = "auth_info"
+
+type AuthInfo struct {
+	User    *user.User
+	Token   string
+	Claims  *jwtutil.AccessTokenClaims
+	Session *session.Session
+}
+
+func setAuthInfo(r *http.Request, info *AuthInfo) *http.Request {
+	ctx := context.WithValue(r.Context(), authInfoKey, info)
+	return r.WithContext(ctx)
+}
+
+func AuthInfoFromContext(ctx context.Context) *AuthInfo {
+	info, _ := ctx.Value(authInfoKey).(*AuthInfo)
+	return info
+}
+
+func UserFromContext(ctx context.Context) *user.User {
+	if info := AuthInfoFromContext(ctx); info != nil {
+		return info.User
+	}
+	return nil
+}
+
+func WithAuthInfo(r *http.Request, info *AuthInfo) *http.Request {
+	return setAuthInfo(r, info)
+}

--- a/pkg/middleware/auth_context_test.go
+++ b/pkg/middleware/auth_context_test.go
@@ -1,0 +1,89 @@
+package middleware
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eugenioenko/autentico/pkg/jwtutil"
+	"github.com/eugenioenko/autentico/pkg/session"
+	"github.com/eugenioenko/autentico/pkg/user"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthInfoFromContext_Missing(t *testing.T) {
+	ctx := context.Background()
+	assert.Nil(t, AuthInfoFromContext(ctx))
+}
+
+func TestUserFromContext_Missing(t *testing.T) {
+	ctx := context.Background()
+	assert.Nil(t, UserFromContext(ctx))
+}
+
+func TestAuthInfoFromContext_Present(t *testing.T) {
+	info := &AuthInfo{
+		User:    &user.User{ID: "u1", Username: "alice"},
+		Token:   "tok-123",
+		Claims:  &jwtutil.AccessTokenClaims{UserID: "u1", SessionID: "s1"},
+		Session: &session.Session{ID: "s1", UserID: "u1"},
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req = setAuthInfo(req, info)
+
+	got := AuthInfoFromContext(req.Context())
+	assert.NotNil(t, got)
+	assert.Equal(t, "u1", got.User.ID)
+	assert.Equal(t, "tok-123", got.Token)
+	assert.Equal(t, "s1", got.Claims.SessionID)
+	assert.Equal(t, "s1", got.Session.ID)
+}
+
+func TestUserFromContext_Present(t *testing.T) {
+	info := &AuthInfo{
+		User: &user.User{ID: "u1", Username: "alice"},
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req = setAuthInfo(req, info)
+
+	usr := UserFromContext(req.Context())
+	assert.NotNil(t, usr)
+	assert.Equal(t, "u1", usr.ID)
+	assert.Equal(t, "alice", usr.Username)
+}
+
+func TestWithAuthInfo_SameAsSetAuthInfo(t *testing.T) {
+	info := &AuthInfo{
+		User:  &user.User{ID: "u1"},
+		Token: "tok",
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req = WithAuthInfo(req, info)
+
+	got := AuthInfoFromContext(req.Context())
+	assert.Equal(t, info, got)
+}
+
+func TestSetAuthInfo_Overwrites(t *testing.T) {
+	first := &AuthInfo{User: &user.User{ID: "u1"}}
+	second := &AuthInfo{User: &user.User{ID: "u2"}}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req = setAuthInfo(req, first)
+	req = setAuthInfo(req, second)
+
+	got := AuthInfoFromContext(req.Context())
+	assert.Equal(t, "u2", got.User.ID)
+}
+
+func TestUserFromContext_NilUser(t *testing.T) {
+	info := &AuthInfo{User: nil, Token: "tok"}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req = setAuthInfo(req, info)
+
+	assert.Nil(t, UserFromContext(req.Context()))
+}

--- a/tests/security/security_account_test.go
+++ b/tests/security/security_account_test.go
@@ -41,7 +41,7 @@ func doAccountRequest(t *testing.T, ts *TestServer, method, token, path string, 
 func TestAccount_ProfileRoleEscalation(t *testing.T) {
 	ts := startTestServer(t)
 	createTestUser(t, "escuser", "password123", "escuser@test.com")
-	tokenResp := obtainTokensViaROPC(t, ts, "test-client", "escuser", "password123")
+	tokenResp := obtainTokensViaROPC(t, ts, "autentico-account", "escuser", "password123")
 
 	payloads := []struct {
 		name string
@@ -81,7 +81,7 @@ func TestAccount_SessionIDOR(t *testing.T) {
 
 	createTestUser(t, "idoruser_a", "password123", "idora@test.com")
 	userB := createTestUser(t, "idoruser_b", "password123", "idorb@test.com")
-	tokenA := obtainTokensViaROPC(t, ts, "test-client", "idoruser_a", "password123")
+	tokenA := obtainTokensViaROPC(t, ts, "autentico-account", "idoruser_a", "password123")
 
 	victimSessionID := "victim-session-idor"
 	err := idpsession.CreateIdpSession(idpsession.IdpSession{
@@ -106,7 +106,7 @@ func TestAccount_SessionIDOR(t *testing.T) {
 func TestAccount_SessionRevoke_NonexistentID(t *testing.T) {
 	ts := startTestServer(t)
 	createTestUser(t, "sessuser", "password123", "sessuser@test.com")
-	tokenResp := obtainTokensViaROPC(t, ts, "test-client", "sessuser", "password123")
+	tokenResp := obtainTokensViaROPC(t, ts, "autentico-account", "sessuser", "password123")
 
 	status, _ := doAccountRequest(t, ts, "DELETE", tokenResp.AccessToken,
 		"/account/api/sessions/nonexistent-session-id-12345", "")
@@ -119,7 +119,7 @@ func TestAccount_SessionRevoke_NonexistentID(t *testing.T) {
 func TestAccount_PasswordChange_WrongCurrentPassword(t *testing.T) {
 	ts := startTestServer(t)
 	createTestUser(t, "pwuser", "password123", "pwuser@test.com")
-	tokenResp := obtainTokensViaROPC(t, ts, "test-client", "pwuser", "password123")
+	tokenResp := obtainTokensViaROPC(t, ts, "autentico-account", "pwuser", "password123")
 
 	status, _ := doAccountRequest(t, ts, "POST", tokenResp.AccessToken,
 		"/account/api/password",
@@ -133,7 +133,7 @@ func TestAccount_PasswordChange_WrongCurrentPassword(t *testing.T) {
 func TestAccount_PasswordChange_ShortNewPassword(t *testing.T) {
 	ts := startTestServer(t)
 	createTestUser(t, "pwuser2", "password123", "pwuser2@test.com")
-	tokenResp := obtainTokensViaROPC(t, ts, "test-client", "pwuser2", "password123")
+	tokenResp := obtainTokensViaROPC(t, ts, "autentico-account", "pwuser2", "password123")
 
 	status, _ := doAccountRequest(t, ts, "POST", tokenResp.AccessToken,
 		"/account/api/password",
@@ -202,8 +202,8 @@ func TestAccount_SessionListIsolation(t *testing.T) {
 	ts := startTestServer(t)
 	createTestUser(t, "isolateA", "password123", "isolatea@test.com")
 	createTestUser(t, "isolateB", "password123", "isolateb@test.com")
-	tokenA := obtainTokensViaROPC(t, ts, "test-client", "isolateA", "password123")
-	_ = obtainTokensViaROPC(t, ts, "test-client", "isolateB", "password123")
+	tokenA := obtainTokensViaROPC(t, ts, "autentico-account", "isolateA", "password123")
+	_ = obtainTokensViaROPC(t, ts, "autentico-account", "isolateB", "password123")
 
 	// User A fetches their sessions — should not see user B's sessions
 	status, body := doAccountRequest(t, ts, "GET", tokenA.AccessToken, "/account/api/sessions", "")
@@ -239,7 +239,7 @@ func TestAccount_PasskeyDeleteIDOR(t *testing.T) {
 	ts := startTestServer(t)
 	createTestUser(t, "pkuserA", "password123", "pkusera@test.com")
 	userB := createTestUser(t, "pkuserB", "password123", "pkuserb@test.com")
-	tokenA := obtainTokensViaROPC(t, ts, "test-client", "pkuserA", "password123")
+	tokenA := obtainTokensViaROPC(t, ts, "autentico-account", "pkuserA", "password123")
 
 	fakeCredID := "fake-passkey-cred-id"
 	_, err := db.GetDB().Exec(
@@ -260,7 +260,7 @@ func TestAccount_TrustedDeviceIDOR(t *testing.T) {
 	ts := startTestServer(t)
 	createTestUser(t, "tduserA", "password123", "tdusera@test.com")
 	userB := createTestUser(t, "tduserB", "password123", "tduserb@test.com")
-	tokenA := obtainTokensViaROPC(t, ts, "test-client", "tduserA", "password123")
+	tokenA := obtainTokensViaROPC(t, ts, "autentico-account", "tduserA", "password123")
 
 	fakeDeviceID := "fake-trusted-device-id"
 	_, err := db.GetDB().Exec(
@@ -281,7 +281,7 @@ func TestAccount_TrustedDeviceIDOR(t *testing.T) {
 func TestAccount_ProfileUpdate_XSSInFields(t *testing.T) {
 	ts := startTestServer(t)
 	createTestUser(t, "xssuser", "password123", "xssuser@test.com")
-	tokenResp := obtainTokensViaROPC(t, ts, "test-client", "xssuser", "password123")
+	tokenResp := obtainTokensViaROPC(t, ts, "autentico-account", "xssuser", "password123")
 
 	xssPayload := `{"given_name": "<script>alert(1)</script>", "family_name": "<img src=x onerror=alert(1)>"}`
 
@@ -307,7 +307,7 @@ func TestAccount_ProfileUpdate_XSSInFields(t *testing.T) {
 func TestAccount_PasswordChange_Success(t *testing.T) {
 	ts := startTestServer(t)
 	createTestUser(t, "pwok", "password123", "pwok@test.com")
-	tokenResp := obtainTokensViaROPC(t, ts, "test-client", "pwok", "password123")
+	tokenResp := obtainTokensViaROPC(t, ts, "autentico-account", "pwok", "password123")
 
 	status, _ := doAccountRequest(t, ts, "POST", tokenResp.AccessToken,
 		"/account/api/password",
@@ -333,8 +333,8 @@ func TestAccount_PasswordChange_InvalidatesOtherSessions(t *testing.T) {
 	createTestUser(t, "pwsess", "password123", "pwsess@test.com")
 
 	// Create two independent sessions via ROPC
-	session1 := obtainTokensViaROPC(t, ts, "test-client", "pwsess", "password123")
-	session2 := obtainTokensViaROPC(t, ts, "test-client", "pwsess", "password123")
+	session1 := obtainTokensViaROPC(t, ts, "autentico-account", "pwsess", "password123")
+	session2 := obtainTokensViaROPC(t, ts, "autentico-account", "pwsess", "password123")
 
 	// Both sessions should work before password change
 	s1Status, _ := doAccountRequest(t, ts, "GET", session1.AccessToken, "/account/api/profile", "")

--- a/tests/security/server_test.go
+++ b/tests/security/server_test.go
@@ -64,6 +64,15 @@ func startTestServer(t *testing.T) *TestServer {
 		t.Fatalf("Failed to seed autentico-admin client: %v", err)
 	}
 
+	// Account client (audience accepted by AccountAuthMiddleware)
+	_, err = db.GetDB().Exec(`
+		INSERT INTO clients (id, client_id, client_name, client_type, redirect_uris, post_logout_redirect_uris, grant_types, response_types, scopes, is_active)
+		VALUES ('autentico-account-id', 'autentico-account', 'Autentico Account', 'public', '["http://localhost:3000/account/callback"]', '[]', '["authorization_code","password","refresh_token"]', '["code"]', 'openid profile email offline_access', TRUE)
+	`)
+	if err != nil {
+		t.Fatalf("Failed to seed autentico-account client: %v", err)
+	}
+
 	// Confidential test client
 	hashedSecret, _ := bcrypt.GenerateFromPassword([]byte("sec-secret"), bcrypt.MinCost)
 	_, err = db.GetDB().Exec(`
@@ -149,20 +158,21 @@ func startTestServer(t *testing.T) *TestServer {
 	mux.Handle("POST "+oauth+"/register", middleware.AdminAuthMiddleware(http.HandlerFunc(client.HandleRegister)))
 	mux.Handle("GET "+oauth+"/register/{client_id}", middleware.AdminAuthMiddleware(http.HandlerFunc(client.HandleGetClient)))
 
-	mux.HandleFunc("GET /account/api/profile", account.HandleGetProfile)
-	mux.HandleFunc("PUT /account/api/profile", account.HandleUpdateProfile)
-	mux.HandleFunc("POST /account/api/password", account.HandleUpdatePassword)
-	mux.HandleFunc("GET /account/api/sessions", account.HandleListSessions)
-	mux.HandleFunc("DELETE /account/api/sessions/{id}", account.HandleRevokeSession)
-	mux.HandleFunc("GET /account/api/mfa", account.HandleGetMfaStatus)
-	mux.HandleFunc("POST /account/api/mfa/totp/setup", account.HandleSetupTotp)
-	mux.HandleFunc("POST /account/api/mfa/totp/verify", account.HandleVerifyTotp)
-	mux.HandleFunc("DELETE /account/api/mfa/totp", account.HandleDeleteMfa)
-	mux.HandleFunc("GET /account/api/passkeys", account.HandleListPasskeys)
-	mux.HandleFunc("DELETE /account/api/passkeys/{id}", account.HandleDeletePasskey)
-	mux.HandleFunc("PATCH /account/api/passkeys/{id}", account.HandleRenamePasskey)
-	mux.HandleFunc("GET /account/api/trusted-devices", account.HandleListTrustedDevices)
-	mux.HandleFunc("DELETE /account/api/trusted-devices/{id}", account.HandleRevokeTrustedDevice)
+	mux.Handle("GET /account/api/profile", middleware.AccountAuthMiddleware(http.HandlerFunc(account.HandleGetProfile)))
+	mux.Handle("PUT /account/api/profile", middleware.AccountAuthMiddleware(http.HandlerFunc(account.HandleUpdateProfile)))
+	mux.Handle("POST /account/api/password", middleware.AccountAuthMiddleware(http.HandlerFunc(account.HandleUpdatePassword)))
+	mux.Handle("GET /account/api/sessions", middleware.AccountAuthMiddleware(http.HandlerFunc(account.HandleListSessions)))
+	mux.Handle("DELETE /account/api/sessions/{id}", middleware.AccountAuthMiddleware(http.HandlerFunc(account.HandleRevokeSession)))
+	mux.Handle("POST /account/api/sessions/revoke-others", middleware.AccountAuthMiddleware(http.HandlerFunc(account.HandleRevokeOtherSessions)))
+	mux.Handle("GET /account/api/mfa", middleware.AccountAuthMiddleware(http.HandlerFunc(account.HandleGetMfaStatus)))
+	mux.Handle("POST /account/api/mfa/totp/setup", middleware.AccountAuthMiddleware(http.HandlerFunc(account.HandleSetupTotp)))
+	mux.Handle("POST /account/api/mfa/totp/verify", middleware.AccountAuthMiddleware(http.HandlerFunc(account.HandleVerifyTotp)))
+	mux.Handle("DELETE /account/api/mfa/totp", middleware.AccountAuthMiddleware(http.HandlerFunc(account.HandleDeleteMfa)))
+	mux.Handle("GET /account/api/passkeys", middleware.AccountAuthMiddleware(http.HandlerFunc(account.HandleListPasskeys)))
+	mux.Handle("DELETE /account/api/passkeys/{id}", middleware.AccountAuthMiddleware(http.HandlerFunc(account.HandleDeletePasskey)))
+	mux.Handle("PATCH /account/api/passkeys/{id}", middleware.AccountAuthMiddleware(http.HandlerFunc(account.HandleRenamePasskey)))
+	mux.Handle("GET /account/api/trusted-devices", middleware.AccountAuthMiddleware(http.HandlerFunc(account.HandleListTrustedDevices)))
+	mux.Handle("DELETE /account/api/trusted-devices/{id}", middleware.AccountAuthMiddleware(http.HandlerFunc(account.HandleRevokeTrustedDevice)))
 	mux.HandleFunc("GET /account/api/settings", account.HandleGetSettings)
 
 	mux.Handle("GET /admin/api/users", middleware.AdminAuthMiddleware(http.HandlerFunc(user.HandleListUsers)))


### PR DESCRIPTION
## Summary

Closes #321

- Both auth middlewares (`AdminAuthMiddleware`, `AccountAuthMiddleware`) now store the validated `AuthInfo` (User, Token, Claims, Session) in request context after completing token validation
- All 17 downstream handlers migrated from `bearer.UserFromRequest` / `bearer.ValidateBearer` to `middleware.UserFromContext` / `middleware.AuthInfoFromContext`, eliminating duplicate DB queries per request
- Fixes a pre-existing nil pointer dereference in `HandleVerifyTotp` when `user.UserByID` fails (error was silently ignored)
- Security test server updated to wrap account endpoints with `AccountAuthMiddleware`, matching production routing

## Test plan

- [x] All account handler tests pass (`go test ./pkg/account/...`)
- [x] Middleware tests pass (`go test ./pkg/middleware/...`)
- [x] Deletion handler tests pass (`go test ./pkg/deletion/...`)
- [x] App settings tests pass (`go test ./pkg/appsettings/...`)
- [x] Security tests pass (`go test ./tests/security/...`)
- [x] Verify no remaining `bearer.UserFromRequest` / `bearer.ValidateBearer` calls in migrated packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)