### PR TITLE
fix: validate path parameters before database lookups

### DIFF
--- a/pkg/federation/admin_handler.go
+++ b/pkg/federation/admin_handler.go
@@ -110,6 +110,10 @@ func HandleCreateProvider(w http.ResponseWriter, r *http.Request) {
 // @Router /admin/api/federation/{id} [get]
 func HandleGetProvider(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	if id == "" {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Missing provider id")
+		return
+	}
 	p, err := FederationProviderByID(id)
 	if err != nil {
 		utils.WriteErrorResponse(w, http.StatusNotFound, "not_found", "Federation provider not found")
@@ -131,6 +135,10 @@ func HandleGetProvider(w http.ResponseWriter, r *http.Request) {
 // @Router /admin/api/federation/{id} [put]
 func HandleUpdateProvider(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	if id == "" {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Missing provider id")
+		return
+	}
 	if _, err := FederationProviderByID(id); err != nil {
 		utils.WriteErrorResponse(w, http.StatusNotFound, "not_found", "Federation provider not found")
 		return
@@ -171,6 +179,10 @@ func HandleUpdateProvider(w http.ResponseWriter, r *http.Request) {
 // @Router /admin/api/federation/{id} [delete]
 func HandleDeleteProvider(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	if id == "" {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Missing provider id")
+		return
+	}
 	if _, err := FederationProviderByID(id); err != nil {
 		utils.WriteErrorResponse(w, http.StatusNotFound, "not_found", "Federation provider not found")
 		return

--- a/pkg/federation/handler.go
+++ b/pkg/federation/handler.go
@@ -30,6 +30,10 @@ import (
 // directly to the URL, treating the SVG as a top-level document.
 func HandleFederationIcon(w http.ResponseWriter, r *http.Request) {
 	providerID := r.PathValue("id")
+	if providerID == "" {
+		http.NotFound(w, r)
+		return
+	}
 	provider, err := FederationProviderByID(providerID)
 	if err != nil || !provider.Enabled || !provider.IconSVG.Valid || provider.IconSVG.String == "" {
 		http.NotFound(w, r)
@@ -116,6 +120,10 @@ func HandleFederationBegin(w http.ResponseWriter, r *http.Request) {
 // resolves the local user, and issues an authorization code.
 func HandleFederationCallback(w http.ResponseWriter, r *http.Request) {
 	providerID := r.PathValue("id")
+	if providerID == "" {
+		http.Error(w, "missing provider id", http.StatusBadRequest)
+		return
+	}
 	q := r.URL.Query()
 
 	rawState := q.Get("state")


### PR DESCRIPTION
## Summary
- Added empty-string validation for `PathValue("id")` in 5 federation handlers that were passing unvalidated IDs directly to database lookups
- `HandleGetProvider`, `HandleUpdateProvider`, `HandleDeleteProvider` now return 400 for missing ID
- `HandleFederationIcon` returns 404 for missing ID (matching its existing error style)
- `HandleFederationCallback` returns 400 for missing provider ID
- All other packages (`user`, `client`, `group`, `session`, etc.) already had proper validation

## Test plan
- [ ] Verify federation provider CRUD endpoints reject requests with missing/empty ID
- [ ] Verify federation icon endpoint returns 404 for missing ID
- [ ] Verify federation callback rejects empty provider ID
- [ ] Run `go test ./pkg/federation/...` — all 33 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)