### PR TITLE
fix: log and handle previously swallowed database errors

### DIFF
--- a/pkg/admin/stats.go
+++ b/pkg/admin/stats.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/eugenioenko/autentico/pkg/db"
@@ -36,14 +37,30 @@ func HandleStats(w http.ResponseWriter, r *http.Request) {
 
 	d := db.GetDB()
 
-	_ = d.QueryRow(`SELECT COUNT(*) FROM users WHERE deactivated_at IS NULL`).Scan(&stats.TotalUsers)
-	_ = d.QueryRow(`SELECT COUNT(*) FROM clients WHERE is_active = TRUE`).Scan(&stats.ActiveClients)
-	_ = d.QueryRow(`SELECT COUNT(*) FROM idp_sessions WHERE deactivated_at IS NULL`).Scan(&stats.ActiveDevices)
-	_ = d.QueryRow(`SELECT COUNT(*) FROM tokens WHERE revoked_at IS NULL AND access_token_expires_at > CURRENT_TIMESTAMP`).Scan(&stats.ActiveTokens)
-	_ = d.QueryRow(`SELECT COUNT(*) FROM sessions WHERE created_at > datetime('now', '-24 hours')`).Scan(&stats.RecentLogins)
-	_ = d.QueryRow(`SELECT COUNT(*) FROM deletion_requests`).Scan(&stats.PendingDeletionRequests)
-	_ = d.QueryRow(`SELECT COUNT(*) FROM audit_logs WHERE event = 'login_failed' AND created_at > datetime('now', '-24 hours')`).Scan(&stats.FailedLogins24h)
-	_ = d.QueryRow(`SELECT COUNT(*) FROM users WHERE locked_until > CURRENT_TIMESTAMP AND deactivated_at IS NULL`).Scan(&stats.LockedAccounts)
+	if err := d.QueryRow(`SELECT COUNT(*) FROM users WHERE deactivated_at IS NULL`).Scan(&stats.TotalUsers); err != nil {
+		slog.Warn("admin: stats query failed for total_users", "error", err)
+	}
+	if err := d.QueryRow(`SELECT COUNT(*) FROM clients WHERE is_active = TRUE`).Scan(&stats.ActiveClients); err != nil {
+		slog.Warn("admin: stats query failed for active_clients", "error", err)
+	}
+	if err := d.QueryRow(`SELECT COUNT(*) FROM idp_sessions WHERE deactivated_at IS NULL`).Scan(&stats.ActiveDevices); err != nil {
+		slog.Warn("admin: stats query failed for active_devices", "error", err)
+	}
+	if err := d.QueryRow(`SELECT COUNT(*) FROM tokens WHERE revoked_at IS NULL AND access_token_expires_at > CURRENT_TIMESTAMP`).Scan(&stats.ActiveTokens); err != nil {
+		slog.Warn("admin: stats query failed for active_tokens", "error", err)
+	}
+	if err := d.QueryRow(`SELECT COUNT(*) FROM sessions WHERE created_at > datetime('now', '-24 hours')`).Scan(&stats.RecentLogins); err != nil {
+		slog.Warn("admin: stats query failed for recent_logins", "error", err)
+	}
+	if err := d.QueryRow(`SELECT COUNT(*) FROM deletion_requests`).Scan(&stats.PendingDeletionRequests); err != nil {
+		slog.Warn("admin: stats query failed for pending_deletion_requests", "error", err)
+	}
+	if err := d.QueryRow(`SELECT COUNT(*) FROM audit_logs WHERE event = 'login_failed' AND created_at > datetime('now', '-24 hours')`).Scan(&stats.FailedLogins24h); err != nil {
+		slog.Warn("admin: stats query failed for failed_logins_24h", "error", err)
+	}
+	if err := d.QueryRow(`SELECT COUNT(*) FROM users WHERE locked_until > CURRENT_TIMESTAMP AND deactivated_at IS NULL`).Scan(&stats.LockedAccounts); err != nil {
+		slog.Warn("admin: stats query failed for locked_accounts", "error", err)
+	}
 
 	utils.SuccessResponse(w, stats, http.StatusOK)
 }

--- a/pkg/audit/model.go
+++ b/pkg/audit/model.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -56,7 +57,9 @@ func ActorFromRequest(r *http.Request) Actor {
 		return nil
 	}
 	var username string
-	_ = db.GetDB().QueryRow("SELECT username FROM users WHERE id = ?", claims.UserID).Scan(&username)
+	if err := db.GetDB().QueryRow("SELECT username FROM users WHERE id = ?", claims.UserID).Scan(&username); err != nil {
+		slog.Warn("audit: failed to look up username for actor", "error", err, "user_id", claims.UserID)
+	}
 	return SimpleActor{ID: claims.UserID, Username: username}
 }
 

--- a/pkg/authorize/handler.go
+++ b/pkg/authorize/handler.go
@@ -40,7 +40,9 @@ import (
 func HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	// Support both GET (query string) and POST (form body) per OIDC Core §3.1.2.1
 	if r.Method == http.MethodPost {
-		_ = r.ParseForm()
+		if err := r.ParseForm(); err != nil {
+			slog.Warn("authorize: failed to parse POST form", "error", err)
+		}
 	}
 	get := func(key string) string {
 		if r.Method == http.MethodPost {

--- a/pkg/client/handler.go
+++ b/pkg/client/handler.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -174,7 +175,9 @@ func HandleDeleteClient(w http.ResponseWriter, r *http.Request) {
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
 	}
-	_, _ = db.GetDB().Exec(`DELETE FROM user_consents WHERE client_id = ?`, clientID)
+	if _, err := db.GetDB().Exec(`DELETE FROM user_consents WHERE client_id = ?`, clientID); err != nil {
+		slog.Error("client: failed to delete user consents for deleted client", "error", err, "client_id", clientID)
+	}
 	audit.Log(audit.EventClientDeleted, audit.ActorFromRequest(r), audit.TargetClient, clientID, nil, utils.GetClientIP(r))
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/pkg/passwordreset/store.go
+++ b/pkg/passwordreset/store.go
@@ -3,6 +3,7 @@ package passwordreset
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"log/slog"
 	"time"
 
 	"github.com/eugenioenko/autentico/pkg/db"
@@ -42,25 +43,31 @@ func getResetTokenInfo(tokenHash string) (userID string, expiresAt time.Time, us
 
 // markTokenUsed sets the used_at timestamp on a token.
 func markTokenUsed(tokenHash string) {
-	_, _ = db.GetDB().Exec(
+	if _, err := db.GetDB().Exec(
 		`UPDATE password_reset_tokens SET used_at = CURRENT_TIMESTAMP WHERE token_hash = ?`,
 		tokenHash,
-	)
+	); err != nil {
+		slog.Error("passwordreset: failed to mark token as used", "error", err)
+	}
 }
 
 // invalidatePreviousTokens marks all unused tokens for a user as used,
 // so only the latest reset link is valid.
 func invalidatePreviousTokens(userID string) {
-	_, _ = db.GetDB().Exec(
+	if _, err := db.GetDB().Exec(
 		`UPDATE password_reset_tokens SET used_at = CURRENT_TIMESTAMP WHERE user_id = ? AND used_at IS NULL`,
 		userID,
-	)
+	); err != nil {
+		slog.Error("passwordreset: failed to invalidate previous tokens", "error", err, "user_id", userID)
+	}
 }
 
 // deactivateUserSessions deactivates all active sessions for a user.
 func deactivateUserSessions(userID string) {
-	_, _ = db.GetDB().Exec(
+	if _, err := db.GetDB().Exec(
 		`UPDATE sessions SET deactivated_at = CURRENT_TIMESTAMP WHERE user_id = ? AND deactivated_at IS NULL`,
 		userID,
-	)
+	); err != nil {
+		slog.Error("passwordreset: failed to deactivate user sessions", "error", err, "user_id", userID)
+	}
 }

--- a/pkg/session/logout.go
+++ b/pkg/session/logout.go
@@ -30,7 +30,9 @@ func HandleLogout(w http.ResponseWriter, r *http.Request) {
 	// RP-Initiated Logout 1.0 §2: OPs MUST support the use of the HTTP GET and
 	// POST methods at the Logout Endpoint. If using POST, the request parameters
 	// are serialized using Form Serialization.
-	_ = r.ParseForm()
+	if err := r.ParseForm(); err != nil {
+		slog.Warn("session: failed to parse logout POST form", "error", err)
+	}
 	rpInitiatedLogout(w, r,
 		r.FormValue("id_token_hint"),
 		r.FormValue("post_logout_redirect_uri"),

--- a/pkg/token/handler.go
+++ b/pkg/token/handler.go
@@ -261,26 +261,34 @@ func HandleToken(w http.ResponseWriter, r *http.Request) {
 		// session from the cascade and let a revoked IdP session produce live
 		// tokens at the next refresh.
 		var priorIdp *string
-		_ = db.GetDB().QueryRow(
+		if err := db.GetDB().QueryRow(
 			`SELECT idp_session_id FROM sessions WHERE refresh_token = ?`,
 			request.RefreshToken,
-		).Scan(&priorIdp)
+		).Scan(&priorIdp); err != nil {
+			slog.Warn("token: failed to look up prior IdP session for refresh token", "error", err)
+		}
 		if priorIdp != nil {
 			idpSessionID = *priorIdp
 		}
 		// RFC 6819 §5.2.2.3 / OAuth 2.1 §6.1: rotate refresh token — revoke old, issue new.
 		// The old token is invalidated so it cannot be reused. If a revoked token is
 		// later presented, UserByRefreshToken detects the replay and revokes all user tokens.
-		_, _ = db.GetDB().Exec(
+		if _, err := db.GetDB().Exec(
 			`UPDATE tokens SET revoked_at = ? WHERE refresh_token = ? AND revoked_at IS NULL`,
 			time.Now().UTC(), request.RefreshToken,
-		)
+		); err != nil {
+			slog.Error("token: failed to revoke old refresh token during rotation", "error", err)
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", "Failed to rotate refresh token")
+			return
+		}
 		// RFC 6749 §5.1: scope must be included in the response when it may differ
 		// from what the client originally requested. Look up the scope and issued_at
 		// stored with the original token.
 		var tokenScope string
 		var tokenIssuedAt time.Time
-		_ = db.GetDB().QueryRow(`SELECT scope, issued_at FROM tokens WHERE refresh_token = ?`, request.RefreshToken).Scan(&tokenScope, &tokenIssuedAt)
+		if err := db.GetDB().QueryRow(`SELECT scope, issued_at FROM tokens WHERE refresh_token = ?`, request.RefreshToken).Scan(&tokenScope, &tokenIssuedAt); err != nil {
+			slog.Warn("token: failed to read scope/issued_at from original token", "error", err)
+		}
 		// OIDC Core §12.2: auth_time in a refreshed ID token MUST match the original
 		// authentication time, not the refresh time.
 		if !tokenIssuedAt.IsZero() {

--- a/pkg/token/refresh_token.go
+++ b/pkg/token/refresh_token.go
@@ -86,9 +86,12 @@ func UserByRefreshToken(w http.ResponseWriter, request TokenRequest) (*user.User
 	if err == nil && revokedAt != nil {
 		slog.Warn("token: rotated refresh token replayed — revoking all user tokens",
 			"user_id", authToken.UserID)
-		_, _ = db.GetDB().Exec(
+		if _, err := db.GetDB().Exec(
 			`UPDATE tokens SET revoked_at = ? WHERE user_id = ? AND revoked_at IS NULL`,
-			time.Now().UTC(), authToken.UserID)
+			time.Now().UTC(), authToken.UserID,
+		); err != nil {
+			slog.Error("token: failed to revoke all user tokens after replay detection", "error", err, "user_id", authToken.UserID)
+		}
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_grant", "Token has been revoked")
 		return nil, fmt.Errorf("token has been revoked")
 	}

--- a/pkg/user/authenticate.go
+++ b/pkg/user/authenticate.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -36,25 +37,31 @@ func verifyPasswordWithLockout(usr *User, password string) error {
 			newAttempts := usr.FailedLoginAttempts + 1
 			if newAttempts >= maxAttempts {
 				lockUntil := time.Now().Add(config.Get().AuthAccountLockoutDuration)
-				_, _ = db.GetDB().Exec(
+				if _, dbErr := db.GetDB().Exec(
 					`UPDATE users SET failed_login_attempts = ?, locked_until = ? WHERE id = ?`,
 					newAttempts, lockUntil, usr.ID,
-				)
+				); dbErr != nil {
+					slog.Error("user: failed to lock account after max attempts", "error", dbErr, "user_id", usr.ID)
+				}
 			} else {
-				_, _ = db.GetDB().Exec(
+				if _, dbErr := db.GetDB().Exec(
 					`UPDATE users SET failed_login_attempts = ? WHERE id = ?`,
 					newAttempts, usr.ID,
-				)
+				); dbErr != nil {
+					slog.Error("user: failed to increment failed login attempts", "error", dbErr, "user_id", usr.ID)
+				}
 			}
 		}
 		return fmt.Errorf("invalid password")
 	}
 
 	if maxAttempts > 0 && usr.FailedLoginAttempts > 0 {
-		_, _ = db.GetDB().Exec(
+		if _, dbErr := db.GetDB().Exec(
 			`UPDATE users SET failed_login_attempts = 0, locked_until = NULL WHERE id = ?`,
 			usr.ID,
-		)
+		); dbErr != nil {
+			slog.Error("user: failed to reset failed login attempts after successful login", "error", dbErr, "user_id", usr.ID)
+		}
 	}
 
 	return nil
@@ -106,10 +113,12 @@ func AuthenticateUser(username, password string) (*User, error) {
 		return nil, fmt.Errorf("invalid username or password")
 	}
 
-	_, _ = db.GetDB().Exec(
+	if _, err := db.GetDB().Exec(
 		`UPDATE users SET last_login = ? WHERE id = ?`,
 		time.Now(), user.ID,
-	)
+	); err != nil {
+		slog.Warn("user: failed to update last_login timestamp", "error", err, "user_id", user.ID)
+	}
 
 	return &user, nil
 }

--- a/pkg/user/read.go
+++ b/pkg/user/read.go
@@ -3,6 +3,7 @@ package user
 import (
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -181,7 +182,10 @@ func GetVerificationTokenInfo(tokenHash string) (userID string, expiresAt time.T
 // regardless of email verification status. Used to prevent duplicate email assignment.
 func UserExistsByEmail(email string) bool {
 	var count int
-	_ = db.GetDB().QueryRow(`SELECT COUNT(*) FROM users WHERE email = ? AND deactivated_at IS NULL`, strings.ToLower(email)).Scan(&count)
+	if err := db.GetDB().QueryRow(`SELECT COUNT(*) FROM users WHERE email = ? AND deactivated_at IS NULL`, strings.ToLower(email)).Scan(&count); err != nil {
+		slog.Error("user: failed to check email existence", "error", err, "email", strings.ToLower(email))
+		return false
+	}
 	return count > 0
 }
 


### PR DESCRIPTION
## Summary
- Added proper error logging/handling to 15+ locations where database errors were silently discarded with `_, _ =`
- **Security-critical**: Token rotation revocation now aborts with 500 if the old token can't be revoked (previously silently issued new token alongside still-valid old one)
- **Security-critical**: Replay-detection token revocation, account lockout enforcement, and password reset cleanup now log at `slog.Error`
- **Operational**: Dashboard stats, audit actor lookup, and form parsing now log at `slog.Warn`
- Intentionally left alone: `rows.Close()`, `w.Write()`, and `f.Close()` in deferred contexts (standard Go idioms)

## Test plan
- [ ] Run `make test` — all tests pass
- [ ] Verify token refresh rotation properly fails if DB update fails
- [ ] Verify account lockout increments are logged on failure
- [ ] Verify password reset token invalidation failures are logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)