### PR TITLE
fix: implement scope validation in authorize endpoint

### DIFF
--- a/pkg/authorize/model.go
+++ b/pkg/authorize/model.go
@@ -1,6 +1,9 @@
 package authorize
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/eugenioenko/autentico/pkg/authzsig"
 	validation "github.com/go-ozzo/ozzo-validation"
 	"github.com/go-ozzo/ozzo-validation/is"
@@ -23,9 +26,44 @@ func ValidateAuthorizeRequest(input AuthorizeRequest) error {
 	return validation.ValidateStruct(&input,
 		validation.Field(&input.ResponseType, validation.Required),
 		validation.Field(&input.RedirectURI, validation.Required, is.URL),
-		// TODO: set proper scope validation
-		//validation.Field(&input.Scope, validation.Required, validation.In("read", "write")),
+		// RFC 6749 §3.3: validate scope token syntax
+		validation.Field(&input.Scope, validation.By(validateScopeSyntax)),
 	)
+}
+
+// validateScopeSyntax validates that the scope string conforms to RFC 6749 §3.3.
+// Each scope token must consist of printable ASCII characters excluding
+// double-quote, backslash, and space (which is the delimiter).
+// NQCHAR = %x21 / %x23-5B / %x5D-7E
+// An empty scope is allowed — the server may assign a default scope.
+func validateScopeSyntax(value interface{}) error {
+	scope, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("scope must be a string")
+	}
+	if scope == "" {
+		// RFC 6749 §3.3: if the client omits the scope parameter, the server
+		// SHOULD either process the request using a pre-defined default or fail.
+		// We allow empty and let the handler decide.
+		return nil
+	}
+	for _, token := range strings.Fields(scope) {
+		if err := validateScopeToken(token); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateScopeToken checks that a single scope token consists only of valid
+// NQCHAR characters per RFC 6749 §3.3 (printable ASCII: 0x21, 0x23-0x5B, 0x5D-0x7E).
+func validateScopeToken(token string) error {
+	for _, ch := range token {
+		if ch < 0x21 || ch > 0x7E || ch == 0x22 || ch == 0x5C {
+			return fmt.Errorf("scope token %q contains invalid character", token)
+		}
+	}
+	return nil
 }
 
 // AuthorizeSignature computes the HMAC signature for the authorize request parameters.

--- a/pkg/authorize/model_test.go
+++ b/pkg/authorize/model_test.go
@@ -1,0 +1,138 @@
+package authorize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateAuthorizeRequest_ValidScopes(t *testing.T) {
+	base := AuthorizeRequest{
+		ResponseType: "code",
+		RedirectURI:  "http://localhost/callback",
+	}
+
+	// Standard OIDC scopes should pass validation
+	tests := []struct {
+		name  string
+		scope string
+	}{
+		{"openid only", "openid"},
+		{"openid profile", "openid profile"},
+		{"openid profile email", "openid profile email"},
+		{"all standard OIDC scopes", "openid profile email address phone offline_access"},
+		{"custom scope", "custom_scope"},
+		{"mixed scopes", "openid custom:read custom:write"},
+		{"empty scope", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := base
+			req.Scope = tt.scope
+			err := ValidateAuthorizeRequest(req)
+			assert.NoError(t, err, "scope %q should be valid", tt.scope)
+		})
+	}
+}
+
+func TestValidateAuthorizeRequest_InvalidScopeSyntax(t *testing.T) {
+	base := AuthorizeRequest{
+		ResponseType: "code",
+		RedirectURI:  "http://localhost/callback",
+	}
+
+	// RFC 6749 §3.3: scope tokens must be NQCHAR (%x21 / %x23-5B / %x5D-7E)
+	tests := []struct {
+		name  string
+		scope string
+	}{
+		{"contains backslash", `openid profile\bad`},
+		{"contains double-quote", `openid "profile"`},
+		{"contains control character", "openid \x01bad"},
+		{"contains non-ASCII", "openid prof\xc3\xadle"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := base
+			req.Scope = tt.scope
+			err := ValidateAuthorizeRequest(req)
+			assert.Error(t, err, "scope %q should be invalid", tt.scope)
+		})
+	}
+}
+
+func TestValidateScopeSyntax_Unit(t *testing.T) {
+	// Valid tokens
+	assert.NoError(t, validateScopeSyntax("openid"))
+	assert.NoError(t, validateScopeSyntax("openid profile email"))
+	assert.NoError(t, validateScopeSyntax("a:b:c"))
+	assert.NoError(t, validateScopeSyntax("scope-with-dash"))
+	assert.NoError(t, validateScopeSyntax("scope_with_underscore"))
+	assert.NoError(t, validateScopeSyntax("scope.with.dots"))
+	assert.NoError(t, validateScopeSyntax(""))
+
+	// All printable ASCII except space, double-quote, backslash
+	assert.NoError(t, validateScopeSyntax("!#$%&'()*+,-./0123456789"))
+	assert.NoError(t, validateScopeSyntax(":;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ["))
+	assert.NoError(t, validateScopeSyntax("]^_`abcdefghijklmnopqrstuvwxyz{|}~"))
+
+	// Invalid tokens
+	assert.Error(t, validateScopeSyntax(`has\"quote`))
+	assert.Error(t, validateScopeSyntax(`has\backslash`))
+	assert.Error(t, validateScopeSyntax("has\x00null"))
+	assert.Error(t, validateScopeSyntax("has\x1fcontrol"))
+}
+
+func TestValidateScopeToken_Unit(t *testing.T) {
+	// Valid
+	assert.NoError(t, validateScopeToken("openid"))
+	assert.NoError(t, validateScopeToken("profile"))
+	assert.NoError(t, validateScopeToken("a:b"))
+	assert.NoError(t, validateScopeToken("!#$%"))
+
+	// Invalid: double-quote (0x22)
+	assert.Error(t, validateScopeToken(`"`))
+	// Invalid: backslash (0x5C)
+	assert.Error(t, validateScopeToken(`\`))
+	// Invalid: space (0x20) - though normally split by Fields()
+	assert.Error(t, validateScopeToken(" "))
+	// Invalid: DEL (0x7F)
+	assert.Error(t, validateScopeToken("\x7f"))
+	// Invalid: non-ASCII
+	assert.Error(t, validateScopeToken("\x80"))
+}
+
+func TestValidateAuthorizeRequest_SubsetOfClientScopes(t *testing.T) {
+	// Structural validation at the model level accepts any valid scope syntax.
+	// Per-client scope restriction is handled by client.ValidateScopes in the handler.
+	// This test verifies that a subset of well-formed scopes passes model validation.
+	req := AuthorizeRequest{
+		ResponseType: "code",
+		RedirectURI:  "http://localhost/callback",
+		Scope:        "openid",
+	}
+	assert.NoError(t, ValidateAuthorizeRequest(req))
+
+	req.Scope = "openid profile"
+	assert.NoError(t, ValidateAuthorizeRequest(req))
+}
+
+func TestValidateAuthorizeRequest_MissingResponseType(t *testing.T) {
+	req := AuthorizeRequest{
+		RedirectURI: "http://localhost/callback",
+		Scope:       "openid",
+	}
+	err := ValidateAuthorizeRequest(req)
+	assert.Error(t, err, "missing response_type should fail validation")
+}
+
+func TestValidateAuthorizeRequest_MissingRedirectURI(t *testing.T) {
+	req := AuthorizeRequest{
+		ResponseType: "code",
+		Scope:        "openid",
+	}
+	err := ValidateAuthorizeRequest(req)
+	assert.Error(t, err, "missing redirect_uri should fail validation")
+}


### PR DESCRIPTION
## Summary
- Replaced TODO comment at `pkg/authorize/model.go:26` with proper RFC 6749 Section 3.3 scope syntax validation
- Added `validateScopeSyntax()` — parses space-separated scope string and validates each token
- Added `validateScopeToken()` — checks each token against NQCHAR character set (`%x21 / %x23-5B / %x5D-7E`), rejecting control characters, double-quotes, backslashes, and non-ASCII
- Empty scope is allowed (server may assign default per RFC 6749 Section 3.3)
- This is the first defense layer (syntax check) before the existing per-client scope restriction
- Added 138 lines of unit tests in `pkg/authorize/model_test.go`

## Test plan
- [ ] Run `go test ./pkg/authorize/... -v` — all tests pass
- [ ] Verify authorize endpoint rejects scopes with invalid characters (backslash, double-quote, control chars)
- [ ] Verify valid OIDC scopes (openid, profile, email, etc.) still work
- [ ] Verify empty scope is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)