### PR TITLE
fix: validate date format and range ordering in list queries

### DIFF
--- a/pkg/api/listquery.go
+++ b/pkg/api/listquery.go
@@ -74,7 +74,7 @@ func parseDate(value string) (time.Time, error) {
 			return t, nil
 		}
 	}
-	return time.Time{}, fmt.Errorf("invalid date format %q: expected ISO 8601 (e.g. 2006-01-02 or 2006-01-02T15:04:05Z)", value)
+	return time.Time{}, fmt.Errorf("invalid date format: expected ISO 8601 (e.g. 2006-01-02 or 2006-01-02T15:04:05Z)")
 }
 
 // ParseDateRange reads "{param}_from" and "{param}_to" from the query string

--- a/pkg/api/listquery.go
+++ b/pkg/api/listquery.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const DefaultMaxLimit = 100
@@ -58,19 +59,56 @@ func ParseFilters(r *http.Request, allowed map[string]bool) map[string]string {
 	return filters
 }
 
+// dateFormats lists the accepted date/datetime formats in order of preference.
+var dateFormats = []string{
+	time.RFC3339,            // 2006-01-02T15:04:05Z07:00
+	"2006-01-02T15:04:05",  // datetime without timezone
+	"2006-01-02",           // date only
+}
+
+// parseDate attempts to parse a date string using the accepted formats.
+// Returns the parsed time and nil error on success, or zero time and an error.
+func parseDate(value string) (time.Time, error) {
+	for _, layout := range dateFormats {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid date format %q: expected ISO 8601 (e.g. 2006-01-02 or 2006-01-02T15:04:05Z)", value)
+}
+
 // ParseDateRange reads "{param}_from" and "{param}_to" from the query string
 // for each entry in columns (param prefix → qualified SQL column).
 // Returns a WHERE fragment (with leading " AND ") and bound args.
-func ParseDateRange(r *http.Request, columns map[string]string) (where string, args []any) {
+// Returns an error if any date value is not a valid ISO 8601 date/datetime,
+// or if _from is after _to for the same parameter.
+func ParseDateRange(r *http.Request, columns map[string]string) (where string, args []any, err error) {
 	var conditions []string
 	for param, col := range columns {
-		if from := r.URL.Query().Get(param + "_from"); from != "" {
+		fromStr := r.URL.Query().Get(param + "_from")
+		toStr := r.URL.Query().Get(param + "_to")
+
+		var fromTime, toTime time.Time
+
+		if fromStr != "" {
+			fromTime, err = parseDate(fromStr)
+			if err != nil {
+				return "", nil, fmt.Errorf("invalid %s_from: %w", param, err)
+			}
 			conditions = append(conditions, col+" >= ?")
-			args = append(args, from)
+			args = append(args, fromStr)
 		}
-		if to := r.URL.Query().Get(param + "_to"); to != "" {
+		if toStr != "" {
+			toTime, err = parseDate(toStr)
+			if err != nil {
+				return "", nil, fmt.Errorf("invalid %s_to: %w", param, err)
+			}
 			conditions = append(conditions, col+" <= ?")
-			args = append(args, to)
+			args = append(args, toStr)
+		}
+
+		if fromStr != "" && toStr != "" && fromTime.After(toTime) {
+			return "", nil, fmt.Errorf("invalid date range: %s_from (%s) is after %s_to (%s)", param, fromStr, param, toStr)
 		}
 	}
 	if len(conditions) > 0 {

--- a/pkg/api/listquery_adversarial_test.go
+++ b/pkg/api/listquery_adversarial_test.go
@@ -249,13 +249,8 @@ func TestParseDateRange_SQLInjection(t *testing.T) {
 		t.Run(payload, func(t *testing.T) {
 			u := "/items?created_at_from=" + url.QueryEscape(payload) + "&created_at_to=" + url.QueryEscape(payload)
 			req := httptest.NewRequest(http.MethodGet, u, nil)
-			where, args := ParseDateRange(req, cols)
-			assert.Contains(t, where, "u.created_at >= ?")
-			assert.Contains(t, where, "u.created_at <= ?")
-			for _, arg := range args {
-				_, ok := arg.(string)
-				assert.True(t, ok, "date args must be strings bound as params")
-			}
+			_, _, err := ParseDateRange(req, cols)
+			assert.Error(t, err, "SQL injection payloads must be rejected as invalid dates")
 		})
 	}
 }
@@ -408,29 +403,48 @@ func TestBuildListQuery_LIKEWildcardAbuse(t *testing.T) {
 func TestParseDateRange_SemanticAbuse(t *testing.T) {
 	cols := map[string]string{"created_at": "u.created_at"}
 
-	cases := []struct {
+	t.Run("inverted_range", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/items?created_at_from=2099-12-31&created_at_to=2000-01-01", nil)
+		_, _, err := ParseDateRange(req, cols)
+		assert.Error(t, err, "inverted date range must be rejected")
+		assert.Contains(t, err.Error(), "is after")
+	})
+
+	invalidCases := []struct {
 		name  string
 		query string
 	}{
-		{"inverted_range", "created_at_from=2099-12-31&created_at_to=2000-01-01"},
 		{"non_date_string", "created_at_from=ZZZZZZZZZ&created_at_to=not-a-date"},
 		{"epoch_zero", "created_at_from=0000-00-00&created_at_to=0000-00-00"},
 		{"far_future", "created_at_from=9999-99-99&created_at_to=9999-99-99"},
 		{"negative_date", "created_at_from=-1&created_at_to=-99999"},
 		{"unix_timestamp", "created_at_from=1700000000&created_at_to=1800000000"},
+	}
+	for _, tc := range invalidCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/items?"+tc.query, nil)
+			_, _, err := ParseDateRange(req, cols)
+			assert.Error(t, err, "malformed date must be rejected")
+		})
+	}
+
+	validCases := []struct {
+		name  string
+		query string
+	}{
 		{"iso_with_timezone", "created_at_from=2024-01-01T00:00:00Z&created_at_to=2024-12-31T23:59:59%2B05:00"},
 		{"only_from", "created_at_from=2024-01-01"},
 		{"only_to", "created_at_to=2024-12-31"},
 	}
-	for _, tc := range cases {
+	for _, tc := range validCases {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/items?"+tc.query, nil)
-			where, args := ParseDateRange(req, cols)
+			where, args, err := ParseDateRange(req, cols)
+			assert.NoError(t, err)
 			assert.NotEqual(t, "", where, "should produce at least one condition")
 			assert.Greater(t, len(args), 0, "should have at least one bound arg")
 			assert.Contains(t, where, "u.created_at")
 			assert.Contains(t, where, "?")
-			assert.NotContains(t, where, "ZZZZZ")
 		})
 	}
 }
@@ -439,9 +453,10 @@ func TestParseDateRange_SemanticAbuse(t *testing.T) {
 func TestParseDateRange_UnknownColumns(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet,
 		"/items?password_from=2024-01-01&secret_to=2024-12-31", nil)
-	where, args := ParseDateRange(req, map[string]string{
+	where, args, err := ParseDateRange(req, map[string]string{
 		"created_at": "u.created_at",
 	})
+	assert.NoError(t, err)
 	assert.Equal(t, "", where)
 	assert.Empty(t, args)
 }
@@ -449,9 +464,10 @@ func TestParseDateRange_UnknownColumns(t *testing.T) {
 func TestParseDateRange_EmptyValues(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet,
 		"/items?created_at_from=&created_at_to=", nil)
-	where, args := ParseDateRange(req, map[string]string{
+	where, args, err := ParseDateRange(req, map[string]string{
 		"created_at": "u.created_at",
 	})
+	assert.NoError(t, err)
 	assert.Equal(t, "", where)
 	assert.Empty(t, args)
 }

--- a/pkg/api/listquery_test.go
+++ b/pkg/api/listquery_test.go
@@ -138,3 +138,107 @@ func TestBuildListQuery_SearchAndFilter(t *testing.T) {
 	assert.Contains(t, result.Where, " AND ")
 	assert.Len(t, result.Args, 3)
 }
+
+// --- ParseDateRange validation tests ---
+
+func TestParseDateRange_ValidRange(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet,
+		"/items?created_at_from=2024-01-01&created_at_to=2024-12-31", nil)
+	where, args, err := ParseDateRange(req, map[string]string{
+		"created_at": "u.created_at",
+	})
+	assert.NoError(t, err)
+	assert.Contains(t, where, "u.created_at >= ?")
+	assert.Contains(t, where, "u.created_at <= ?")
+	assert.Len(t, args, 2)
+	assert.Equal(t, "2024-01-01", args[0])
+	assert.Equal(t, "2024-12-31", args[1])
+}
+
+func TestParseDateRange_ValidRFC3339(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet,
+		"/items?created_at_from=2024-01-01T00:00:00Z&created_at_to=2024-12-31T23:59:59Z", nil)
+	where, args, err := ParseDateRange(req, map[string]string{
+		"created_at": "u.created_at",
+	})
+	assert.NoError(t, err)
+	assert.Contains(t, where, "u.created_at >= ?")
+	assert.Contains(t, where, "u.created_at <= ?")
+	assert.Len(t, args, 2)
+}
+
+func TestParseDateRange_ValidDatetimeNoTimezone(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet,
+		"/items?created_at_from=2024-01-01T00:00:00&created_at_to=2024-12-31T23:59:59", nil)
+	_, _, err := ParseDateRange(req, map[string]string{
+		"created_at": "u.created_at",
+	})
+	assert.NoError(t, err)
+}
+
+func TestParseDateRange_InvalidFromFormat(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet,
+		"/items?created_at_from=not-a-date", nil)
+	_, _, err := ParseDateRange(req, map[string]string{
+		"created_at": "u.created_at",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid created_at_from")
+	assert.Contains(t, err.Error(), "invalid date format")
+}
+
+func TestParseDateRange_InvalidToFormat(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet,
+		"/items?created_at_to=2024/01/01", nil)
+	_, _, err := ParseDateRange(req, map[string]string{
+		"created_at": "u.created_at",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid created_at_to")
+}
+
+func TestParseDateRange_InvertedRange(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet,
+		"/items?created_at_from=2024-12-31&created_at_to=2024-01-01", nil)
+	_, _, err := ParseDateRange(req, map[string]string{
+		"created_at": "u.created_at",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "is after")
+}
+
+func TestParseDateRange_OnlyFrom(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet,
+		"/items?created_at_from=2024-06-15", nil)
+	where, args, err := ParseDateRange(req, map[string]string{
+		"created_at": "u.created_at",
+	})
+	assert.NoError(t, err)
+	assert.Contains(t, where, "u.created_at >= ?")
+	assert.NotContains(t, where, "u.created_at <= ?")
+	assert.Len(t, args, 1)
+}
+
+func TestParseDateRange_OnlyTo(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet,
+		"/items?created_at_to=2024-06-15", nil)
+	where, args, err := ParseDateRange(req, map[string]string{
+		"created_at": "u.created_at",
+	})
+	assert.NoError(t, err)
+	assert.NotContains(t, where, "u.created_at >= ?")
+	assert.Contains(t, where, "u.created_at <= ?")
+	assert.Len(t, args, 1)
+}
+
+func TestParseDateRange_EqualFromAndTo(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet,
+		"/items?created_at_from=2024-06-15&created_at_to=2024-06-15", nil)
+	where, args, err := ParseDateRange(req, map[string]string{
+		"created_at": "u.created_at",
+	})
+	assert.NoError(t, err)
+	assert.Contains(t, where, "u.created_at >= ?")
+	assert.Contains(t, where, "u.created_at <= ?")
+	assert.Len(t, args, 2)
+}

--- a/pkg/audit/handler.go
+++ b/pkg/audit/handler.go
@@ -32,9 +32,13 @@ func HandleListAuditLogs(w http.ResponseWriter, r *http.Request) {
 		params.Order = "desc"
 	}
 
-	dateWhere, dateArgs := api.ParseDateRange(r, map[string]string{
+	dateWhere, dateArgs, dateErr := api.ParseDateRange(r, map[string]string{
 		"created_at": "created_at",
 	})
+	if dateErr != nil {
+		utils.ErrorResponse(w, dateErr.Error(), http.StatusBadRequest)
+		return
+	}
 
 	logs, total, err := ListAuditLogsWithParams(params, dateWhere, dateArgs)
 	if err != nil {

--- a/pkg/deletion/handler.go
+++ b/pkg/deletion/handler.go
@@ -147,9 +147,13 @@ func HandleCancelDeletionRequest(w http.ResponseWriter, r *http.Request) {
 // @Router /admin/api/deletion-requests [get]
 func HandleListDeletionRequests(w http.ResponseWriter, r *http.Request) {
 	params := api.ParseListParams(r)
-	dateWhere, dateArgs := api.ParseDateRange(r, map[string]string{
+	dateWhere, dateArgs, dateErr := api.ParseDateRange(r, map[string]string{
 		"requested_at": "d.requested_at",
 	})
+	if dateErr != nil {
+		utils.ErrorResponse(w, dateErr.Error(), http.StatusBadRequest)
+		return
+	}
 
 	requests, total, err := ListDeletionRequestsWithParams(params, dateWhere, dateArgs)
 	if err != nil {

--- a/pkg/idpsession/admin_handler.go
+++ b/pkg/idpsession/admin_handler.go
@@ -60,10 +60,14 @@ func deviceRowsToResponse(devices []DeviceRow) []IdpSessionResponse {
 // @Router /admin/api/idp-sessions [get]
 func HandleListIdpSessions(w http.ResponseWriter, r *http.Request) {
 	params := api.ParseListParams(r)
-	dateWhere, dateArgs := api.ParseDateRange(r, map[string]string{
+	dateWhere, dateArgs, dateErr := api.ParseDateRange(r, map[string]string{
 		"created_at":       "s.created_at",
 		"last_activity_at": "s.last_activity_at",
 	})
+	if dateErr != nil {
+		utils.ErrorResponse(w, dateErr.Error(), http.StatusBadRequest)
+		return
+	}
 
 	devices, total, err := ListIdpSessionsWithParams(params, dateWhere, dateArgs)
 	if err != nil {

--- a/pkg/token/admin_handler.go
+++ b/pkg/token/admin_handler.go
@@ -63,9 +63,13 @@ func tokenRowToResponse(r TokenRow) AdminTokenResponse {
 // @Router /admin/api/tokens [get]
 func HandleListTokens(w http.ResponseWriter, r *http.Request) {
 	params := api.ParseListParams(r)
-	dateWhere, dateArgs := api.ParseDateRange(r, map[string]string{
+	dateWhere, dateArgs, dateErr := api.ParseDateRange(r, map[string]string{
 		"issued_at": "t.issued_at",
 	})
+	if dateErr != nil {
+		utils.ErrorResponse(w, dateErr.Error(), http.StatusBadRequest)
+		return
+	}
 
 	tokens, total, err := ListTokensWithParams(params, dateWhere, dateArgs)
 	if err != nil {

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -282,9 +282,13 @@ func HandleListUsers(w http.ResponseWriter, r *http.Request) {
 	if groupName := r.URL.Query().Get("group"); groupName != "" {
 		params.Filters["group"] = groupName
 	}
-	dateWhere, dateArgs := api.ParseDateRange(r, map[string]string{
+	dateWhere, dateArgs, dateErr := api.ParseDateRange(r, map[string]string{
 		"created_at": "users.created_at",
 	})
+	if dateErr != nil {
+		utils.ErrorResponse(w, dateErr.Error(), http.StatusBadRequest)
+		return
+	}
 
 	users, total, err := ListUsersWithParams(params, dateWhere, dateArgs)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Added ISO 8601 date format validation to `ParseDateRange()` in `pkg/api/listquery.go`
- Supports three formats: RFC 3339, datetime without timezone, date-only
- Validates that `_from` is before `_to` when both are provided
- Changed `ParseDateRange` signature to return an error (breaking change for callers)
- Updated all 5 callers (`audit`, `token`, `user`, `idpsession`, `deletion`) to handle errors with 400 Bad Request
- Added 9 new unit tests + updated existing adversarial tests (SQL injection payloads now properly rejected)
- All 48 tests in `./pkg/api/...` pass

## Test plan
- [ ] Run `go test ./pkg/api/... -v` — all 48 tests pass
- [ ] Run `make test` — full suite passes
- [ ] Verify admin list endpoints reject malformed dates with 400
- [ ] Verify inverted date ranges return descriptive error

🤖 Generated with [Claude Code](https://claude.com/claude-code)