### PR TITLE
docs: add CHANGELOG.md with v2.0 breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+## v2.0 (unreleased)
+
+### Breaking Changes
+
+#### List endpoints return paginated response objects
+
+**Affected endpoints:** All admin list endpoints (`/admin/api/users`, `/admin/api/groups`, `/admin/api/clients`, `/admin/api/federation`, `/admin/api/sessions`, `/admin/api/audit`, `/admin/api/tokens`, `/admin/api/deletions`)
+
+**Before (v1.x):**
+```json
+[
+  { "id": "...", "username": "..." },
+  { "id": "...", "username": "..." }
+]
+```
+
+**After (v2.0):**
+```json
+{
+  "items": [
+    { "id": "...", "username": "..." },
+    { "id": "...", "username": "..." }
+  ],
+  "total": 42
+}
+```
+
+**Migration:** Update API consumers to read `.items` instead of the root array, and use `.total` for pagination UI.
+
+#### Account API requires audience claim
+
+**Affected endpoints:** All `/account/api/*` endpoints
+
+**Before (v1.x):** Any valid access token could call account API endpoints.
+
+**After (v2.0):** Tokens must include `autentico-account` or `autentico-admin` in the `aud` (audience) claim. Tokens without a matching audience are rejected with 401.
+
+**Migration:** Ensure clients that need account API access have `autentico-account` in their `allowed_audiences` configuration, or use the built-in `autentico-account` / `autentico-admin` clients.


### PR DESCRIPTION
## Summary

- Adds `CHANGELOG.md` to track breaking changes across major releases
- Documents the two breaking changes for the upcoming v2.0 release:
  - List endpoints return `{items, total}` instead of raw arrays
  - Account API endpoints require `autentico-account` or `autentico-admin` in the token `aud` claim

## Test plan

- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)