### PR TITLE
fix: remove SQLite WAL/shm files in make fresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ docker-compose:
 
 # Fresh start: wipe local DB, rebuild, init, and launch
 fresh: build
-	rm -f ./autentico.db .env
+	rm -f ./autentico.db ./autentico.db-shm ./autentico.db-wal .env
 	./$(APP_NAME) init
 	./$(APP_NAME) start
 


### PR DESCRIPTION
## Summary
- `make fresh` now removes `autentico.db-shm` and `autentico.db-wal` alongside the database file
- Stale `-shm` files can cause `disk I/O error (522)` when restarting the server after a crash or branch switch

## Test plan
- [ ] Run `make fresh` and verify all three DB files are removed before reinitializing

🤖 Generated with [Claude Code](https://claude.com/claude-code)