### PR TITLE
security: validate URL scheme on OIDC profile URL claims

### DIFF
--- a/pkg/signup/handler.go
+++ b/pkg/signup/handler.go
@@ -145,14 +145,7 @@ func handleSignupPost(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	usr, err := user.CreateUser(username, password, emailAddr)
-	if err != nil {
-		redirectSignupError(w, r, params, "Could not create account. Username may already be taken.")
-		return
-	}
-	audit.Log(audit.EventUserCreated, nil, audit.TargetUser, usr.ID, audit.Detail("source", "signup", "username", username), utils.GetClientIP(r))
-
-	// Save optional/required profile fields
+	// Validate profile fields (e.g. URL scheme checks) before creating the user
 	profileUpdate := user.UserUpdateRequest{
 		GivenName:         profileFields["given_name"],
 		FamilyName:        profileFields["family_name"],
@@ -165,6 +158,19 @@ func handleSignupPost(w http.ResponseWriter, r *http.Request) {
 		AddressPostalCode: profileFields["address_postal_code"],
 		AddressCountry:    profileFields["address_country"],
 	}
+	if err := user.ValidateUserUpdateRequest(profileUpdate); err != nil {
+		redirectSignupError(w, r, params, err.Error())
+		return
+	}
+
+	usr, err := user.CreateUser(username, password, emailAddr)
+	if err != nil {
+		redirectSignupError(w, r, params, "Could not create account. Username may already be taken.")
+		return
+	}
+	audit.Log(audit.EventUserCreated, nil, audit.TargetUser, usr.ID, audit.Detail("source", "signup", "username", username), utils.GetClientIP(r))
+
+	// Save profile fields
 	_ = user.UpdateUser(usr.ID, profileUpdate)
 
 	// Email verification gate — non-admin users with an email must verify before logging in

--- a/pkg/user/model.go
+++ b/pkg/user/model.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/eugenioenko/autentico/pkg/config"
@@ -191,6 +192,19 @@ type UserUpdateRequest struct {
 	AddressCountry    string `json:"address_country,omitempty"`
 }
 
+// validateURLScheme checks that a URL string uses http or https scheme.
+// Returns an error for javascript:, file:, data:, and other non-http(s) schemes.
+func validateURLScheme(value string) error {
+	u, err := url.Parse(value)
+	if err != nil {
+		return fmt.Errorf("invalid URL")
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("URL must use http or https scheme")
+	}
+	return nil
+}
+
 func ValidateUserUpdateRequest(input UserUpdateRequest) error {
 	if input.Username != "" {
 		if err := validation.Validate(input.Username, validation.Length(config.Get().ValidationMinUsernameLength, config.Get().ValidationMaxUsernameLength)); err != nil {
@@ -210,6 +224,21 @@ func ValidateUserUpdateRequest(input UserUpdateRequest) error {
 	if input.Role != "" {
 		if err := validation.Validate(input.Role, validation.In("user", "admin")); err != nil {
 			return fmt.Errorf("role is invalid: %w", err)
+		}
+	}
+	if input.Picture != "" {
+		if err := validateURLScheme(input.Picture); err != nil {
+			return fmt.Errorf("picture is invalid: %w", err)
+		}
+	}
+	if input.Website != "" {
+		if err := validateURLScheme(input.Website); err != nil {
+			return fmt.Errorf("website is invalid: %w", err)
+		}
+	}
+	if input.ProfileURL != "" {
+		if err := validateURLScheme(input.ProfileURL); err != nil {
+			return fmt.Errorf("profile URL is invalid: %w", err)
 		}
 	}
 	return nil

--- a/pkg/user/model_test.go
+++ b/pkg/user/model_test.go
@@ -224,3 +224,99 @@ func TestValidateUserUpdateRequest(t *testing.T) {
 	})
 	assert.Error(t, err)
 }
+
+func TestValidateURLScheme(t *testing.T) {
+	// Valid http URL
+	err := validateURLScheme("http://example.com/photo.jpg")
+	assert.NoError(t, err)
+
+	// Valid https URL
+	err = validateURLScheme("https://example.com/photo.jpg")
+	assert.NoError(t, err)
+
+	// javascript: scheme rejected
+	err = validateURLScheme("javascript:alert(1)")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "http or https")
+
+	// file: scheme rejected
+	err = validateURLScheme("file:///etc/passwd")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "http or https")
+
+	// data: scheme rejected
+	err = validateURLScheme("data:text/html,<script>alert(1)</script>")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "http or https")
+
+	// Relative URL without scheme rejected
+	err = validateURLScheme("example.com/photo.jpg")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "http or https")
+}
+
+func TestValidateUserUpdateRequest_URLFields(t *testing.T) {
+	testutils.WithConfigOverride(t, func() {
+		config.Values.ValidationMinUsernameLength = 3
+		config.Values.ValidationMaxUsernameLength = 50
+	})
+
+	// Empty URL fields are allowed (optional)
+	err := ValidateUserUpdateRequest(UserUpdateRequest{
+		Picture:    "",
+		Website:    "",
+		ProfileURL: "",
+	})
+	assert.NoError(t, err)
+
+	// Valid https URLs pass
+	err = ValidateUserUpdateRequest(UserUpdateRequest{
+		Picture:    "https://example.com/photo.jpg",
+		Website:    "https://example.com",
+		ProfileURL: "https://example.com/profile",
+	})
+	assert.NoError(t, err)
+
+	// Valid http URLs pass
+	err = ValidateUserUpdateRequest(UserUpdateRequest{
+		Picture:    "http://example.com/photo.jpg",
+		Website:    "http://example.com",
+		ProfileURL: "http://example.com/profile",
+	})
+	assert.NoError(t, err)
+
+	// javascript: in Picture rejected
+	err = ValidateUserUpdateRequest(UserUpdateRequest{
+		Picture: "javascript:alert(1)",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "picture is invalid")
+
+	// javascript: in Website rejected
+	err = ValidateUserUpdateRequest(UserUpdateRequest{
+		Website: "javascript:alert(1)",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "website is invalid")
+
+	// javascript: in ProfileURL rejected
+	err = ValidateUserUpdateRequest(UserUpdateRequest{
+		ProfileURL: "javascript:alert(1)",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "profile URL is invalid")
+
+	// file: scheme rejected
+	err = ValidateUserUpdateRequest(UserUpdateRequest{
+		Picture: "file:///etc/passwd",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "picture is invalid")
+
+	// Relative URL without scheme rejected
+	err = ValidateUserUpdateRequest(UserUpdateRequest{
+		Website: "example.com/page",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "website is invalid")
+}


### PR DESCRIPTION
## Summary
- Add `validateURLScheme` helper that rejects non-http/https URI schemes (javascript:, file:, data:, etc.) on OIDC profile URL fields
- Apply validation to `picture`, `website`, and `profile` (ProfileURL) fields in `ValidateUserUpdateRequest`, which covers both admin user updates and account self-service profile updates
- Move profile field validation in signup handler before user creation to prevent orphaned accounts on validation failure

## Test plan
- [x] Unit tests for `validateURLScheme` helper: http/https pass, javascript:/file:/data:/schemeless rejected
- [x] Unit tests for `ValidateUserUpdateRequest` URL fields: empty allowed, valid URLs pass, malicious schemes rejected per field
- [x] `go test -p 1 ./pkg/user/...` passes

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)