### PR TITLE
security: enforce scope check on account API middleware

### DIFF
--- a/pkg/jwtutil/validate.go
+++ b/pkg/jwtutil/validate.go
@@ -16,6 +16,7 @@ type AccessTokenClaims struct {
 	ExpiresAt int64    `json:"exp"`
 	Audience  []string `json:"aud"`
 	Issuer    string   `json:"iss"`
+	Scope     string   `json:"scope"`
 }
 
 func (a *AccessTokenClaims) Valid() error {

--- a/pkg/middleware/account_auth.go
+++ b/pkg/middleware/account_auth.go
@@ -72,6 +72,7 @@ func AccountAuthMiddleware(next http.Handler) http.Handler {
 		// Require openid, profile, and email scopes for account API access.
 		// This prevents third-party tokens with partial scopes from performing
 		// account management operations beyond what the user consented to.
+		// TODO #365: add per-field phone and address scope enforcement
 		if !hasRequiredScopes(claims.Scope, []string{"openid", "profile", "email"}) {
 			slog.Warn("account_auth: insufficient scope", "scope", claims.Scope, "ip", utils.GetClientIP(r))
 			utils.WriteErrorResponse(w, http.StatusForbidden, "insufficient_scope", "Token requires openid, profile, and email scopes")

--- a/pkg/middleware/account_auth.go
+++ b/pkg/middleware/account_auth.go
@@ -13,6 +13,23 @@ import (
 	"github.com/eugenioenko/autentico/pkg/utils"
 )
 
+func hasRequiredScopes(tokenScope string, required []string) bool {
+	scopes := strings.Fields(tokenScope)
+	for _, req := range required {
+		found := false
+		for _, s := range scopes {
+			if s == req {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
 // AccountAuthMiddleware verifies that the request has a valid JWT token
 // issued for the account API (audience "autentico-account" or "autentico-admin").
 func AccountAuthMiddleware(next http.Handler) http.Handler {
@@ -49,6 +66,15 @@ func AccountAuthMiddleware(next http.Handler) http.Handler {
 		if err := jwtutil.ValidateAudience(claims.Audience, []string{config.AccountClientID, config.AdminClientID}); err != nil {
 			slog.Warn("account_auth: token not issued for account API", "aud", claims.Audience, "ip", utils.GetClientIP(r))
 			utils.WriteErrorResponse(w, http.StatusForbidden, "forbidden", "Token not issued for account API")
+			return
+		}
+
+		// Require openid, profile, and email scopes for account API access.
+		// This prevents third-party tokens with partial scopes from performing
+		// account management operations beyond what the user consented to.
+		if !hasRequiredScopes(claims.Scope, []string{"openid", "profile", "email"}) {
+			slog.Warn("account_auth: insufficient scope", "scope", claims.Scope, "ip", utils.GetClientIP(r))
+			utils.WriteErrorResponse(w, http.StatusForbidden, "insufficient_scope", "Token requires openid, profile, and email scopes")
 			return
 		}
 

--- a/pkg/middleware/account_auth_test.go
+++ b/pkg/middleware/account_auth_test.go
@@ -353,6 +353,50 @@ func TestAccountAuthMiddleware_WWWAuthenticate_On401(t *testing.T) {
 	}
 }
 
+func TestAccountAuthMiddleware_InsufficientScope(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	userID := xid.New().String()
+	_, _ = db.GetDB().Exec(`INSERT INTO users (id, username, email, password, role) VALUES (?, 'scopeuser', 'scope@example.com', 'hashed', 'user')`, userID)
+
+	accessClaims := jwt.MapClaims{
+		"exp":   time.Now().Add(time.Hour).Unix(),
+		"iat":   time.Now().Unix(),
+		"iss":   config.GetBootstrap().AppAuthIssuer,
+		"aud":   []string{config.GetBootstrap().AppAuthIssuer, config.AccountClientID},
+		"sub":   userID,
+		"typ":   "Bearer",
+		"sid":   xid.New().String(),
+		"scope": "openid",
+	}
+	accessToken := jwt.NewWithClaims(jwt.SigningMethodRS256, accessClaims)
+	accessToken.Header["kid"] = config.GetBootstrap().AuthJwkCertKeyID
+	token, err := accessToken.SignedString(key.GetPrivateKey())
+	assert.NoError(t, err)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	wrapped := AccountAuthMiddleware(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	wrapped.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Contains(t, rr.Body.String(), "insufficient_scope")
+}
+
+func TestHasRequiredScopes(t *testing.T) {
+	assert.True(t, hasRequiredScopes("openid profile email", []string{"openid", "profile", "email"}))
+	assert.True(t, hasRequiredScopes("openid profile email offline_access", []string{"openid", "profile", "email"}))
+	assert.False(t, hasRequiredScopes("openid", []string{"openid", "profile", "email"}))
+	assert.False(t, hasRequiredScopes("openid profile", []string{"openid", "profile", "email"}))
+	assert.False(t, hasRequiredScopes("", []string{"openid", "profile", "email"}))
+	assert.True(t, hasRequiredScopes("openid profile email", []string{}))
+}
+
 // Verify that lowercase "bearer" is accepted (RFC 6750 §2.1 / RFC 7235).
 func TestAccountAuthMiddleware_CaseInsensitiveBearer(t *testing.T) {
 	testutils.WithTestDB(t)

--- a/tests/e2e/test_helpers_test.go
+++ b/tests/e2e/test_helpers_test.go
@@ -113,6 +113,7 @@ func performAuthorizationCodeFlow(t *testing.T, ts *TestServer, clientID, redire
 		"response_type":        {"code"},
 		"client_id":            {clientID},
 		"redirect_uri":         {redirectURI},
+		"scope":                {"openid profile email"},
 		"state":                {state},
 		"code_challenge":       {testCodeChallenge},
 		"code_challenge_method": {"S256"},
@@ -137,6 +138,7 @@ func performAuthorizationCodeFlow(t *testing.T, ts *TestServer, clientID, redire
 	form.Set("username", username)
 	form.Set("password", password)
 	form.Set("redirect_uri", redirectURI)
+	form.Set("scope", "openid profile email")
 	form.Set("state", state)
 	form.Set("client_id", clientID)
 	form.Set("code_challenge", testCodeChallenge)


### PR DESCRIPTION
## Summary

- Require `openid`, `profile`, and `email` scopes for all `/account/api/*` requests
- Prevents third-party tokens with partial scopes from performing account management operations beyond what the user consented to
- Add `Scope` field to `AccessTokenClaims` so the middleware can read the JWT scope claim

### What was wrong

The account middleware only checked audience — never scope. A token from a third-party RP with `scope=openid` (read-only consent) could perform destructive operations: profile updates, deletion requests, session revocation, passkey registration.

### Fix

One check in `AccountAuthMiddleware`: verify the token has all three required scopes (`openid profile email`). First-party apps (account UI, admin UI) always request the full set — nothing changes for them. Third-party tokens with partial scopes are rejected.

Closes #362

## Known  limitations
`phone` and `address` is not set in the scocpe even though  `account/api` allows modifying those. Requiring them would be a breaking change that is tracked for v3 here https://github.com/eugenioenko/autentico/issues/365
