### PR TITLE
security: add per-challenge attempt limit to TOTP verification

### DIFF
--- a/pkg/mfa/handler.go
+++ b/pkg/mfa/handler.go
@@ -189,8 +189,14 @@ func handleMfaPost(w http.ResponseWriter, r *http.Request) {
 		} else {
 			// Verification flow: validate against stored secret
 			if !ValidateTotpCode(usr.TotpSecret, code) {
-				slog.Warn("mfa: invalid TOTP verification code", "request_id", reqid.Get(r.Context()), "ip", utils.GetClientIP(r))
+				_ = IncrementFailedAttempts(challenge.ID)
+				slog.Warn("mfa: invalid TOTP verification code", "request_id", reqid.Get(r.Context()), "ip", utils.GetClientIP(r), "attempts", challenge.FailedAttempts+1)
 				audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "totp"), utils.GetClientIP(r))
+				if challenge.FailedAttempts+1 >= 5 {
+					_ = MarkChallengeUsed(challenge.ID)
+					redirectToLoginWithError(w, r, challenge, "Too many failed attempts. Please log in again.")
+					return
+				}
 				renderVerifyPage(w, r, challenge, cfg, "Invalid verification code", "")
 				return
 			}

--- a/pkg/mfa/handler_test.go
+++ b/pkg/mfa/handler_test.go
@@ -665,4 +665,59 @@ func TestHandleMfa_SwitchToSameMethodIgnored(t *testing.T) {
 	assert.False(t, old.Used)
 }
 
+func TestHandleMfa_Post_TotpLockedAfter5Attempts(t *testing.T) {
+	testutils.WithTestDB(t)
+	u, _ := user.CreateUser("mfalock", "pass", "mfalock@example.com")
+	secret, _, _ := GenerateTotpSecret("mfalock", "Auth")
+	_ = user.SaveTotpSecret(u.ID, secret)
+
+	c := MfaChallenge{
+		ID:         "chall-lock",
+		UserID:     u.ID,
+		Method:     "totp",
+		LoginState: `{"redirect_uri":"http://localhost/cb","state":"s1","client_id":"autentico-account","scope":"openid profile email"}`,
+		ExpiresAt:  time.Now().Add(time.Hour),
+	}
+	_ = CreateMfaChallenge(c)
+
+	// First 4 wrong attempts — should re-render the verify page
+	for i := 0; i < 4; i++ {
+		form := url.Values{}
+		form.Set("challenge_id", "chall-lock")
+		form.Set("code", "000000")
+		req := httptest.NewRequest(http.MethodPost, "/oauth2/mfa", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rr := httptest.NewRecorder()
+		HandleMfa(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code, "attempt %d should render verify page", i+1)
+		assert.Contains(t, rr.Body.String(), "Invalid verification code")
+	}
+
+	// 5th wrong attempt — should lock the challenge and redirect to login
+	form := url.Values{}
+	form.Set("challenge_id", "chall-lock")
+	form.Set("code", "000000")
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/mfa", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	HandleMfa(rr, req)
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "error=Too+many+failed+attempts")
+
+	// 6th attempt — challenge is used, should be rejected
+	form = url.Values{}
+	form.Set("challenge_id", "chall-lock")
+	form.Set("code", "000000")
+	req = httptest.NewRequest(http.MethodPost, "/oauth2/mfa", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr = httptest.NewRecorder()
+	HandleMfa(rr, req)
+	assert.Equal(t, http.StatusFound, rr.Code)
+
+	// Verify the challenge is marked as used
+	ch, _ := MfaChallengeByIDIncludingExpired("chall-lock")
+	assert.True(t, ch.Used)
+	assert.GreaterOrEqual(t, ch.FailedAttempts, 5)
+}
+
 func boolPtr(b bool) *bool { return &b }


### PR DESCRIPTION
## Summary

- Add per-challenge failed attempt counting to the TOTP verification branch, matching the existing email OTP behavior
- After 5 wrong TOTP codes, the challenge is marked as used and the user is redirected to login with "Too many failed attempts"
- The 6th attempt is rejected because the challenge is already used

### What was wrong

The email OTP branch (line 201-206) counted failed attempts and locked the challenge after 5 failures. The TOTP branch just re-rendered the verify page with no counter — allowing unlimited retries against the same challenge until expiration.

### Fix

3 lines added to the TOTP verification branch: `IncrementFailedAttempts`, check `>= 5`, `MarkChallengeUsed`. Same pattern as email OTP.

Closes #360

## Test plan

- [x] `go test -p 1 ./pkg/mfa/...` — all tests pass
- [x] New test: 4 wrong attempts → re-renders verify page
- [x] New test: 5th wrong attempt → redirects with "Too many failed attempts"
- [x] New test: 6th attempt → rejected (challenge used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)