### PR TITLE
test: add functional tests for account API scope enforcement

### DIFF
--- a/tests/functional/tests/account-api.test.ts
+++ b/tests/functional/tests/account-api.test.ts
@@ -67,3 +67,30 @@ describe('Account API — audience enforcement', () => {
     expect(resp.status).toBe(403);
   });
 });
+
+describe('Account API — scope enforcement', () => {
+  it('rejects token with only openid scope', async () => {
+    const tokens = await obtainAccountToken('admin', 'Password123!', 'openid');
+
+    const resp = await getResponse(`${BASE_URL}/account/api/profile`, tokens.access_token);
+    expect(resp.status).toBe(403);
+    const body = await resp.json();
+    expect(body.error).toBe('insufficient_scope');
+  });
+
+  it('rejects token with openid profile (missing email)', async () => {
+    const tokens = await obtainAccountToken('admin', 'Password123!', 'openid profile');
+
+    const resp = await getResponse(`${BASE_URL}/account/api/profile`, tokens.access_token);
+    expect(resp.status).toBe(403);
+    const body = await resp.json();
+    expect(body.error).toBe('insufficient_scope');
+  });
+
+  it('accepts token with openid profile email', async () => {
+    const tokens = await obtainAccountToken('admin', 'Password123!', 'openid profile email');
+
+    const resp = await getResponse(`${BASE_URL}/account/api/profile`, tokens.access_token);
+    expect(resp.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Add 3 functional tests verifying that the account API middleware rejects tokens with insufficient scopes (added in #364):

- `openid` only → 403 `insufficient_scope`
- `openid profile` (missing email) → 403 `insufficient_scope`
- `openid profile email` → 200 (accepted)

## Test plan

- [x] `pnpm test` in `tests/functional/` — 196/196 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)