### PR TITLE
ux: redirect non-admin users to unauthorized  instead of dashboard error 

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -1,20 +1,39 @@
 import { lazy, Suspense, useMemo } from "react";
-import { BrowserRouter, Routes, Route, useNavigate, useLocation, Outlet } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate, useNavigate, useLocation, Outlet } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { App, ConfigProvider, theme } from "antd";
-import { AuthProvider, RequireAuth } from "oidc-js-react";
+import { AuthProvider, RequireAuth, useAuth } from "oidc-js-react";
 import type { OidcConfig } from "oidc-js-react";
 import { ThemeProvider, useTheme } from "./context/ThemeContext";
 import AuthBridge from "./components/AuthBridge";
 import AdminLayout from "./layouts/AdminLayout";
 
+function parseJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const base64 = token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/");
+    return JSON.parse(atob(base64));
+  } catch {
+    return null;
+  }
+}
+
 function ProtectedRoute() {
   const { pathname } = useLocation();
+  const { tokens } = useAuth();
+
+  if (tokens.access) {
+    const payload = parseJwtPayload(tokens.access);
+    if (payload && payload.role !== "admin") {
+      return <Navigate to="/access-denied" replace />;
+    }
+  }
+
   return <RequireAuth key={pathname}><Outlet /></RequireAuth>;
 }
 
 const LoginPage = lazy(() => import("./pages/LoginPage"));
 const CallbackPage = lazy(() => import("./pages/CallbackPage"));
+const AccessDeniedPage = lazy(() => import("./pages/AccessDeniedPage"));
 const DashboardPage = lazy(() => import("./pages/DashboardPage"));
 const ClientsPage = lazy(() => import("./pages/ClientsPage"));
 const UsersPage = lazy(() => import("./pages/UsersPage"));
@@ -88,6 +107,7 @@ function ThemedApp() {
             <Routes>
               <Route path="/login" element={<Suspense fallback={null}><LoginPage /></Suspense>} />
               <Route path="/callback" element={<Suspense fallback={null}><CallbackPage /></Suspense>} />
+              <Route path="/access-denied" element={<Suspense fallback={null}><AccessDeniedPage /></Suspense>} />
               <Route element={<ProtectedRoute />}>
                 <Route element={<AdminLayout />}>
                   <Route index element={<DashboardPage />} />

--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -36,6 +36,11 @@ apiClient.interceptors.response.use(
     const originalRequest = error.config;
     const retryCount = originalRequest._retryCount ?? 0;
 
+    if (error.response?.status === 403) {
+      window.location.href = "/admin/access-denied";
+      return new Promise(() => {});
+    }
+
     if (error.response?.status !== 401 || retryCount >= MAX_RETRIES) {
       return Promise.reject(error);
     }

--- a/admin-ui/src/pages/AccessDeniedPage.tsx
+++ b/admin-ui/src/pages/AccessDeniedPage.tsx
@@ -1,0 +1,28 @@
+import { Button, Result, ConfigProvider, theme } from "antd";
+
+export default function AccessDeniedPage() {
+  return (
+    <ConfigProvider theme={{ algorithm: theme.defaultAlgorithm }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          minHeight: "100vh",
+          background: "#f0f2f5",
+        }}
+      >
+        <Result
+          status="403"
+          title="Unauthorized"
+          subTitle="Your account does not have administrator privileges."
+          extra={
+            <Button type="primary" href="/account/">
+              Go to Account Portal
+            </Button>
+          }
+        />
+      </div>
+    </ConfigProvider>
+  );
+}

--- a/pkg/token/generate.go
+++ b/pkg/token/generate.go
@@ -67,6 +67,7 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 		"sid":       sessionID,
 		"acr":       acrForUser(user),
 		"scope":     scope,
+		"role":      user.Role,
 	}
 
 	// OIDC Core §5.4: only embed profile claims when "profile" scope was requested.

--- a/pkg/token/generate_test.go
+++ b/pkg/token/generate_test.go
@@ -36,6 +36,145 @@ func TestGenerateTokens(t *testing.T) {
 	assert.WithinDuration(t, time.Now().Add(config.Values.AuthRefreshTokenExpiration), tokens.RefreshExpiresAt, time.Minute)
 }
 
+func TestGenerateTokens_AccessTokenClaimSet(t *testing.T) {
+	config.Values.AuthAccessTokenExpiration = 15 * time.Minute
+	config.Bootstrap.AuthRefreshTokenSecret = "test-secret"
+	config.Bootstrap.AppAuthIssuer = "http://localhost/oauth2"
+	config.Values.AuthAccessTokenAudience = []string{}
+
+	testUser := user.User{
+		ID:              "user-1",
+		Username:        "testuser",
+		Email:           "testuser@example.com",
+		IsEmailVerified: true,
+		Role:            "user",
+	}
+
+	tokens, err := GenerateTokens(testUser, "my-client", "openid profile email", config.Get())
+	require.NoError(t, err)
+
+	parsed, err := jwt.Parse(tokens.AccessToken, func(token *jwt.Token) (interface{}, error) {
+		return key.GetPublicKey(), nil
+	})
+	require.NoError(t, err)
+	claims := parsed.Claims.(jwt.MapClaims)
+
+	expectedKeys := []string{
+		"exp", "iat", "auth_time", "jti", "iss", "aud", "sub",
+		"typ", "azp", "sid", "acr", "scope", "role",
+		"name", "preferred_username",
+		"email", "email_verified",
+	}
+	for _, k := range expectedKeys {
+		assert.Contains(t, claims, k, "access token must contain claim %q", k)
+	}
+	assert.Len(t, claims, len(expectedKeys), "access token must contain exactly %d claims, got %d — update this test if adding new claims", len(expectedKeys), len(claims))
+
+	assert.Equal(t, "user-1", claims["sub"])
+	assert.Equal(t, "http://localhost/oauth2", claims["iss"])
+	assert.Equal(t, "my-client", claims["azp"])
+	assert.Equal(t, "Bearer", claims["typ"])
+	assert.Equal(t, "1", claims["acr"])
+	assert.Equal(t, "openid profile email", claims["scope"])
+	assert.Equal(t, "user", claims["role"])
+	assert.Equal(t, "testuser", claims["name"])
+	assert.Equal(t, "testuser", claims["preferred_username"])
+	assert.Equal(t, "testuser@example.com", claims["email"])
+	assert.Equal(t, true, claims["email_verified"])
+}
+
+func TestGenerateTokens_AccessTokenClaimSet_MinimalScope(t *testing.T) {
+	config.Values.AuthAccessTokenExpiration = 15 * time.Minute
+	config.Bootstrap.AuthRefreshTokenSecret = "test-secret"
+	config.Bootstrap.AppAuthIssuer = "http://localhost/oauth2"
+	config.Values.AuthAccessTokenAudience = []string{}
+
+	testUser := user.User{
+		ID:       "user-1",
+		Username: "testuser",
+		Email:    "testuser@example.com",
+		Role:     "admin",
+	}
+
+	tokens, err := GenerateTokens(testUser, "my-client", "openid", config.Get())
+	require.NoError(t, err)
+
+	parsed, err := jwt.Parse(tokens.AccessToken, func(token *jwt.Token) (interface{}, error) {
+		return key.GetPublicKey(), nil
+	})
+	require.NoError(t, err)
+	claims := parsed.Claims.(jwt.MapClaims)
+
+	expectedKeys := []string{
+		"exp", "iat", "auth_time", "jti", "iss", "aud", "sub",
+		"typ", "azp", "sid", "acr", "scope", "role",
+	}
+	for _, k := range expectedKeys {
+		assert.Contains(t, claims, k, "access token must contain claim %q", k)
+	}
+	assert.Len(t, claims, len(expectedKeys), "access token with openid-only scope must contain exactly %d claims", len(expectedKeys))
+
+	assert.Equal(t, "admin", claims["role"])
+	assert.Nil(t, claims["name"], "name must not be present without profile scope")
+	assert.Nil(t, claims["email"], "email must not be present without email scope")
+}
+
+func TestGenerateIDToken_ClaimSet(t *testing.T) {
+	config.Values.AuthAccessTokenExpiration = 15 * time.Minute
+	config.Bootstrap.AppAuthIssuer = "http://localhost/oauth2"
+
+	testUser := user.User{
+		ID:              "user-1",
+		Username:        "testuser",
+		GivenName:       "Test",
+		FamilyName:      "User",
+		Email:           "testuser@example.com",
+		IsEmailVerified: true,
+	}
+
+	idToken, err := GenerateIDToken(testUser, "session-1", "test-nonce", "openid profile email", "my-client", time.Now(), "fake-access-token")
+	require.NoError(t, err)
+	claims := parseIDTokenClaims(t, idToken)
+
+	expectedKeys := []string{
+		"iss", "sub", "aud", "exp", "iat", "auth_time", "sid", "acr",
+		"nonce", "at_hash", "azp",
+		"name", "preferred_username", "given_name", "family_name",
+		"email", "email_verified",
+	}
+	for _, k := range expectedKeys {
+		assert.Contains(t, claims, k, "ID token must contain claim %q", k)
+	}
+	assert.Len(t, claims, len(expectedKeys), "ID token must contain exactly %d claims, got %d — update this test if adding new claims", len(expectedKeys), len(claims))
+}
+
+func TestGenerateIDToken_ClaimSet_MinimalScope(t *testing.T) {
+	config.Values.AuthAccessTokenExpiration = 15 * time.Minute
+	config.Bootstrap.AppAuthIssuer = "http://localhost/oauth2"
+
+	testUser := user.User{
+		ID:       "user-1",
+		Username: "testuser",
+	}
+
+	idToken, err := GenerateIDToken(testUser, "session-1", "", "openid", "my-client", time.Now(), "")
+	require.NoError(t, err)
+	claims := parseIDTokenClaims(t, idToken)
+
+	expectedKeys := []string{
+		"iss", "sub", "aud", "exp", "iat", "auth_time", "sid", "acr", "azp",
+	}
+	for _, k := range expectedKeys {
+		assert.Contains(t, claims, k, "ID token must contain claim %q", k)
+	}
+	assert.Len(t, claims, len(expectedKeys), "ID token with openid-only scope must contain exactly %d claims", len(expectedKeys))
+
+	assert.Nil(t, claims["nonce"], "nonce must not be present when empty")
+	assert.Nil(t, claims["at_hash"], "at_hash must not be present without access token")
+	assert.Nil(t, claims["name"], "name must not be present without profile scope")
+	assert.Nil(t, claims["email"], "email must not be present without email scope")
+}
+
 func TestGenerateIDToken_WithNonce(t *testing.T) {
 	config.Values.AuthAccessTokenExpiration = 15 * time.Minute
 	config.Bootstrap.AppAuthIssuer = "http://localhost/oauth2"


### PR DESCRIPTION
## Motivation
Before switch,ing to oidc-js-react we used oidc-client-ts and made an extra api call to verify that user was admin.  That was removed but it means that if non admin logs in into admin portal, they just get errors because they have no access. This adds "role" into the access token and checks on it. Also any 403 will redirect to unauthorized.


## Summary

- Non-admin users logging into the admin panel now see a clean "Unauthorized" page with a link to the Account Portal, instead of a broken dashboard
- Add `role` claim to access tokens for client-side role checking
- Add `/admin/access-denied` route with friendly messaging
- Axios interceptor handles 403 responses as a fallback

## Test plan

- [x] `go test -p 1 ./...` — all tests pass
- [ ] Log in to admin UI as non-admin user — see "Unauthorized" page immediately
- [ ] Log in to admin UI as admin — works normally
- [ ] Verify access token contains `role` claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)