### PR TITLE
test: isolate functional tests with per-file server instances

### DIFF
--- a/tests/functional/helpers.ts
+++ b/tests/functional/helpers.ts
@@ -17,6 +17,11 @@ let cachedAdminToken: string | null = null;
 // Client with ROPC enabled, created on first use
 let ropcClientID: string | null = null;
 
+export function resetState(): void {
+  cachedAdminToken = null;
+  ropcClientID = null;
+}
+
 export async function postForm(url: string, data: Record<string, string>, bearer?: string): Promise<Response> {
   const body = new URLSearchParams(data);
   const headers: Record<string, string> = { 'Content-Type': 'application/x-www-form-urlencoded' };

--- a/tests/functional/server-manager.ts
+++ b/tests/functional/server-manager.ts
@@ -1,0 +1,70 @@
+import { execSync, spawn, type ChildProcess } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const ROOT = join(import.meta.dirname, '../..');
+const BINARY = join(ROOT, 'autentico');
+const PORT = 19999;
+const BASE_URL = `http://localhost:${PORT}`;
+
+let serverProcess: ChildProcess | null = null;
+let tempDir: string | null = null;
+
+async function waitForServer(url: string, timeoutMs = 15000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`Server did not start within ${timeoutMs}ms`);
+}
+
+export async function startServer(): Promise<void> {
+  tempDir = mkdtempSync(join(tmpdir(), 'autentico-functional-'));
+
+  const env = {
+    ...process.env,
+    AUTENTICO_DB_FILE_PATH: join(tempDir, 'autentico.db'),
+  };
+
+  execSync(`${BINARY} init --url ${BASE_URL}`, { cwd: tempDir, stdio: 'pipe', env });
+
+  execSync(
+    `${BINARY} onboard --username admin --password Password123! --email admin@test.com --enable-admin-password-grant`,
+    { cwd: tempDir, stdio: 'pipe', env }
+  );
+
+  serverProcess = spawn(BINARY, ['start'], {
+    cwd: tempDir,
+    stdio: 'pipe',
+    detached: false,
+    env: {
+      ...env,
+      AUTENTICO_CSRF_SECURE_COOKIE: 'false',
+      AUTENTICO_IDP_SESSION_SECURE: 'false',
+      AUTENTICO_REFRESH_TOKEN_SECURE: 'false',
+      AUTENTICO_RATE_LIMIT_RPS: '0',
+      AUTENTICO_RATE_LIMIT_RPM: '0',
+    },
+  });
+
+  serverProcess.stdout?.on('data', (d: Buffer) => process.stdout.write(d));
+  serverProcess.stderr?.on('data', (d: Buffer) => process.stderr.write(d));
+
+  await waitForServer(`${BASE_URL}/.well-known/openid-configuration`);
+}
+
+export function stopServer(): void {
+  if (serverProcess?.pid) {
+    serverProcess.kill('SIGTERM');
+    serverProcess = null;
+  }
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  }
+}

--- a/tests/functional/setup-per-file.ts
+++ b/tests/functional/setup-per-file.ts
@@ -1,0 +1,12 @@
+import { beforeAll, afterAll } from 'vitest';
+import { startServer, stopServer } from './server-manager';
+import { resetState } from './helpers';
+
+beforeAll(async () => {
+  resetState();
+  await startServer();
+}, 30000);
+
+afterAll(() => {
+  stopServer();
+});

--- a/tests/functional/setup.ts
+++ b/tests/functional/setup.ts
@@ -1,92 +1,15 @@
-import { execSync, spawn, type ChildProcess } from 'child_process';
-import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { existsSync } from 'fs';
+import { execSync } from 'child_process';
 import { join } from 'path';
-import { tmpdir } from 'os';
 
 const ROOT = join(import.meta.dirname, '../..');
 const BINARY = join(ROOT, 'autentico');
-const PORT = 19999;
-const BASE_URL = `http://localhost:${PORT}`;
-
-let serverProcess: ChildProcess | null = null;
-let tempDir: string | null = null;
-
-async function waitForServer(url: string, timeoutMs = 15000): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const res = await fetch(url);
-      if (res.ok) return;
-    } catch {}
-    await new Promise((r) => setTimeout(r, 200));
-  }
-  throw new Error(`Server did not start within ${timeoutMs}ms`);
-}
 
 export async function setup() {
-  // 1. Build the Go binary (skip if already built, e.g. by CI build job)
   if (existsSync(BINARY)) {
     console.log('[functional] Binary already exists, skipping build.');
   } else {
     console.log('[functional] Building binary...');
     execSync('make build-go', { cwd: ROOT, stdio: 'inherit' });
-  }
-
-  // 2. Create a temp working directory for .env and .db
-  tempDir = mkdtempSync(join(tmpdir(), 'autentico-functional-'));
-  console.log(`[functional] Temp dir: ${tempDir}`);
-
-  const env = {
-    ...process.env,
-    AUTENTICO_DB_FILE_PATH: join(tempDir, 'autentico.db'),
-  };
-
-  // 3. Initialize configuration
-  console.log('[functional] Running init...');
-  execSync(`${BINARY} init --url ${BASE_URL}`, { cwd: tempDir, stdio: 'inherit', env });
-
-  // 4. Create admin account via CLI onboard
-  console.log('[functional] Running onboard...');
-  execSync(
-    `${BINARY} onboard --username admin --password Password123! --email admin@test.com --enable-admin-password-grant`,
-    { cwd: tempDir, stdio: 'inherit', env }
-  );
-
-  // 5. Start the server
-  console.log('[functional] Starting server...');
-  serverProcess = spawn(BINARY, ['start'], {
-    cwd: tempDir,
-    stdio: 'pipe',
-    detached: false,
-    env: {
-      ...env,
-      AUTENTICO_CSRF_SECURE_COOKIE: 'false',
-      AUTENTICO_IDP_SESSION_SECURE: 'false',
-      AUTENTICO_REFRESH_TOKEN_SECURE: 'false',
-      AUTENTICO_RATE_LIMIT_RPS: '0',
-      AUTENTICO_RATE_LIMIT_RPM: '0',
-    },
-  });
-
-  serverProcess.stdout?.on('data', (d) => process.stdout.write(d));
-  serverProcess.stderr?.on('data', (d) => process.stderr.write(d));
-
-  // 6. Wait for server readiness
-  await waitForServer(`${BASE_URL}/.well-known/openid-configuration`);
-  console.log('[functional] Server is ready.');
-}
-
-export async function teardown() {
-  // Kill server
-  if (serverProcess?.pid) {
-    console.log('[functional] Stopping server...');
-    serverProcess.kill('SIGTERM');
-    serverProcess = null;
-  }
-
-  // Clean up temp dir
-  if (tempDir) {
-    rmSync(tempDir, { recursive: true, force: true });
-    tempDir = null;
   }
 }

--- a/tests/functional/tests/login-page-modes.test.ts
+++ b/tests/functional/tests/login-page-modes.test.ts
@@ -50,6 +50,11 @@ describe('Login page — auth_mode=password (default)', () => {
     const html = await fetchLoginPage();
     expect(html).not.toContain('id="passkey-login-btn"');
   });
+
+  it('does not show "or" divider', async () => {
+    const html = await fetchLoginPage();
+    expect(html).not.toContain('"auth-divider">or<');
+  });
 });
 
 describe('Login page — auth_mode=password_and_passkey', () => {

--- a/tests/functional/vitest.config.ts
+++ b/tests/functional/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globalSetup: ['./setup.ts'],
+    setupFiles: ['./setup-per-file.ts'],
     testTimeout: 15000,
     hookTimeout: 60000,
     fileParallelism: false,


### PR DESCRIPTION
## Summary
- Each functional test file now starts/stops its own server instance with a fresh temp dir and database, eliminating shared state between test files
- Added `server-manager.ts` (modeled after browser tests) and `setup-per-file.ts` as a vitest `setupFiles` hook
- Trimmed `setup.ts` global setup to only handle binary build check
- Restored the "or" divider test in `login-page-modes.test.ts` that was previously removed due to federation provider leakage

## Test plan
- [x] All 29 test files, 213 tests pass
- [x] Verified the restored divider test passes with isolated server
- [x] Special test files (`custom-oauth-path`, `federation-flow`) that manage their own servers still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)