### PR TITLE
fix: prevent column ellipsis from clipping copy icon in tables

### DIFF
--- a/admin-ui/src/components/users/DeletionRequestsTab.tsx
+++ b/admin-ui/src/components/users/DeletionRequestsTab.tsx
@@ -112,7 +112,7 @@ export default function DeletionRequestsTab() {
       sorter: true,
       ellipsis: true,
       render: (email: string) => (
-        <Text copyable={{ text: email }}>
+        <Text copyable={{ text: email }} ellipsis>
           {email}
         </Text>
       ),

--- a/admin-ui/src/components/users/DeletionRequestsTab.tsx
+++ b/admin-ui/src/components/users/DeletionRequestsTab.tsx
@@ -112,7 +112,7 @@ export default function DeletionRequestsTab() {
       sorter: true,
       ellipsis: true,
       render: (email: string) => (
-        <Text copyable={{ text: email }} ellipsis>
+        <Text copyable={{ text: email }}>
           {email}
         </Text>
       ),

--- a/admin-ui/src/components/users/DeletionRequestsTab.tsx
+++ b/admin-ui/src/components/users/DeletionRequestsTab.tsx
@@ -110,7 +110,6 @@ export default function DeletionRequestsTab() {
       dataIndex: "email",
       key: "email",
       sorter: true,
-      ellipsis: true,
       render: (email: string) => (
         <Text copyable={{ text: email }} ellipsis>
           {email}

--- a/admin-ui/src/pages/AuditLogPage.tsx
+++ b/admin-ui/src/pages/AuditLogPage.tsx
@@ -205,7 +205,7 @@ export default function AuditLogPage() {
       width: 160,
       render: (username: string) =>
         username ? (
-          <Text copyable={{ text: username }} ellipsis>
+          <Text copyable={{ text: username }}>
             {username}
           </Text>
         ) : (
@@ -223,7 +223,7 @@ export default function AuditLogPage() {
         if (!record.target_id)
           return <Text>{record.target_type}</Text>;
         return (
-          <Text copyable={{ text: record.target_id }} ellipsis>
+          <Text copyable={{ text: record.target_id }}>
             {record.target_type}: {record.target_id}
           </Text>
         );

--- a/admin-ui/src/pages/AuditLogPage.tsx
+++ b/admin-ui/src/pages/AuditLogPage.tsx
@@ -205,7 +205,7 @@ export default function AuditLogPage() {
       width: 160,
       render: (username: string) =>
         username ? (
-          <Text copyable={{ text: username }}>
+          <Text copyable={{ text: username }} ellipsis>
             {username}
           </Text>
         ) : (
@@ -223,7 +223,7 @@ export default function AuditLogPage() {
         if (!record.target_id)
           return <Text>{record.target_type}</Text>;
         return (
-          <Text copyable={{ text: record.target_id }}>
+          <Text copyable={{ text: record.target_id }} ellipsis>
             {record.target_type}: {record.target_id}
           </Text>
         );

--- a/admin-ui/src/pages/AuditLogPage.tsx
+++ b/admin-ui/src/pages/AuditLogPage.tsx
@@ -216,7 +216,6 @@ export default function AuditLogPage() {
       title: "Target",
       key: "target",
       width: 200,
-      ellipsis: true,
       render: (_: unknown, record: AuditLogEntry) => {
         if (!record.target_type && !record.target_id)
           return <Text type="secondary">—</Text>;

--- a/admin-ui/src/pages/ClientsPage.tsx
+++ b/admin-ui/src/pages/ClientsPage.tsx
@@ -110,7 +110,6 @@ export default function ClientsPage() {
             ? "descend"
             : "ascend"
           : undefined,
-      ellipsis: true,
       render: (name: string) => (
         <Text copyable={{ text: name }} ellipsis>
           {name}
@@ -128,7 +127,6 @@ export default function ClientsPage() {
             ? "descend"
             : "ascend"
           : undefined,
-      ellipsis: true,
       render: (id: string) => (
         <Text copyable={{ text: id }} ellipsis>
           {id}

--- a/admin-ui/src/pages/ClientsPage.tsx
+++ b/admin-ui/src/pages/ClientsPage.tsx
@@ -112,7 +112,7 @@ export default function ClientsPage() {
           : undefined,
       ellipsis: true,
       render: (name: string) => (
-        <Text copyable={{ text: name }} ellipsis>
+        <Text copyable={{ text: name }}>
           {name}
         </Text>
       ),
@@ -130,7 +130,7 @@ export default function ClientsPage() {
           : undefined,
       ellipsis: true,
       render: (id: string) => (
-        <Text copyable={{ text: id }} ellipsis>
+        <Text copyable={{ text: id }}>
           {id}
         </Text>
       ),

--- a/admin-ui/src/pages/ClientsPage.tsx
+++ b/admin-ui/src/pages/ClientsPage.tsx
@@ -112,7 +112,7 @@ export default function ClientsPage() {
           : undefined,
       ellipsis: true,
       render: (name: string) => (
-        <Text copyable={{ text: name }}>
+        <Text copyable={{ text: name }} ellipsis>
           {name}
         </Text>
       ),
@@ -130,7 +130,7 @@ export default function ClientsPage() {
           : undefined,
       ellipsis: true,
       render: (id: string) => (
-        <Text copyable={{ text: id }}>
+        <Text copyable={{ text: id }} ellipsis>
           {id}
         </Text>
       ),

--- a/admin-ui/src/pages/FederationPage.tsx
+++ b/admin-ui/src/pages/FederationPage.tsx
@@ -107,7 +107,7 @@ export default function FederationPage() {
       sortOrder: sortOrder("name"),
       ellipsis: true,
       render: (name: string) => (
-        <Text copyable={{ text: name }}>
+        <Text copyable={{ text: name }} ellipsis>
           {name}
         </Text>
       ),
@@ -120,7 +120,7 @@ export default function FederationPage() {
       sortOrder: sortOrder("issuer"),
       ellipsis: true,
       render: (issuer: string) => (
-        <Text copyable={{ text: issuer }}>
+        <Text copyable={{ text: issuer }} ellipsis>
           {issuer}
         </Text>
       ),
@@ -133,7 +133,7 @@ export default function FederationPage() {
       sortOrder: sortOrder("client_id"),
       ellipsis: true,
       render: (id: string) => (
-        <Text copyable={{ text: id }}>
+        <Text copyable={{ text: id }} ellipsis>
           {id}
         </Text>
       ),

--- a/admin-ui/src/pages/FederationPage.tsx
+++ b/admin-ui/src/pages/FederationPage.tsx
@@ -105,7 +105,6 @@ export default function FederationPage() {
       key: "name",
       sorter: true,
       sortOrder: sortOrder("name"),
-      ellipsis: true,
       render: (name: string) => (
         <Text copyable={{ text: name }} ellipsis>
           {name}
@@ -118,7 +117,6 @@ export default function FederationPage() {
       key: "issuer",
       sorter: true,
       sortOrder: sortOrder("issuer"),
-      ellipsis: true,
       render: (issuer: string) => (
         <Text copyable={{ text: issuer }} ellipsis>
           {issuer}
@@ -131,7 +129,6 @@ export default function FederationPage() {
       key: "client_id",
       sorter: true,
       sortOrder: sortOrder("client_id"),
-      ellipsis: true,
       render: (id: string) => (
         <Text copyable={{ text: id }} ellipsis>
           {id}

--- a/admin-ui/src/pages/FederationPage.tsx
+++ b/admin-ui/src/pages/FederationPage.tsx
@@ -107,7 +107,7 @@ export default function FederationPage() {
       sortOrder: sortOrder("name"),
       ellipsis: true,
       render: (name: string) => (
-        <Text copyable={{ text: name }} ellipsis>
+        <Text copyable={{ text: name }}>
           {name}
         </Text>
       ),
@@ -120,7 +120,7 @@ export default function FederationPage() {
       sortOrder: sortOrder("issuer"),
       ellipsis: true,
       render: (issuer: string) => (
-        <Text copyable={{ text: issuer }} ellipsis>
+        <Text copyable={{ text: issuer }}>
           {issuer}
         </Text>
       ),
@@ -133,7 +133,7 @@ export default function FederationPage() {
       sortOrder: sortOrder("client_id"),
       ellipsis: true,
       render: (id: string) => (
-        <Text copyable={{ text: id }} ellipsis>
+        <Text copyable={{ text: id }}>
           {id}
         </Text>
       ),

--- a/admin-ui/src/pages/SessionsPage.tsx
+++ b/admin-ui/src/pages/SessionsPage.tsx
@@ -473,7 +473,7 @@ export default function SessionsPage() {
       key: "email",
       ellipsis: true,
       render: (email: string) => (
-        <Typography.Text copyable={{ text: email }} ellipsis>
+        <Typography.Text copyable={{ text: email }}>
           {email}
         </Typography.Text>
       ),

--- a/admin-ui/src/pages/SessionsPage.tsx
+++ b/admin-ui/src/pages/SessionsPage.tsx
@@ -471,7 +471,6 @@ export default function SessionsPage() {
       title: "Email",
       dataIndex: "email",
       key: "email",
-      ellipsis: true,
       render: (email: string) => (
         <Typography.Text copyable={{ text: email }} ellipsis>
           {email}

--- a/admin-ui/src/pages/SessionsPage.tsx
+++ b/admin-ui/src/pages/SessionsPage.tsx
@@ -473,7 +473,7 @@ export default function SessionsPage() {
       key: "email",
       ellipsis: true,
       render: (email: string) => (
-        <Typography.Text copyable={{ text: email }}>
+        <Typography.Text copyable={{ text: email }} ellipsis>
           {email}
         </Typography.Text>
       ),

--- a/admin-ui/src/pages/TokensPage.tsx
+++ b/admin-ui/src/pages/TokensPage.tsx
@@ -187,7 +187,7 @@ export default function TokensPage() {
       ellipsis: true,
       render: (email: string) =>
         email ? (
-          <Typography.Text copyable={{ text: email }} ellipsis>
+          <Typography.Text copyable={{ text: email }}>
             {email}
           </Typography.Text>
         ) : (

--- a/admin-ui/src/pages/TokensPage.tsx
+++ b/admin-ui/src/pages/TokensPage.tsx
@@ -187,7 +187,7 @@ export default function TokensPage() {
       ellipsis: true,
       render: (email: string) =>
         email ? (
-          <Typography.Text copyable={{ text: email }}>
+          <Typography.Text copyable={{ text: email }} ellipsis>
             {email}
           </Typography.Text>
         ) : (

--- a/admin-ui/src/pages/TokensPage.tsx
+++ b/admin-ui/src/pages/TokensPage.tsx
@@ -184,7 +184,6 @@ export default function TokensPage() {
       title: "Email",
       dataIndex: "email",
       key: "email",
-      ellipsis: true,
       render: (email: string) =>
         email ? (
           <Typography.Text copyable={{ text: email }} ellipsis>

--- a/admin-ui/src/pages/UsersPage.tsx
+++ b/admin-ui/src/pages/UsersPage.tsx
@@ -194,7 +194,7 @@ export default function UsersPage() {
       sorter: true,
       ellipsis: true,
       render: (email: string) => (
-        <Typography.Text copyable={{ text: email }} ellipsis>
+        <Typography.Text copyable={{ text: email }}>
           {email}
         </Typography.Text>
       ),

--- a/admin-ui/src/pages/UsersPage.tsx
+++ b/admin-ui/src/pages/UsersPage.tsx
@@ -194,7 +194,7 @@ export default function UsersPage() {
       sorter: true,
       ellipsis: true,
       render: (email: string) => (
-        <Typography.Text copyable={{ text: email }}>
+        <Typography.Text copyable={{ text: email }} ellipsis>
           {email}
         </Typography.Text>
       ),

--- a/admin-ui/src/pages/UsersPage.tsx
+++ b/admin-ui/src/pages/UsersPage.tsx
@@ -192,7 +192,6 @@ export default function UsersPage() {
       dataIndex: "email",
       key: "email",
       sorter: true,
-      ellipsis: true,
       render: (email: string) => (
         <Typography.Text copyable={{ text: email }} ellipsis>
           {email}


### PR DESCRIPTION
## Summary
- Column-level `ellipsis: true` applies CSS `overflow: hidden` to the entire cell, clipping the copy icon when the column shrinks
- Removed column-level `ellipsis: true` from columns that use `<Text copyable ellipsis>`, which truncates only the text while keeping the copy icon visible
- Affects 7 files: Clients, Federation, Audit Log, Sessions, Tokens, Users, Deletion Requests

## Test plan
- [ ] Shrink a table column — text truncates with ellipsis, copy icon remains visible
- [ ] Expand column back — full text restores correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)