### PR TITLE
fix: reset IdP session idle timeout on token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ These live in the `settings` database table and are loaded into memory at startu
 | `mfa_method`                     | `totp` \| `email`                                      | `totp`           |
 | `trust_device_enabled`           | Allow users to bypass MFA on trusted devices           | `false`          |
 | `trust_device_expiration`        | Trusted device token lifetime                          | `720h` (30 days) |
-| `sso_session_idle_timeout`       | IdP session idle timeout (`0` = disabled)              | `4h`             |
+| `sso_session_idle_timeout`       | IdP session idle timeout (`0` = disabled); resets on login and token refresh | `4h`             |
 | `sso_session_max_age`            | Absolute max session lifetime (`0` = disabled)         | `720h` (30 days) |
 | `allow_self_signup`              | Allow end users to register their own accounts         | `false`          |
 | `account_lockout_max_attempts`   | Failed logins before account lock                      | `5`              |
@@ -383,7 +383,7 @@ Each registered client can override a subset of global settings. Unset fields fa
 | `authorization_code_expiration` | Auth code TTL                                                   |
 | `allowed_audiences`             | Additional `aud` values in tokens for this client               |
 | `allow_self_signup`             | Override self-signup for this client's login page               |
-| `sso_session_idle_timeout`      | Override idle timeout for sessions originating from this client |
+| `sso_session_idle_timeout`      | Override idle timeout for this client's login page (not enforced by the background cleanup sweep, which uses the global value) |
 | `trust_device_enabled`          | Enable or disable trusted devices for this client               |
 | `trust_device_expiration`       | Trust duration for this client's users                          |
 

--- a/pkg/token/handler.go
+++ b/pkg/token/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/client"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
+	"github.com/eugenioenko/autentico/pkg/idpsession"
 	"github.com/eugenioenko/autentico/pkg/mfa"
 	"github.com/eugenioenko/autentico/pkg/reqid"
 	"github.com/eugenioenko/autentico/pkg/session"
@@ -276,6 +277,9 @@ func HandleToken(w http.ResponseWriter, r *http.Request) {
 		}
 		if priorIdp != nil {
 			idpSessionID = *priorIdp
+			// Treat token refresh as user activity so the idle sweeper
+			// measures inactivity from last use, not from original login.
+			_ = idpsession.UpdateLastActivity(idpSessionID)
 		}
 		// RFC 6819 §5.2.2.3 / OAuth 2.1 §6.1: rotate refresh token — revoke old, issue new.
 		// The old token is invalidated so it cannot be reused. If a revoked token is

--- a/pkg/token/handler_test.go
+++ b/pkg/token/handler_test.go
@@ -14,6 +14,7 @@ import (
 	authcode "github.com/eugenioenko/autentico/pkg/auth_code"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
+	"github.com/eugenioenko/autentico/pkg/idpsession"
 	"github.com/eugenioenko/autentico/pkg/user"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
 
@@ -1307,4 +1308,78 @@ func TestHandleToken_RefreshTokenGrant_ClientMismatch(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, rr2.Code)
 	assert.Contains(t, rr2.Body.String(), "invalid_grant")
+}
+
+// TestHandleToken_RefreshTokenGrant_UpdatesIdpSessionLastActivity verifies that
+// a refresh_token grant resets the IdP session's last_activity_at, so the idle
+// sweeper measures inactivity from the last token refresh rather than the
+// original login. See https://github.com/eugenioenko/autentico/issues/376
+func TestHandleToken_RefreshTokenGrant_UpdatesIdpSessionLastActivity(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.WithConfigOverride(t, func() {
+		config.Bootstrap.AuthRefreshTokenCookieOnly = false
+	})
+
+	usr, err := user.CreateUser("testuser", "password123", "testuser@example.com")
+	require.NoError(t, err)
+
+	// Create an IdP session with last_activity_at set far in the past.
+	idpID := "idp-idle-test"
+	err = idpsession.CreateIdpSession(idpsession.IdpSession{
+		ID:     idpID,
+		UserID: usr.ID,
+	})
+	require.NoError(t, err)
+
+	staleTime := time.Now().Add(-2 * time.Hour)
+	_, err = db.GetDB().Exec(
+		`UPDATE idp_sessions SET last_activity_at = ? WHERE id = ?`,
+		staleTime, idpID,
+	)
+	require.NoError(t, err)
+
+	// Issue tokens via authorization_code linked to the IdP session.
+	code := authcode.AuthCode{
+		Code:         "idle-test-code",
+		UserID:       usr.ID,
+		RedirectURI:  "http://localhost/callback",
+		Scope:        "openid profile email",
+		ExpiresAt:    time.Now().Add(10 * time.Minute),
+		IdpSessionID: idpID,
+	}
+	require.NoError(t, authcode.CreateAuthCode(code))
+
+	form := url.Values{}
+	form.Add("grant_type", "authorization_code")
+	form.Add("code", "idle-test-code")
+	form.Add("redirect_uri", "http://localhost/callback")
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	HandleToken(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var tokenResp TokenResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &tokenResp))
+
+	// Refresh the token.
+	form2 := url.Values{}
+	form2.Add("grant_type", "refresh_token")
+	form2.Add("refresh_token", tokenResp.RefreshToken)
+
+	req2 := httptest.NewRequest(http.MethodPost, "/oauth2/token", strings.NewReader(form2.Encode()))
+	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr2 := httptest.NewRecorder()
+	HandleToken(rr2, req2)
+	require.Equal(t, http.StatusOK, rr2.Code)
+
+	// Verify last_activity_at was updated to roughly now (within 5s).
+	var lastActivity time.Time
+	err = db.GetDB().QueryRow(
+		`SELECT last_activity_at FROM idp_sessions WHERE id = ?`, idpID,
+	).Scan(&lastActivity)
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now(), lastActivity, 5*time.Second,
+		"refresh_token grant must update idp_sessions.last_activity_at")
 }


### PR DESCRIPTION
## Summary

Fixes #376

- `last_activity_at` on `idp_sessions` was only updated during browser-based SSO auto-login at `/authorize`, never during `refresh_token` grants. This caused the idle sweeper to cascade-revoke all tokens for clients that silently refresh in the background (standard OAuth2 behavior), since inactivity was measured from the original login rather than from last use.
- Calls `idpsession.UpdateLastActivity()` in the `refresh_token` grant path after resolving the IdP session ID, aligning with how Keycloak, Auth0, Azure AD, and Okta handle idle timeouts.
- Documents the per-client `sso_session_idle_timeout` limitation: the background cleanup sweep only reads the global config value, so per-client overrides only apply at the `/authorize` auto-login check.

## Test plan

- [x] New test `TestHandleToken_RefreshTokenGrant_UpdatesIdpSessionLastActivity` — creates an IdP session with stale `last_activity_at`, issues tokens via auth code, refreshes, and asserts `last_activity_at` is updated to now
- [x] All existing token package tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)