### PR TITLE
fix: inject version from git tag instead of hardcoding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,12 @@ jobs:
 
       - name: Build binaries
         run: |
-          CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build -ldflags="-s -w" -o autentico-linux-amd64   main.go
-          CGO_ENABLED=0 GOOS=linux   GOARCH=arm64 go build -ldflags="-s -w" -o autentico-linux-arm64   main.go
-          CGO_ENABLED=0 GOOS=darwin  GOARCH=amd64 go build -ldflags="-s -w" -o autentico-darwin-amd64  main.go
-          CGO_ENABLED=0 GOOS=darwin  GOARCH=arm64 go build -ldflags="-s -w" -o autentico-darwin-arm64  main.go
-          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o autentico-windows-amd64.exe main.go
+          LDFLAGS="-s -w -X github.com/eugenioenko/autentico/pkg/cli.Version=${GITHUB_REF_NAME}"
+          CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build -ldflags="$LDFLAGS" -o autentico-linux-amd64   main.go
+          CGO_ENABLED=0 GOOS=linux   GOARCH=arm64 go build -ldflags="$LDFLAGS" -o autentico-linux-arm64   main.go
+          CGO_ENABLED=0 GOOS=darwin  GOARCH=amd64 go build -ldflags="$LDFLAGS" -o autentico-darwin-amd64  main.go
+          CGO_ENABLED=0 GOOS=darwin  GOARCH=arm64 go build -ldflags="$LDFLAGS" -o autentico-darwin-arm64  main.go
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags="$LDFLAGS" -o autentico-windows-amd64.exe main.go
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
@@ -112,5 +113,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+          build-args: VERSION=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN cd account-ui && pnpm install --frozen-lockfile
 COPY . .
 
 # Build: generates swagger docs, builds admin UI, compiles Go binary
-RUN CI=true CGO_ENABLED=0 make build
+ARG VERSION=dev
+RUN CI=true CGO_ENABLED=0 make build VERSION=${VERSION}
 
 # ── Stage 2: runner ───────────────────────────────────────────────────────────
 FROM debian:bookworm-slim AS runner

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # Variables
 APP_NAME=autentico
+VERSION=$(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS=-s -w -X github.com/eugenioenko/autentico/pkg/cli.Version=$(VERSION)
 SWAG=$(shell go env GOPATH)/bin/swag
 
 # Default target
@@ -7,11 +9,11 @@ all: build
 
 # Build Go binary
 build-go:
-	go build -o $(APP_NAME) main.go
+	go build -ldflags="$(LDFLAGS)" -o $(APP_NAME) main.go
 
 # Build admin UI + account UI + Go binary
 build: admin-ui-build account-ui-build
-	CGO_ENABLED=0 go build -ldflags="-s -w" -o $(APP_NAME) main.go
+	CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -o $(APP_NAME) main.go
 	@echo ""
 	@echo "Build complete. Binary: ./$(APP_NAME)"
 	@echo ""
@@ -74,7 +76,7 @@ account-ui-build:
 
 # Fast build: skip tsc type-checking in UI builds
 fast: admin-ui-build-fast account-ui-build-fast
-	CGO_ENABLED=0 go build -ldflags="-s -w" -o $(APP_NAME) main.go
+	CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -o $(APP_NAME) main.go
 	@echo ""
 	@echo "Fast build complete. Binary: ./$(APP_NAME)"
 	@echo ""

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var Version = "v.1.6.2"
+var Version = "dev"
 
 func RunVersion(_ *cli.Context) error {
 	fmt.Println(Version)

--- a/pkg/cli/version_test.go
+++ b/pkg/cli/version_test.go
@@ -13,5 +13,4 @@ func TestRunVersion(t *testing.T) {
 
 func TestVersionNotEmpty(t *testing.T) {
 	assert.NotEmpty(t, Version)
-	assert.Contains(t, Version, "v.")
 }


### PR DESCRIPTION
## Summary

- Version was hardcoded as `v.1.6.2` in `pkg/cli/version.go` — had to be manually bumped every release
- Now defaults to `"dev"` and gets injected via `-ldflags -X` at build time from the git tag
- Updated all build paths: Makefile (`git describe`), release workflow (`GITHUB_REF_NAME`), and Dockerfile (`ARG VERSION`)

## Test plan

- [x] `go build -ldflags="-X .../cli.Version=v1.7.0-test"` correctly shows `v1.7.0-test`
- [x] Default build without ldflags shows `dev`
- [x] Existing version tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)