### PR TITLE
fix: replace copyable+ellipsis with CopyText component

### DIFF
--- a/admin-ui/src/components/CopyText.tsx
+++ b/admin-ui/src/components/CopyText.tsx
@@ -1,0 +1,51 @@
+import { Typography, Tooltip } from "antd";
+import { CopyOutlined, CheckOutlined } from "@ant-design/icons";
+import { useState } from "react";
+
+interface CopyTextProps {
+  text: string;
+  children?: React.ReactNode;
+}
+
+export default function CopyText({ text, children }: CopyTextProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        maxWidth: "100%",
+        minWidth: 0,
+        gap: 4,
+      }}
+    >
+      <span
+        style={{
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          minWidth: 0,
+        }}
+      >
+        {children ?? (text || "—")}
+      </span>
+      {text && (
+        <Tooltip title={copied ? "Copied" : "Copy"}>
+          <Typography.Link
+            onClick={handleCopy}
+            style={{ flexShrink: 0, fontSize: "inherit", lineHeight: 1 }}
+          >
+            {copied ? <CheckOutlined /> : <CopyOutlined />}
+          </Typography.Link>
+        </Tooltip>
+      )}
+    </span>
+  );
+}

--- a/admin-ui/src/components/users/DeletionRequestsTab.tsx
+++ b/admin-ui/src/components/users/DeletionRequestsTab.tsx
@@ -22,6 +22,7 @@ import type { DeletionRequestResponse } from "../../api/deletion";
 import type { ListParams } from "../../api/users";
 import { useTableScrollY } from "../../hooks/useTableScrollY";
 import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from "../../constants/table";
+import CopyText from "../CopyText";
 
 const { Text } = Typography;
 
@@ -112,9 +113,7 @@ export default function DeletionRequestsTab() {
       sorter: true,
       ellipsis: true,
       render: (email: string) => (
-        <Text copyable={{ text: email }} ellipsis>
-          {email}
-        </Text>
+        <CopyText text={email} />
       ),
     },
     {
@@ -242,9 +241,7 @@ export default function DeletionRequestsTab() {
               {detailRequest.email}
             </Descriptions.Item>
             <Descriptions.Item label="User ID">
-              <Text copyable={{ text: detailRequest.user_id }}>
-                {detailRequest.user_id}
-              </Text>
+              <CopyText text={detailRequest.user_id} />
             </Descriptions.Item>
             <Descriptions.Item label="Reason">
               {detailRequest.reason ?? "No reason provided"}

--- a/admin-ui/src/pages/AuditLogPage.tsx
+++ b/admin-ui/src/pages/AuditLogPage.tsx
@@ -22,6 +22,7 @@ import type { AuditLogEntry } from "../types/audit";
 import type { ListParams } from "../api/users";
 import { useTableScrollY } from "../hooks/useTableScrollY";
 import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from "../constants/table";
+import CopyText from "../components/CopyText";
 
 const { Text } = Typography;
 
@@ -205,9 +206,7 @@ export default function AuditLogPage() {
       width: 160,
       render: (username: string) =>
         username ? (
-          <Text copyable={{ text: username }} ellipsis>
-            {username}
-          </Text>
+          <CopyText text={username} />
         ) : (
           <Text type="secondary">—</Text>
         ),
@@ -223,9 +222,9 @@ export default function AuditLogPage() {
         if (!record.target_id)
           return <Text>{record.target_type}</Text>;
         return (
-          <Text copyable={{ text: record.target_id }} ellipsis>
+          <CopyText text={record.target_id}>
             {record.target_type}: {record.target_id}
-          </Text>
+          </CopyText>
         );
       },
     },

--- a/admin-ui/src/pages/ClientsPage.tsx
+++ b/admin-ui/src/pages/ClientsPage.tsx
@@ -25,8 +25,7 @@ import ClientDetail from "../components/clients/ClientDetail";
 import { useTableScrollY } from "../hooks/useTableScrollY";
 import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from "../constants/table";
 import GrantChips from "../components/GrantChips";
-
-const { Text } = Typography;
+import CopyText from "../components/CopyText";
 
 
 export default function ClientsPage() {
@@ -112,9 +111,7 @@ export default function ClientsPage() {
           : undefined,
       ellipsis: true,
       render: (name: string) => (
-        <Text copyable={{ text: name }} ellipsis>
-          {name}
-        </Text>
+        <CopyText text={name} />
       ),
     },
     {
@@ -130,9 +127,7 @@ export default function ClientsPage() {
           : undefined,
       ellipsis: true,
       render: (id: string) => (
-        <Text copyable={{ text: id }} ellipsis>
-          {id}
-        </Text>
+        <CopyText text={id} />
       ),
     },
     {

--- a/admin-ui/src/pages/FederationPage.tsx
+++ b/admin-ui/src/pages/FederationPage.tsx
@@ -24,8 +24,7 @@ import FederationCreateForm from "../components/federation/FederationCreateForm"
 import FederationEditForm from "../components/federation/FederationEditForm";
 import { useTableScrollY } from "../hooks/useTableScrollY";
 import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from "../constants/table";
-
-const { Text } = Typography;
+import CopyText from "../components/CopyText";
 
 export default function FederationPage() {
   const { message } = App.useApp();
@@ -107,9 +106,7 @@ export default function FederationPage() {
       sortOrder: sortOrder("name"),
       ellipsis: true,
       render: (name: string) => (
-        <Text copyable={{ text: name }} ellipsis>
-          {name}
-        </Text>
+        <CopyText text={name} />
       ),
     },
     {
@@ -120,9 +117,7 @@ export default function FederationPage() {
       sortOrder: sortOrder("issuer"),
       ellipsis: true,
       render: (issuer: string) => (
-        <Text copyable={{ text: issuer }} ellipsis>
-          {issuer}
-        </Text>
+        <CopyText text={issuer} />
       ),
     },
     {
@@ -133,9 +128,7 @@ export default function FederationPage() {
       sortOrder: sortOrder("client_id"),
       ellipsis: true,
       render: (id: string) => (
-        <Text copyable={{ text: id }} ellipsis>
-          {id}
-        </Text>
+        <CopyText text={id} />
       ),
     },
     {

--- a/admin-ui/src/pages/SessionsPage.tsx
+++ b/admin-ui/src/pages/SessionsPage.tsx
@@ -38,6 +38,7 @@ import type {
 import { describeUserAgent } from "../lib/utils";
 import { useTableScrollY } from "../hooks/useTableScrollY";
 import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from "../constants/table";
+import CopyText from "../components/CopyText";
 
 function formatDate(date: string | null): string {
   if (!date) return "—";
@@ -168,9 +169,7 @@ function SessionsView({
       key: "id",
       width: 160,
       render: (id: string) => (
-        <Typography.Text copyable={{ text: id }} style={{ fontSize: 13 }}>
-          {id.slice(0, 12) + "..."}
-        </Typography.Text>
+        <CopyText text={id}>{id.slice(0, 12) + "..."}</CopyText>
       ),
     },
     {
@@ -455,9 +454,7 @@ export default function SessionsPage() {
       key: "id",
       width: 140,
       render: (id: string) => (
-        <Typography.Text copyable={{ text: id }} style={{ fontSize: 13 }}>
-          {id.slice(0, 12) + "..."}
-        </Typography.Text>
+        <CopyText text={id}>{id.slice(0, 12) + "..."}</CopyText>
       ),
     },
     {
@@ -473,9 +470,7 @@ export default function SessionsPage() {
       key: "email",
       ellipsis: true,
       render: (email: string) => (
-        <Typography.Text copyable={{ text: email }} ellipsis>
-          {email}
-        </Typography.Text>
+        <CopyText text={email} />
       ),
     },
     {

--- a/admin-ui/src/pages/TokensPage.tsx
+++ b/admin-ui/src/pages/TokensPage.tsx
@@ -23,6 +23,7 @@ import type { AdminTokenResponse } from "../types/token";
 import GrantChips from "../components/GrantChips";
 import { useTableScrollY } from "../hooks/useTableScrollY";
 import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from "../constants/table";
+import CopyText from "../components/CopyText";
 
 function formatDate(date: string | null): string {
   if (!date) return "—";
@@ -167,9 +168,7 @@ export default function TokensPage() {
       key: "id",
       width: 140,
       render: (id: string) => (
-        <Typography.Text copyable={{ text: id }} style={{ fontSize: 13 }}>
-          {id.slice(0, 12) + "..."}
-        </Typography.Text>
+        <CopyText text={id}>{id.slice(0, 12) + "..."}</CopyText>
       ),
     },
     {
@@ -187,9 +186,7 @@ export default function TokensPage() {
       ellipsis: true,
       render: (email: string) =>
         email ? (
-          <Typography.Text copyable={{ text: email }} ellipsis>
-            {email}
-          </Typography.Text>
+          <CopyText text={email} />
         ) : (
           "—"
         ),

--- a/admin-ui/src/pages/UsersPage.tsx
+++ b/admin-ui/src/pages/UsersPage.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import {
-  Typography,
   Table,
   Button,
   Tag,
@@ -39,6 +38,7 @@ import DeletionRequestsTab from "../components/users/DeletionRequestsTab";
 import { useTableScrollY } from "../hooks/useTableScrollY";
 import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from "../constants/table";
 import CountTooltip from "../components/CountTooltip";
+import CopyText from "../components/CopyText";
 
 function isLocked(record: UserResponseExt): boolean {
   return !!record.locked_until && new Date(record.locked_until) > new Date();
@@ -194,9 +194,7 @@ export default function UsersPage() {
       sorter: true,
       ellipsis: true,
       render: (email: string) => (
-        <Typography.Text copyable={{ text: email }} ellipsis>
-          {email}
-        </Typography.Text>
+        <CopyText text={email} />
       ),
     },
     {


### PR DESCRIPTION
## Summary

- Ant Design's `Typography.Text` with both `copyable` and `ellipsis` has a bug where truncated text doesn't unshrink when the column grows back
- New `CopyText` component uses CSS `text-overflow: ellipsis` with `inline-flex` layout — the text truncates naturally and the copy icon stays pinned
- Returns a dash when text is empty instead of showing a broken copy icon
- Replaced all 13 instances across 7 files (ClientsPage, FederationPage, AuditLogPage, UsersPage, TokensPage, SessionsPage, DeletionRequestsTab)


Closes
https://github.com/eugenioenko/autentico/issues/369