### PR TITLE
feat: add batch user lookup endpoint for ABAC integration

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -185,6 +185,7 @@ func RunStart(c *cli.Context) error {
 	mux.Handle("POST /admin/api/users/{id}/reactivate", adminAPI(user.HandleReactivateUser))
 	mux.Handle("POST /admin/api/users/{id}/unlock", adminAPI(user.HandleUnlockUser))
 	mux.Handle("POST /admin/api/users/{id}/revoke-sessions", adminAPI(user.HandleRevokeUserSessions))
+	mux.Handle("POST /admin/api/users/lookup", adminAPI(user.HandleLookupUsers))
 	mux.Handle("GET /admin/api/clients", adminAPI(client.HandleAdminListClients))
 	mux.Handle("POST /admin/api/clients", adminAPI(client.HandleRegister))
 	mux.Handle("GET /admin/api/clients/{client_id}", adminAPI(client.HandleGetClient))

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -368,3 +368,99 @@ func HandleUnlockUser(w http.ResponseWriter, r *http.Request) {
 	}
 	utils.SuccessResponse(w, result.ToResponse(), http.StatusOK)
 }
+
+// HandleLookupUsers godoc
+// @Summary Batch lookup users by identifiers
+// @Description Resolves a list of user IDs, emails, and/or usernames into full user profiles in a single call. Maximum 100 identifiers total across all fields per request. Designed for external systems (e.g. ABAC policy engines) that need to resolve known identifiers into user data. Returns both matched users and any identifiers that could not be found.
+// @Tags admin-users
+// @Accept json
+// @Produce json
+// @Param body body LookupUsersRequest true "Lookup request with IDs, emails, and/or usernames"
+// @Security AdminAuth
+// @Success 200 {object} model.ApiResponse[LookupUsersResponse]
+// @Failure 400 {object} model.AuthErrorResponse
+// @Failure 500 {object} model.AuthErrorResponse
+// @Router /admin/api/users/lookup [post]
+func HandleLookupUsers(w http.ResponseWriter, r *http.Request) {
+	var req LookupUsersRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Invalid request payload")
+		return
+	}
+
+	totalIdentifiers := len(req.IDs) + len(req.Emails) + len(req.Usernames)
+	if totalIdentifiers == 0 {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "At least one identifier (id, email, or username) is required")
+		return
+	}
+	if totalIdentifiers > LookupMaxIdentifiers {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request",
+			fmt.Sprintf("Too many identifiers: %d exceeds maximum of %d", totalIdentifiers, LookupMaxIdentifiers))
+		return
+	}
+
+	for i := range req.Emails {
+		req.Emails[i] = strings.ToLower(strings.TrimSpace(req.Emails[i]))
+	}
+	for i := range req.IDs {
+		req.IDs[i] = strings.TrimSpace(req.IDs[i])
+	}
+	for i := range req.Usernames {
+		req.Usernames[i] = strings.TrimSpace(req.Usernames[i])
+	}
+
+	users, err := LookupUsers(req.IDs, req.Emails, req.Usernames)
+	if err != nil {
+		slog.Error("user: failed to lookup users", "error", err)
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", "Failed to lookup users")
+		return
+	}
+
+	foundIDs := make(map[string]bool)
+	foundEmails := make(map[string]bool)
+	foundUsernames := make(map[string]bool)
+	userIDs := make([]string, len(users))
+	for i, u := range users {
+		userIDs[i] = u.ID
+		foundIDs[u.ID] = true
+		foundEmails[strings.ToLower(u.Email)] = true
+		foundUsernames[u.Username] = true
+	}
+
+	groupMap, _ := group.GroupNamesByUserIDs(userIDs)
+
+	items := make([]UserResponse, 0, len(users))
+	for _, u := range users {
+		resp := u.ToResponse()
+		if names, ok := groupMap[u.ID]; ok {
+			resp.Groups = names
+		}
+		items = append(items, resp)
+	}
+
+	notFound := LookupNotFound{
+		IDs:       make([]string, 0),
+		Emails:    make([]string, 0),
+		Usernames: make([]string, 0),
+	}
+	for _, id := range req.IDs {
+		if !foundIDs[id] {
+			notFound.IDs = append(notFound.IDs, id)
+		}
+	}
+	for _, email := range req.Emails {
+		if !foundEmails[email] {
+			notFound.Emails = append(notFound.Emails, email)
+		}
+	}
+	for _, username := range req.Usernames {
+		if !foundUsernames[username] {
+			notFound.Usernames = append(notFound.Usernames, username)
+		}
+	}
+
+	utils.SuccessResponse(w, LookupUsersResponse{
+		Items:    items,
+		NotFound: notFound,
+	})
+}

--- a/pkg/user/handler_test.go
+++ b/pkg/user/handler_test.go
@@ -543,3 +543,135 @@ func TestHandleListUsers_DbError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 	assert.NotContains(t, rr.Body.String(), "SQL")
 }
+
+// --- HandleLookupUsers tests ---
+
+func TestHandleLookupUsers_InvalidBody(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/users/lookup", bytes.NewBufferString("not-json"))
+	rr := httptest.NewRecorder()
+	HandleLookupUsers(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Invalid request payload")
+}
+
+func TestHandleLookupUsers_EmptyRequest(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	body, _ := json.Marshal(LookupUsersRequest{})
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/users/lookup", bytes.NewBuffer(body))
+	rr := httptest.NewRecorder()
+	HandleLookupUsers(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "At least one identifier")
+}
+
+func TestHandleLookupUsers_TooManyIdentifiers(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	ids := make([]string, LookupMaxIdentifiers+1)
+	for i := range ids {
+		ids[i] = "id-" + string(rune('a'+i%26))
+	}
+	body, _ := json.Marshal(LookupUsersRequest{IDs: ids})
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/users/lookup", bytes.NewBuffer(body))
+	rr := httptest.NewRecorder()
+	HandleLookupUsers(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Too many identifiers")
+}
+
+func TestHandleLookupUsers_Success(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	u1, _ := CreateUser("alice", "pass123", "alice@test.com")
+	u2, _ := CreateUser("bob", "pass123", "bob@test.com")
+
+	body, _ := json.Marshal(LookupUsersRequest{
+		IDs:       []string{u1.ID},
+		Emails:    []string{"bob@test.com"},
+		Usernames: []string{"nonexistent"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/users/lookup", bytes.NewBuffer(body))
+	rr := httptest.NewRecorder()
+	HandleLookupUsers(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp model.ApiResponse[LookupUsersResponse]
+	err := json.Unmarshal(rr.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.Len(t, resp.Data.Items, 2)
+	assert.Empty(t, resp.Data.NotFound.IDs)
+	assert.Empty(t, resp.Data.NotFound.Emails)
+	assert.Equal(t, []string{"nonexistent"}, resp.Data.NotFound.Usernames)
+
+	foundUsernames := make(map[string]bool)
+	for _, item := range resp.Data.Items {
+		foundUsernames[item.Username] = true
+	}
+	assert.True(t, foundUsernames["alice"])
+	assert.True(t, foundUsernames["bob"])
+	_ = u2
+}
+
+func TestHandleLookupUsers_PartialMatch(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	u1, _ := CreateUser("found", "pass123", "found@test.com")
+
+	body, _ := json.Marshal(LookupUsersRequest{
+		IDs:    []string{u1.ID, "missing-id"},
+		Emails: []string{"gone@test.com"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/users/lookup", bytes.NewBuffer(body))
+	rr := httptest.NewRecorder()
+	HandleLookupUsers(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp model.ApiResponse[LookupUsersResponse]
+	err := json.Unmarshal(rr.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.Len(t, resp.Data.Items, 1)
+	assert.Equal(t, "found", resp.Data.Items[0].Username)
+	assert.Equal(t, []string{"missing-id"}, resp.Data.NotFound.IDs)
+	assert.Equal(t, []string{"gone@test.com"}, resp.Data.NotFound.Emails)
+}
+
+func TestHandleLookupUsers_DeactivatedExcluded(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	u1, _ := CreateUser("active", "pass123", "active@test.com")
+	u2, _ := CreateUser("gone", "pass123", "gone@test.com")
+	_, _ = db.GetDB().Exec("UPDATE users SET deactivated_at = CURRENT_TIMESTAMP WHERE id = ?", u2.ID)
+
+	body, _ := json.Marshal(LookupUsersRequest{
+		IDs: []string{u1.ID, u2.ID},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/users/lookup", bytes.NewBuffer(body))
+	rr := httptest.NewRecorder()
+	HandleLookupUsers(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp model.ApiResponse[LookupUsersResponse]
+	err := json.Unmarshal(rr.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.Len(t, resp.Data.Items, 1)
+	assert.Equal(t, "active", resp.Data.Items[0].Username)
+	assert.Equal(t, []string{u2.ID}, resp.Data.NotFound.IDs)
+}
+
+func TestHandleLookupUsers_DbError(t *testing.T) {
+	testutils.WithTestDB(t)
+	db.CloseDB()
+
+	body, _ := json.Marshal(LookupUsersRequest{IDs: []string{"some-id"}})
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/users/lookup", bytes.NewBuffer(body))
+	rr := httptest.NewRecorder()
+	HandleLookupUsers(rr, req)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.NotContains(t, rr.Body.String(), "SQL")
+	assert.NotContains(t, rr.Body.String(), "constraint")
+	assert.NotContains(t, rr.Body.String(), "database")
+	assert.Contains(t, rr.Body.String(), "Failed to lookup users")
+}

--- a/pkg/user/model.go
+++ b/pkg/user/model.go
@@ -205,6 +205,25 @@ func validateURLScheme(value string) error {
 	return nil
 }
 
+type LookupUsersRequest struct {
+	IDs       []string `json:"ids"`
+	Emails    []string `json:"emails"`
+	Usernames []string `json:"usernames"`
+}
+
+type LookupNotFound struct {
+	IDs       []string `json:"ids"`
+	Emails    []string `json:"emails"`
+	Usernames []string `json:"usernames"`
+}
+
+type LookupUsersResponse struct {
+	Items    []UserResponse `json:"items"`
+	NotFound LookupNotFound `json:"not_found"`
+}
+
+const LookupMaxIdentifiers = 100
+
 func ValidateUserUpdateRequest(input UserUpdateRequest) error {
 	if input.Username != "" {
 		if err := validation.Validate(input.Username, validation.Length(config.Get().ValidationMinUsernameLength, config.Get().ValidationMaxUsernameLength)); err != nil {

--- a/pkg/user/read.go
+++ b/pkg/user/read.go
@@ -178,6 +178,59 @@ func GetVerificationTokenInfo(tokenHash string) (userID string, expiresAt time.T
 	return
 }
 
+func LookupUsers(ids, emails, usernames []string) ([]*User, error) {
+	if len(ids) == 0 && len(emails) == 0 && len(usernames) == 0 {
+		return nil, nil
+	}
+
+	var conditions []string
+	var args []any
+
+	if len(ids) > 0 {
+		placeholders := make([]string, len(ids))
+		for i, id := range ids {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		conditions = append(conditions, "users.id IN ("+strings.Join(placeholders, ",")+")")
+	}
+
+	if len(emails) > 0 {
+		placeholders := make([]string, len(emails))
+		for i, email := range emails {
+			placeholders[i] = "?"
+			args = append(args, strings.ToLower(email))
+		}
+		conditions = append(conditions, "LOWER(users.email) IN ("+strings.Join(placeholders, ",")+")")
+	}
+
+	if len(usernames) > 0 {
+		placeholders := make([]string, len(usernames))
+		for i, username := range usernames {
+			placeholders[i] = "?"
+			args = append(args, username)
+		}
+		conditions = append(conditions, "users.username IN ("+strings.Join(placeholders, ",")+")")
+	}
+
+	query := `SELECT` + userSelectColumns + `FROM users WHERE users.deactivated_at IS NULL AND (` + strings.Join(conditions, " OR ") + `)`
+	rows, err := db.GetDB().Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup users: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var users []*User
+	for rows.Next() {
+		u, err := scanUser(rows)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan user: %w", err)
+		}
+		users = append(users, u)
+	}
+	return users, rows.Err()
+}
+
 // UserExistsByEmail returns true if any non-deactivated user has the given email,
 // regardless of email verification status. Used to prevent duplicate email assignment.
 func UserExistsByEmail(email string) bool {

--- a/pkg/user/read_test.go
+++ b/pkg/user/read_test.go
@@ -71,6 +71,79 @@ func TestUserExistsByEmail(t *testing.T) {
 	assert.False(t, UserExistsByEmail("notexists@test.com"))
 }
 
+func TestLookupUsers_ByIDs(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	u1, _ := CreateUser("alice", "pass", "alice@test.com")
+	u2, _ := CreateUser("bob", "pass", "bob@test.com")
+	_, _ = CreateUser("charlie", "pass", "charlie@test.com")
+
+	users, err := LookupUsers([]string{u1.ID, u2.ID}, nil, nil)
+	assert.NoError(t, err)
+	assert.Len(t, users, 2)
+}
+
+func TestLookupUsers_ByEmails(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	_, _ = CreateUser("alice", "pass", "alice@test.com")
+	_, _ = CreateUser("bob", "pass", "bob@test.com")
+
+	users, err := LookupUsers(nil, []string{"ALICE@TEST.COM", "bob@test.com"}, nil)
+	assert.NoError(t, err)
+	assert.Len(t, users, 2)
+}
+
+func TestLookupUsers_ByUsernames(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	_, _ = CreateUser("alice", "pass", "alice@test.com")
+	_, _ = CreateUser("bob", "pass", "bob@test.com")
+
+	users, err := LookupUsers(nil, nil, []string{"alice", "bob"})
+	assert.NoError(t, err)
+	assert.Len(t, users, 2)
+}
+
+func TestLookupUsers_Mixed_Deduplicates(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	u1, _ := CreateUser("alice", "pass", "alice@test.com")
+
+	users, err := LookupUsers([]string{u1.ID}, []string{"alice@test.com"}, []string{"alice"})
+	assert.NoError(t, err)
+	assert.Len(t, users, 1)
+}
+
+func TestLookupUsers_NotFound(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	users, err := LookupUsers([]string{"nonexistent-id"}, []string{"no@one.com"}, []string{"ghost"})
+	assert.NoError(t, err)
+	assert.Empty(t, users)
+}
+
+func TestLookupUsers_Empty(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	users, err := LookupUsers(nil, nil, nil)
+	assert.NoError(t, err)
+	assert.Nil(t, users)
+}
+
+func TestLookupUsers_ExcludesDeactivated(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	u1, _ := CreateUser("active", "pass", "active@test.com")
+	u2, _ := CreateUser("deactivated", "pass", "deactivated@test.com")
+	_, _ = db.GetDB().Exec("UPDATE users SET deactivated_at = CURRENT_TIMESTAMP WHERE id = ?", u2.ID)
+
+	users, err := LookupUsers([]string{u1.ID, u2.ID}, nil, nil)
+	assert.NoError(t, err)
+	assert.Len(t, users, 1)
+	assert.Equal(t, u1.ID, users[0].ID)
+}
+
 func TestCountUsers(t *testing.T) {
 	testutils.WithTestDB(t)
 


### PR DESCRIPTION
## Summary

- Adds `POST /admin/api/users/lookup` — resolves user IDs, emails, and/or usernames into full user profiles in a single call
- Returns partial-success response: matched users in `items` and unresolved identifiers in `not_found`
- Capped at 100 total identifiers per request, emails case-insensitive, deactivated users excluded
- Designed for external systems (ABAC policy engines, authorization services) that need to batch-resolve known identifiers

### Request
```json
{
  "ids": ["uuid1", "uuid2"],
  "emails": ["alice@example.com"],
  "usernames": ["bob"]
}
```

### Response
```json
{
  "data": {
    "items": [ ...UserResponse objects... ],
    "not_found": {
      "ids": ["uuid-that-doesnt-exist"],
      "emails": [],
      "usernames": []
    }
  }
}
```

## Test plan

- [x] Unit tests for `LookupUsers` DB query (by IDs, emails, usernames, mixed/dedup, not found, empty, deactivated excluded)
- [x] Handler tests (invalid body, empty request, over limit, success, partial match, deactivated excluded, DB error with no internal detail leakage)
- [x] `go vet` clean
- [x] Full `pkg/user` test suite passes
- [x] Project builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)