### PR TITLE
chore: migrate from dgrijalva/jwt-go to golang-jwt/jwt/v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ toolchain go1.24.2
 
 require (
 	github.com/coreos/go-oidc/v3 v3.17.0
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/go-webauthn/webauthn v0.15.0
 	github.com/golang-jwt/jwt/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=

--- a/pkg/account/common_test.go
+++ b/pkg/account/common_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/jwtutil"
 	"github.com/eugenioenko/autentico/pkg/key"

--- a/pkg/bearer/user_from_request_test.go
+++ b/pkg/bearer/user_from_request_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/bearer"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"

--- a/pkg/deletion/handler_test.go
+++ b/pkg/deletion/handler_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/jwtutil"

--- a/pkg/introspect/handler_test.go
+++ b/pkg/introspect/handler_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/key"

--- a/pkg/jwtutil/audience_test.go
+++ b/pkg/jwtutil/audience_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/key"
 	testutils "github.com/eugenioenko/autentico/tests/utils"

--- a/pkg/jwtutil/claims.go
+++ b/pkg/jwtutil/claims.go
@@ -1,0 +1,19 @@
+package jwtutil
+
+import "github.com/golang-jwt/jwt/v5"
+
+// ZeroClaims satisfies the jwt/v5 Claims getter interface with empty values.
+// Embed it in a custom claims struct and override only the getters that carry
+// validation policy (typically GetExpirationTime).
+//
+// Safe only because no parser passes WithIssuer/WithSubject/WithAudience
+// options — issuer and audience checks are done explicitly after parsing
+// (see ValidateAudience).
+type ZeroClaims struct{}
+
+func (ZeroClaims) GetExpirationTime() (*jwt.NumericDate, error) { return nil, nil }
+func (ZeroClaims) GetIssuedAt() (*jwt.NumericDate, error)       { return nil, nil }
+func (ZeroClaims) GetNotBefore() (*jwt.NumericDate, error)      { return nil, nil }
+func (ZeroClaims) GetIssuer() (string, error)                   { return "", nil }
+func (ZeroClaims) GetSubject() (string, error)                  { return "", nil }
+func (ZeroClaims) GetAudience() (jwt.ClaimStrings, error)       { return nil, nil }

--- a/pkg/jwtutil/validate.go
+++ b/pkg/jwtutil/validate.go
@@ -2,13 +2,15 @@ package jwtutil
 
 import (
 	"fmt"
+	"time"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/key"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type AccessTokenClaims struct {
+	ZeroClaims
 	UserID    string   `json:"sub"`
 	Email     string   `json:"email"`
 	SessionID string   `json:"sid"`
@@ -19,14 +21,11 @@ type AccessTokenClaims struct {
 	Scope     string   `json:"scope"`
 }
 
-func (a *AccessTokenClaims) Valid() error {
+func (a *AccessTokenClaims) GetExpirationTime() (*jwt.NumericDate, error) {
 	if a.ExpiresAt == 0 {
-		return fmt.Errorf("token missing exp")
+		return nil, nil
 	}
-	if a.ExpiresAt < jwt.TimeFunc().Unix() {
-		return fmt.Errorf("token has expired")
-	}
-	return nil
+	return jwt.NewNumericDate(time.Unix(a.ExpiresAt, 0)), nil
 }
 
 // ExtractAzp parses a JWT without signature verification and returns the "azp"
@@ -34,11 +33,10 @@ func (a *AccessTokenClaims) Valid() error {
 // before performing ownership checks. Returns "" if the claim is absent or the
 // token is malformed — callers should treat missing azp as "skip the check".
 func ExtractAzp(tokenString string) string {
-	parser := jwt.Parser{SkipClaimsValidation: true}
 	claims := jwt.MapClaims{}
 	// Parse without key function — we only need the claims, not verification.
 	// The token has already been validated or will be looked up in the DB.
-	_, _, err := parser.ParseUnverified(tokenString, claims)
+	_, _, err := jwt.NewParser().ParseUnverified(tokenString, claims)
 	if err != nil {
 		return ""
 	}
@@ -73,7 +71,7 @@ func ValidateAccessToken(tokenString string) (*AccessTokenClaims, error) {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return publicKey, nil
-	})
+	}, jwt.WithExpirationRequired())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/jwtutil/validate_test.go
+++ b/pkg/jwtutil/validate_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/key"
 	testutils "github.com/eugenioenko/autentico/tests/utils"
@@ -114,27 +114,29 @@ func TestValidateAudience_NoRequiredAudiences(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// Expiry validation moved from a Valid() method to the jwt/v5 validator —
+// ValidateAccessToken passes WithExpirationRequired, mirrored here.
 func TestAccessTokenClaims_Valid(t *testing.T) {
 	claims := &AccessTokenClaims{
 		ExpiresAt: time.Now().Add(1 * time.Hour).Unix(),
 	}
-	assert.NoError(t, claims.Valid())
+	assert.NoError(t, jwt.NewValidator(jwt.WithExpirationRequired()).Validate(claims))
 }
 
 func TestAccessTokenClaims_MissingExp(t *testing.T) {
 	claims := &AccessTokenClaims{
 		ExpiresAt: 0,
 	}
-	err := claims.Valid()
+	err := jwt.NewValidator(jwt.WithExpirationRequired()).Validate(claims)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "token missing exp")
+	assert.ErrorIs(t, err, jwt.ErrTokenRequiredClaimMissing)
 }
 
 func TestAccessTokenClaims_Expired(t *testing.T) {
 	claims := &AccessTokenClaims{
 		ExpiresAt: time.Now().Add(-1 * time.Hour).Unix(),
 	}
-	err := claims.Valid()
+	err := jwt.NewValidator(jwt.WithExpirationRequired()).Validate(claims)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "token has expired")
+	assert.ErrorIs(t, err, jwt.ErrTokenExpired)
 }

--- a/pkg/middleware/account_auth_test.go
+++ b/pkg/middleware/account_auth_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/key"

--- a/pkg/middleware/admin_auth_test.go
+++ b/pkg/middleware/admin_auth_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/key"

--- a/pkg/middleware/auth_audience_test.go
+++ b/pkg/middleware/auth_audience_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/key"

--- a/pkg/revoke/handler_test.go
+++ b/pkg/revoke/handler_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/key"

--- a/pkg/session/logout.go
+++ b/pkg/session/logout.go
@@ -5,12 +5,13 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/eugenioenko/autentico/pkg/client"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/idpsession"
+	"github.com/eugenioenko/autentico/pkg/jwtutil"
 	"github.com/eugenioenko/autentico/pkg/key"
 	"github.com/eugenioenko/autentico/view"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // HandleLogout godoc
@@ -42,14 +43,14 @@ func HandleLogout(w http.ResponseWriter, r *http.Request) {
 }
 
 // idTokenHintClaims holds the claims we care about from an id_token_hint.
-// Valid() always returns nil so that expired ID tokens are accepted per the spec.
+// ZeroClaims provides the jwt/v5 getters; parsing uses WithoutClaimsValidation
+// so that expired ID tokens are accepted per the spec.
 type idTokenHintClaims struct {
+	jwtutil.ZeroClaims
 	Subject  string `json:"sub"`
 	ClientID string `json:"azp"` // authorized party
 	RawAud   interface{}
 }
-
-func (c *idTokenHintClaims) Valid() error { return nil }
 
 func (c *idTokenHintClaims) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
@@ -89,9 +90,11 @@ func parseIDTokenHint(hint string) *idTokenHintClaims {
 		return nil
 	}
 	claims := &idTokenHintClaims{}
+	// RP-Initiated Logout 1.0 §2: the OP SHOULD accept ID Tokens even when the
+	// exp time has passed — skip claims validation, signature is still verified.
 	_, err := jwt.ParseWithClaims(hint, claims, func(t *jwt.Token) (interface{}, error) {
 		return key.GetPublicKey(), nil
-	})
+	}, jwt.WithoutClaimsValidation())
 	if err != nil {
 		return nil
 	}

--- a/pkg/session/logout_test.go
+++ b/pkg/session/logout_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/idpsession"

--- a/pkg/token/client_credentials_test.go
+++ b/pkg/token/client_credentials_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/key"

--- a/pkg/token/decode.go
+++ b/pkg/token/decode.go
@@ -3,7 +3,7 @@ package token
 import (
 	"fmt"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func DecodeRefreshToken(tokenString string, secretKey string) (*RefreshTokenClaims, error) {

--- a/pkg/token/decode_test.go
+++ b/pkg/token/decode_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,7 +41,7 @@ func TestDecodeToken_ExpiredToken(t *testing.T) {
 
 	_, err = DecodeRefreshToken(signedToken, secretKey)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "token has expired")
+	assert.ErrorIs(t, err, jwt.ErrTokenExpired)
 }
 
 func TestDecodeToken_InvalidSignature(t *testing.T) {

--- a/pkg/token/generate.go
+++ b/pkg/token/generate.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/rs/xid"
 
 	"github.com/eugenioenko/autentico/pkg/config"

--- a/pkg/token/generate_groups_test.go
+++ b/pkg/token/generate_groups_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/key"
 	"github.com/eugenioenko/autentico/pkg/user"

--- a/pkg/token/generate_test.go
+++ b/pkg/token/generate_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/key"
 	"github.com/eugenioenko/autentico/pkg/user"

--- a/pkg/token/model.go
+++ b/pkg/token/model.go
@@ -1,11 +1,12 @@
 package token
 
 import (
-	"fmt"
 	"time"
 
 	validation "github.com/go-ozzo/ozzo-validation"
 	"github.com/go-ozzo/ozzo-validation/is"
+	"github.com/eugenioenko/autentico/pkg/jwtutil"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // Token represents a token record in the database
@@ -40,6 +41,7 @@ type TokenRequest struct {
 }
 
 type RefreshTokenClaims struct {
+	jwtutil.ZeroClaims
 	UserID    string `json:"sub"` // The ID of the user associated with the refresh token
 	SessionID string `json:"sid"` // The session ID for which the refresh token is issued
 	ClientID  string `json:"azp"` // The client the refresh token was issued to
@@ -47,11 +49,10 @@ type RefreshTokenClaims struct {
 	ExpiresAt int64  `json:"exp"` // The timestamp when the refresh token will expire
 }
 
-func (r *RefreshTokenClaims) Valid() error {
-	if time.Unix(r.ExpiresAt, 0).Before(time.Now()) {
-		return fmt.Errorf("token has expired")
-	}
-	return nil
+// GetExpirationTime returns exp unconditionally so a missing exp (zero value)
+// parses as 1970 and fails validation as expired.
+func (r *RefreshTokenClaims) GetExpirationTime() (*jwt.NumericDate, error) {
+	return jwt.NewNumericDate(time.Unix(r.ExpiresAt, 0)), nil
 }
 
 func ValidateTokenRequest(input TokenRequest) error {

--- a/pkg/user/handler_test.go
+++ b/pkg/user/handler_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/key"

--- a/pkg/userinfo/debug_test.go
+++ b/pkg/userinfo/debug_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/key"
 	"github.com/eugenioenko/autentico/pkg/jwtutil"
 	"github.com/stretchr/testify/assert"

--- a/pkg/userinfo/handler_test.go
+++ b/pkg/userinfo/handler_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/eugenioenko/autentico/pkg/config"
 	"github.com/eugenioenko/autentico/pkg/db"
 	"github.com/eugenioenko/autentico/pkg/key"


### PR DESCRIPTION
## Summary
- Replaces the abandoned `dgrijalva/jwt-go` (CVE-2020-26160, unmaintained since 2021) with its maintained fork `golang-jwt/jwt/v5`
- Adds `jwtutil.ZeroClaims` — a shared embeddable type that provides no-op jwt/v5 `Claims` getters, so each custom claims struct only overrides `GetExpirationTime` where expiry policy differs
- Updates all 18 test files to use the new import and error types
- `dgrijalva/jwt-go` fully removed from `go.mod`

## Changes by file
| Area | What changed |
|---|---|
| `pkg/jwtutil/claims.go` | New `ZeroClaims` type (6 no-op getters) |
| `pkg/jwtutil/validate.go` | `AccessTokenClaims` embeds `ZeroClaims`, overrides `GetExpirationTime`; parser uses `WithExpirationRequired()` |
| `pkg/token/model.go` | `RefreshTokenClaims` embeds `jwtutil.ZeroClaims`, overrides `GetExpirationTime` |
| `pkg/session/logout.go` | `idTokenHintClaims` embeds `jwtutil.ZeroClaims`; parser uses `WithoutClaimsValidation()` for expired ID token hints |
| `pkg/token/decode.go`, `pkg/token/generate.go` | Import swap only |
| 18 test files | Import swap + one error assertion updated (`ErrTokenExpired` instead of string match) |

## Test plan
- [x] `go build ./...` passes
- [x] All touched package tests pass (jwtutil, token, session, middleware, introspect, revoke, bearer, account, userinfo, user, deletion)
- [x] Security test suite passes (`tests/security/`) — includes JWT algorithm confusion tests (CVE-2022-23539/40/41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)