### PR TITLE
fix: use correct input type "tel" for phone number styling

### DIFF
--- a/account-ui/src/index.css
+++ b/account-ui/src/index.css
@@ -37,7 +37,7 @@
   input[type="text"],
   input[type="email"],
   input[type="password"],
-  input[type="phone"],
+  input[type="tel"],
   input[type="url"] {
     @apply w-full px-4 py-3 rounded-brand text-sm outline-none bg-theme-bg border border-theme-fg/40 placeholder:text-theme-muted focus:border-theme-fg/40 focus:ring-2 focus:ring-theme-highlight disabled:opacity-40 disabled:cursor-not-allowed transition-all;
   }


### PR DESCRIPTION
## Summary
- Fixes the CSS selector `input[type="phone"]` → `input[type="tel"]` in `account-ui/src/index.css`
- `"phone"` is not a valid HTML input type; `"tel"` is the correct type, so the phone number field on the profile page was missing shared input styles

Closes #386

## Test plan
- [x] Open the account UI profile page and verify the phone number field has the same styling (border, padding, focus ring) as other text inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)