### PR TITLE
feat: custom per-user claims via the custom_claims scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,7 +293,7 @@ Overridable: token expiration times, `allowed_audiences`, `allow_self_signup`, `
 
 ### Database
 
-Initialized by `db.InitDB()`. Schema defined in `pkg/db/migrations/`. 21 tables (SchemaVersion 11):
+Initialized by `db.InitDB()`. Schema defined in `pkg/db/migrations/`. 20 tables listed below (SchemaVersion 11):
 
 | Table | Purpose |
 |-------|---------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,7 @@ Each feature package in `pkg/` follows a consistent pattern:
 | `pkg/token` | `/oauth2/token` — code exchange, refresh token grant, ROPC, client credentials |
 | `pkg/trusteddevice` | Trusted device tokens — MFA bypass cookie management |
 | `pkg/user` | User CRUD, bcrypt password hashing, account lockout, TOTP secret storage |
+| `pkg/userclaim` | Custom per-user claims — admin CRUD + merge into tokens/UserInfo when `custom_claims` scope granted |
 | `pkg/userinfo` | `/oauth2/userinfo` endpoint |
 | `pkg/utils` | Shared helpers: response writers, bearer token extraction, redirect URI validation, SHA-256 hashing, client IP |
 | `pkg/wellknown` | `/.well-known/openid-configuration` and `/oauth2/.well-known/jwks.json` |
@@ -292,7 +293,7 @@ Overridable: token expiration times, `allowed_audiences`, `allow_self_signup`, `
 
 ### Database
 
-Initialized by `db.InitDB()`. Schema defined in `pkg/db/migrations/`. 20 tables (SchemaVersion 7):
+Initialized by `db.InitDB()`. Schema defined in `pkg/db/migrations/`. 21 tables (SchemaVersion 11):
 
 | Table | Purpose |
 |-------|---------|
@@ -315,6 +316,7 @@ Initialized by `db.InitDB()`. Schema defined in `pkg/db/migrations/`. 20 tables 
 | `groups` | User groups (migration 004) |
 | `user_groups` | Group membership join table (migration 004) |
 | `user_consents` | Stored OAuth2 consent decisions per user+client+scopes (migration 007) |
+| `user_claims` | Custom per-user claims — one row per `(user_id, claim_name)` (migration 011) |
 
 **SQLite driver:** `modernc.org/sqlite` (NOT `mattn/go-sqlite3`). Scanning SQL NULL into a plain `string` causes an error — always use `*string` or provide explicit `""` in test fixtures for nullable string columns.
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ It is not designed for organizations that require horizontal scaling of the auth
 - **Per-client configuration overrides** — token TTLs, allowed audiences, self-signup, session idle timeout, and trusted device settings can be tuned per client without touching global defaults
 - **Self-signup** — optionally allow end users to register accounts on the login page, globally or per client
 - **User CRUD** — full user lifecycle management with role support (`user`, `admin`)
+- **Custom claims** — assign arbitrary key/value claims to a user; emitted into the ID token, access token, and UserInfo response when the `custom_claims` scope is granted
+- **User groups** — organize users into groups; group names are emitted as a `groups` claim when the `groups` scope is granted
 - **Soft deletes** — users and clients are deactivated, not destroyed, preserving audit history
 - **Account self-service** — users can manage their own profile, security settings, sessions, passkeys, MFA, and connected providers via the built-in Account UI
 
@@ -184,6 +186,7 @@ Each package in `pkg/` owns a vertical slice of IdP functionality. The conventio
 | `pkg/idpsession`    | IdP-level SSO sessions — cross-request browser sessions                          |
 | `pkg/client`        | OAuth2 client registration, CRUD, and authentication                             |
 | `pkg/user`          | User identity management — CRUD, authentication, lockout                         |
+| `pkg/userclaim`     | Custom per-user claims — CRUD and token/UserInfo embedding                        |
 | `pkg/signup`        | Self-service user registration flow                                              |
 | `pkg/onboarding`    | First-run admin account creation                                                 |
 | `pkg/appsettings`   | Runtime settings — DB persistence, loading into config                           |

--- a/admin-ui/src/api/userClaims.ts
+++ b/admin-ui/src/api/userClaims.ts
@@ -1,0 +1,25 @@
+import apiClient from "./client";
+import type { UserClaim, UserClaimRequest } from "../types/userClaim";
+
+const base = (userId: string) => `/admin/api/users/${userId}/claims`;
+
+export async function getUserClaims(userId: string): Promise<UserClaim[]> {
+  const { data } = await apiClient.get<{ data: UserClaim[] }>(base(userId));
+  return data.data;
+}
+
+export async function upsertUserClaim(
+  userId: string,
+  request: UserClaimRequest
+): Promise<void> {
+  await apiClient.post(base(userId), request);
+}
+
+export async function deleteUserClaim(
+  userId: string,
+  name: string
+): Promise<void> {
+  // Claim names may be namespaced URIs containing "/"; the DELETE route captures
+  // the full remaining path, so the name is appended verbatim.
+  await apiClient.delete(`${base(userId)}/${name}`);
+}

--- a/admin-ui/src/api/userClaims.ts
+++ b/admin-ui/src/api/userClaims.ts
@@ -19,8 +19,6 @@ export async function deleteUserClaim(
   userId: string,
   name: string
 ): Promise<void> {
-  // Claim names may be namespaced URIs containing "/". Sent raw, net/http.ServeMux
-  // path-cleans the "//" and 301-redirects, breaking the delete. Percent-encode the
-  // whole name; the {name...} route decodes it back on the server.
+  // encoded: names may be namespaced URIs; raw "//" gets path-cleaned + redirected
   await apiClient.delete(`${base(userId)}/${encodeURIComponent(name)}`);
 }

--- a/admin-ui/src/api/userClaims.ts
+++ b/admin-ui/src/api/userClaims.ts
@@ -19,7 +19,8 @@ export async function deleteUserClaim(
   userId: string,
   name: string
 ): Promise<void> {
-  // Claim names may be namespaced URIs containing "/"; the DELETE route captures
-  // the full remaining path, so the name is appended verbatim.
-  await apiClient.delete(`${base(userId)}/${name}`);
+  // Claim names may be namespaced URIs containing "/". Sent raw, net/http.ServeMux
+  // path-cleans the "//" and 301-redirects, breaking the delete. Percent-encode the
+  // whole name; the {name...} route decodes it back on the server.
+  await apiClient.delete(`${base(userId)}/${encodeURIComponent(name)}`);
 }

--- a/admin-ui/src/components/clients/ClientCreateForm.tsx
+++ b/admin-ui/src/components/clients/ClientCreateForm.tsx
@@ -61,6 +61,8 @@ const SCOPE_OPTIONS = [
   { label: "address", value: "address" },
   { label: "phone", value: "phone" },
   { label: "offline_access", value: "offline_access" },
+  { label: "groups", value: "groups" },
+  { label: "custom_claims", value: "custom_claims" },
 ];
 
 export default function ClientCreateForm({

--- a/admin-ui/src/components/clients/ClientEditForm.tsx
+++ b/admin-ui/src/components/clients/ClientEditForm.tsx
@@ -55,6 +55,8 @@ const SCOPE_OPTIONS = [
   { label: "address", value: "address" },
   { label: "phone", value: "phone" },
   { label: "offline_access", value: "offline_access" },
+  { label: "groups", value: "groups" },
+  { label: "custom_claims", value: "custom_claims" },
 ];
 
 export default function ClientEditForm({

--- a/admin-ui/src/components/users/UserClaimsDrawer.tsx
+++ b/admin-ui/src/components/users/UserClaimsDrawer.tsx
@@ -84,7 +84,13 @@ export default function UserClaimsDrawer({
           okText="Remove"
           okButtonProps={{ danger: true }}
         >
-          <Button type="text" size="small" danger icon={<DeleteOutlined />} />
+          <Button
+            type="text"
+            size="small"
+            danger
+            aria-label={`Remove claim ${record.name}`}
+            icon={<DeleteOutlined />}
+          />
         </Popconfirm>
       ),
     },
@@ -138,7 +144,7 @@ export default function UserClaimsDrawer({
             style={{ display: "block", marginTop: 8, fontSize: 12 }}
           >
             Emitted into tokens and UserInfo when the client is granted the{" "}
-            <code>custom_claims</code> scope. Standard claim names are rejected.
+            <code>custom_claims</code> scope.
           </Typography.Text>
         </div>
 

--- a/admin-ui/src/components/users/UserClaimsDrawer.tsx
+++ b/admin-ui/src/components/users/UserClaimsDrawer.tsx
@@ -1,0 +1,157 @@
+import { useState } from "react";
+import {
+  Drawer,
+  Input,
+  Table,
+  Button,
+  Space,
+  Typography,
+  Popconfirm,
+  App,
+} from "antd";
+import { DeleteOutlined, PlusOutlined } from "@ant-design/icons";
+import type { ColumnsType } from "antd/es/table";
+import {
+  useUserClaims,
+  useUpsertUserClaim,
+  useDeleteUserClaim,
+} from "../../hooks/useUserClaims";
+import type { UserClaim } from "../../types/userClaim";
+
+interface UserClaimsDrawerProps {
+  open: boolean;
+  userId: string | null;
+  username: string;
+  onClose: () => void;
+}
+
+export default function UserClaimsDrawer({
+  open,
+  userId,
+  username,
+  onClose,
+}: UserClaimsDrawerProps) {
+  const { message } = App.useApp();
+  const { data: claims, isLoading } = useUserClaims(userId, open);
+  const upsertClaim = useUpsertUserClaim();
+  const deleteClaim = useDeleteUserClaim();
+  const [name, setName] = useState("");
+  const [value, setValue] = useState("");
+
+  const reset = () => {
+    setName("");
+    setValue("");
+  };
+
+  const handleAdd = async () => {
+    if (!userId || !name.trim()) return;
+    try {
+      await upsertClaim.mutateAsync({
+        userId,
+        claim: { name: name.trim(), value },
+      });
+      message.success("Claim saved");
+      reset();
+    } catch (err) {
+      const detail =
+        (err as { response?: { data?: { error_description?: string } } })
+          ?.response?.data?.error_description ?? "Failed to save claim";
+      message.error(detail);
+    }
+  };
+
+  const handleDelete = async (claimName: string) => {
+    if (!userId) return;
+    try {
+      await deleteClaim.mutateAsync({ userId, name: claimName });
+      message.success("Claim removed");
+    } catch {
+      message.error("Failed to remove claim");
+    }
+  };
+
+  const columns: ColumnsType<UserClaim> = [
+    { title: "Name", dataIndex: "name", key: "name", ellipsis: true },
+    { title: "Value", dataIndex: "value", key: "value", ellipsis: true },
+    {
+      title: "",
+      key: "actions",
+      width: 50,
+      render: (_, record) => (
+        <Popconfirm
+          title="Remove this claim?"
+          onConfirm={() => handleDelete(record.name)}
+          okText="Remove"
+          okButtonProps={{ danger: true }}
+        >
+          <Button type="text" size="small" danger icon={<DeleteOutlined />} />
+        </Popconfirm>
+      ),
+    },
+  ];
+
+  return (
+    <Drawer
+      title={`Custom claims for ${username}`}
+      open={open}
+      onClose={() => {
+        onClose();
+        reset();
+      }}
+      width={480}
+    >
+      <Space direction="vertical" size="middle" style={{ display: "flex" }}>
+        <div>
+          <Typography.Text
+            type="secondary"
+            style={{ display: "block", marginBottom: 8 }}
+          >
+            Add claim
+          </Typography.Text>
+          <Space.Compact style={{ width: "100%" }}>
+            <Input
+              style={{ width: "40%" }}
+              placeholder="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onPressEnter={handleAdd}
+            />
+            <Input
+              style={{ width: "60%" }}
+              placeholder="value"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onPressEnter={handleAdd}
+            />
+            <Button
+              type="primary"
+              icon={<PlusOutlined />}
+              onClick={handleAdd}
+              loading={upsertClaim.isPending}
+              disabled={!name.trim()}
+            >
+              Add
+            </Button>
+          </Space.Compact>
+          <Typography.Text
+            type="secondary"
+            style={{ display: "block", marginTop: 8, fontSize: 12 }}
+          >
+            Emitted into tokens and UserInfo when the client is granted the{" "}
+            <code>custom_claims</code> scope. Standard claim names are rejected.
+          </Typography.Text>
+        </div>
+
+        <Table<UserClaim>
+          columns={columns}
+          dataSource={claims ?? []}
+          rowKey="name"
+          loading={isLoading}
+          pagination={false}
+          size="small"
+          locale={{ emptyText: "No custom claims" }}
+        />
+      </Space>
+    </Drawer>
+  );
+}

--- a/admin-ui/src/hooks/useUserClaims.ts
+++ b/admin-ui/src/hooks/useUserClaims.ts
@@ -1,0 +1,46 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  getUserClaims,
+  upsertUserClaim,
+  deleteUserClaim,
+} from "../api/userClaims";
+import type { UserClaimRequest } from "../types/userClaim";
+
+export function useUserClaims(userId: string | null, enabled = true) {
+  return useQuery({
+    queryKey: ["user-claims", userId],
+    queryFn: () => getUserClaims(userId!),
+    enabled: !!userId && enabled,
+  });
+}
+
+export function useUpsertUserClaim() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      userId,
+      claim,
+    }: {
+      userId: string;
+      claim: UserClaimRequest;
+    }) => upsertUserClaim(userId, claim),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["user-claims", variables.userId],
+      });
+    },
+  });
+}
+
+export function useDeleteUserClaim() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ userId, name }: { userId: string; name: string }) =>
+      deleteUserClaim(userId, name),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["user-claims", variables.userId],
+      });
+    },
+  });
+}

--- a/admin-ui/src/pages/UsersPage.tsx
+++ b/admin-ui/src/pages/UsersPage.tsx
@@ -21,6 +21,7 @@ import {
   UnlockOutlined,
   TeamOutlined,
   LaptopOutlined,
+  IdcardOutlined,
 } from "@ant-design/icons";
 import type { ColumnsType, TablePaginationConfig } from "antd/es/table";
 import type { FilterValue, SorterResult } from "antd/es/table/interface";
@@ -33,6 +34,7 @@ import type { UserResponseExt } from "../types/user";
 import UserCreateForm from "../components/users/UserCreateForm";
 import UserEditForm from "../components/users/UserEditForm";
 import UserGroupsDrawer from "../components/users/UserGroupsDrawer";
+import UserClaimsDrawer from "../components/users/UserClaimsDrawer";
 import UserSessionsDrawer from "../components/users/UserSessionsDrawer";
 import DeletionRequestsTab from "../components/users/DeletionRequestsTab";
 import { useTableScrollY } from "../hooks/useTableScrollY";
@@ -72,6 +74,7 @@ export default function UsersPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [editUser, setEditUser] = useState<UserResponseExt | null>(null);
   const [groupsUser, setGroupsUser] = useState<UserResponseExt | null>(null);
+  const [claimsUser, setClaimsUser] = useState<UserResponseExt | null>(null);
   const [sessionsUser, setSessionsUser] = useState<UserResponseExt | null>(null);
 
   useEffect(() => {
@@ -301,6 +304,12 @@ export default function UsersPage() {
           <Button
             type="text"
             size="small"
+            icon={<IdcardOutlined />}
+            onClick={() => setClaimsUser(record)}
+          />
+          <Button
+            type="text"
+            size="small"
             icon={<LaptopOutlined />}
             onClick={() => setSessionsUser(record)}
           />
@@ -426,6 +435,12 @@ export default function UsersPage() {
         userId={groupsUser?.id ?? null}
         username={groupsUser?.username ?? ""}
         onClose={() => setGroupsUser(null)}
+      />
+      <UserClaimsDrawer
+        open={!!claimsUser}
+        userId={claimsUser?.id ?? null}
+        username={claimsUser?.username ?? ""}
+        onClose={() => setClaimsUser(null)}
       />
 
       <UserSessionsDrawer

--- a/admin-ui/src/pages/UsersPage.tsx
+++ b/admin-ui/src/pages/UsersPage.tsx
@@ -305,6 +305,7 @@ export default function UsersPage() {
             type="text"
             size="small"
             icon={<IdcardOutlined />}
+            aria-label={`Custom claims for ${record.username}`}
             onClick={() => setClaimsUser(record)}
           />
           <Button

--- a/admin-ui/src/types/userClaim.d.ts
+++ b/admin-ui/src/types/userClaim.d.ts
@@ -1,0 +1,10 @@
+export interface UserClaim {
+  name: string;
+  value: string;
+  updated_at: string;
+}
+
+export interface UserClaimRequest {
+  name: string;
+  value: string;
+}

--- a/docs-web/astro.config.mjs
+++ b/docs-web/astro.config.mjs
@@ -120,6 +120,7 @@ export default defineConfig({
 						{ label: 'Managing Users', link: '/users/managing-users/' },
 						{ label: 'Self-Signup', link: '/users/self-signup/' },
 						{ label: 'Groups', link: '/users/groups/' },
+						{ label: 'Custom Claims', link: '/users/custom-claims/' },
 						{ label: 'Account Lockout', link: '/users/account-lockout/' },
 						{ label: 'Account Deletion', link: '/users/account-deletion/' },
 					],

--- a/docs-web/src/content/docs/api-reference/endpoints.mdx
+++ b/docs-web/src/content/docs/api-reference/endpoints.mdx
@@ -95,6 +95,9 @@ All admin endpoints require a bearer token with admin role.
 | POST | `/admin/api/users/{id}/unlock` | Unlock locked user account |
 | POST | `/admin/api/users/{id}/revoke-sessions` | Revoke all sessions for a user |
 | GET | `/admin/api/users/{id}/groups` | List groups a user belongs to |
+| GET | `/admin/api/users/{id}/claims` | List a user's custom claims |
+| POST | `/admin/api/users/{id}/claims` | Create or update a custom claim |
+| DELETE | `/admin/api/users/{id}/claims/{name}` | Remove a custom claim |
 | GET | `/admin/api/users/{id}/idp-sessions` | List IdP sessions for a user |
 
 ### Clients

--- a/docs-web/src/content/docs/api-reference/endpoints.mdx
+++ b/docs-web/src/content/docs/api-reference/endpoints.mdx
@@ -97,7 +97,7 @@ All admin endpoints require a bearer token with admin role.
 | GET | `/admin/api/users/{id}/groups` | List groups a user belongs to |
 | GET | `/admin/api/users/{id}/claims` | List a user's custom claims |
 | POST | `/admin/api/users/{id}/claims` | Create or update a custom claim |
-| DELETE | `/admin/api/users/{id}/claims/{name}` | Remove a custom claim |
+| DELETE | `/admin/api/users/{id}/claims/{name...}` | Remove a custom claim (the name is the rest of the path; percent-encode `/` as `%2F` for namespaced names) |
 | GET | `/admin/api/users/{id}/idp-sessions` | List IdP sessions for a user |
 
 ### Clients

--- a/docs-web/src/content/docs/architecture/database-schema.mdx
+++ b/docs-web/src/content/docs/architecture/database-schema.mdx
@@ -356,6 +356,9 @@ Composite primary key on `(user_id, claim_name)` -- one row per pair.
 | 5 | `005_nullable_token_user_id.go` | Rebuilds `tokens` table to make `user_id` nullable (for client_credentials grant) |
 | 6 | `006_idp_session_linkage.go` | Adds `idp_session_id` column to `auth_codes` and `sessions` tables |
 | 7 | `007_user_consents.go` | Adds `consent_required` column to `clients` and creates `user_consents` table |
+| 8 | `008_device_codes.go` | Creates `device_codes` table for the device authorization grant |
+| 9 | `009_magic_link_tokens.go` | Creates `magic_link_tokens` table for passwordless email login |
+| 10 | `010_nullable_passkey_challenge_user_id.go` | Rebuilds `passkey_challenges` to make `user_id` nullable (for discoverable login) |
 | 11 | `011_user_claims.go` | Creates `user_claims` table for custom per-user claims |
 
 ## Indexes

--- a/docs-web/src/content/docs/architecture/database-schema.mdx
+++ b/docs-web/src/content/docs/architecture/database-schema.mdx
@@ -331,6 +331,20 @@ Stored OAuth2 consent decisions per user and client. Added in migration 007.
 
 Unique constraint on `(user_id, client_id)`. When a user approves a consent screen, the decision is stored here. Subsequent logins skip the consent screen unless the requested scopes change.
 
+### `user_claims`
+
+Custom per-user claims emitted when the `custom_claims` scope is granted. Added in migration 011.
+
+| Column | Type | Notes |
+|---|---|---|
+| `user_id` | TEXT FK | -> users (ON DELETE CASCADE) |
+| `claim_name` | TEXT | |
+| `claim_value` | TEXT | String value |
+| `created_at` | DATETIME | |
+| `updated_at` | DATETIME | |
+
+Composite primary key on `(user_id, claim_name)` -- one row per pair.
+
 ## Migrations
 
 | Version | File | Description |
@@ -342,6 +356,7 @@ Unique constraint on `(user_id, client_id)`. When a user approves a consent scre
 | 5 | `005_nullable_token_user_id.go` | Rebuilds `tokens` table to make `user_id` nullable (for client_credentials grant) |
 | 6 | `006_idp_session_linkage.go` | Adds `idp_session_id` column to `auth_codes` and `sessions` tables |
 | 7 | `007_user_consents.go` | Adds `consent_required` column to `clients` and creates `user_consents` table |
+| 11 | `011_user_claims.go` | Creates `user_claims` table for custom per-user claims |
 
 ## Indexes
 
@@ -365,3 +380,4 @@ The following indexes are created across migrations:
 - `idx_user_groups_group_id` on `user_groups(group_id)`
 - `idx_auth_codes_idp_session_id` on `auth_codes(idp_session_id)`
 - `idx_user_consents_user_client` on `user_consents(user_id, client_id)`
+- `idx_user_claims_user_id` on `user_claims(user_id)`

--- a/docs-web/src/content/docs/architecture/package-structure.mdx
+++ b/docs-web/src/content/docs/architecture/package-structure.mdx
@@ -51,6 +51,7 @@ autentico/
 │   ├── token/                POST /oauth2/token — all grant types, token generation
 │   ├── trusteddevice/        Trusted device create/read/validate
 │   ├── user/                 User CRUD, authentication, lockout
+│   ├── userclaim/            Custom per-user claims — CRUD, token/userinfo embedding
 │   ├── userinfo/             GET /oauth2/userinfo
 │   ├── utils/                Shared helpers — response writers, redirect URI validation, hashing
 │   └── wellknown/            GET /.well-known/openid-configuration, GET /oauth2/.well-known/jwks.json

--- a/docs-web/src/content/docs/protocol/scopes.mdx
+++ b/docs-web/src/content/docs/protocol/scopes.mdx
@@ -83,4 +83,4 @@ The scopes are recorded on the authorization code and propagated to the token re
 
 When registering a client, set its allowed scopes via the `scopes` field. If omitted, the client defaults to `openid profile email`. The authorization request can request any subset of the client's allowed scopes.
 
-To emit custom claims, the client must include `custom_claims` in its `scopes` and request it; otherwise the request is rejected like any other disallowed scope.
+Custom claims are emitted only when the request includes the `custom_claims` scope. Omitting it is fine: the request succeeds and no custom claims are returned. Requesting it when the client's `scopes` do not list `custom_claims` is rejected like any other disallowed scope (`invalid_scope`).

--- a/docs-web/src/content/docs/protocol/scopes.mdx
+++ b/docs-web/src/content/docs/protocol/scopes.mdx
@@ -16,6 +16,7 @@ Scopes control which claims are included in the ID token and returned from the U
 | `phone` | `phone_number`, `phone_number_verified` |
 | `offline_access` | No additional claims — enables refresh token issuance so the client can obtain new access tokens without user interaction |
 | `groups` | `groups` — an array of group names the user belongs to |
+| `custom_claims` | Every custom claim assigned to the user by an admin, merged into the ID token, access token, and UserInfo response (see [Custom Claims](/users/custom-claims/)) |
 
 Always request `openid` to get an ID token. Add `profile` and `email` to include those claims.
 
@@ -81,3 +82,5 @@ The scopes are recorded on the authorization code and propagated to the token re
 ## Default scopes for clients
 
 When registering a client, set its allowed scopes via the `scopes` field. If omitted, the client defaults to `openid profile email`. The authorization request can request any subset of the client's allowed scopes.
+
+To emit custom claims, the client must include `custom_claims` in its `scopes` and request it; otherwise the request is rejected like any other disallowed scope.

--- a/docs-web/src/content/docs/users/custom-claims.mdx
+++ b/docs-web/src/content/docs/users/custom-claims.mdx
@@ -54,7 +54,7 @@ All custom claim endpoints require admin authentication.
 |---|---|---|
 | `GET` | `/admin/api/users/{id}/claims` | List a user's custom claims |
 | `POST` | `/admin/api/users/{id}/claims` | Create or update one custom claim |
-| `DELETE` | `/admin/api/users/{id}/claims/{name}` | Remove one custom claim |
+| `DELETE` | `/admin/api/users/{id}/claims/{name...}` | Remove one custom claim |
 
 ### List a user's claims
 
@@ -97,7 +97,7 @@ curl -X DELETE https://auth.example.com/admin/api/users/$USER_ID/claims/tier \
   -H "Authorization: Bearer $ADMIN_TOKEN"
 ```
 
-For a namespaced claim name, pass it as the remaining path (`.../claims/https://app.example.com/tier`). Returns `404 Not Found` if the claim does not exist.
+The name is the rest of the path. For a namespaced claim name, percent-encode the slashes as `%2F` (e.g. `.../claims/https:%2F%2Fapp.example.com%2Ftier`) — sent raw, the `//` is path-cleaned and the request is redirected. Returns `404 Not Found` if the claim does not exist.
 
 ## Database table
 

--- a/docs-web/src/content/docs/users/custom-claims.mdx
+++ b/docs-web/src/content/docs/users/custom-claims.mdx
@@ -1,0 +1,114 @@
+---
+title: Custom Claims
+description: Assigning arbitrary key/value claims to users and emitting them in tokens via the custom_claims scope.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Custom claims let an admin attach arbitrary `name` / `value` pairs to a user. When the `custom_claims` scope is granted, those pairs are merged into the user's ID token, access token, and UserInfo response. Use them to carry application-specific attributes (tenant, tier, department, entitlements) that Autentico does not model natively.
+
+## Custom claims in tokens
+
+When the `custom_claims` scope is requested and granted, every custom claim assigned to the user is included in:
+
+- **Access tokens** -- as string values
+- **ID tokens** -- as string values
+- **UserInfo responses** -- as string fields
+
+Example token claims:
+
+```json
+{
+  "sub": "user-123",
+  "tier": "gold",
+  "region": "eu",
+  "scope": "openid custom_claims"
+}
+```
+
+<Aside type="tip">
+Add `custom_claims` to the client's allowed scopes and include it in the authorization request. If the client requests `custom_claims` but it is not in its allowed scopes, the request is rejected like any other disallowed scope. See [Scopes](/protocol/scopes/).
+</Aside>
+
+### Values are strings
+
+Every custom claim value is emitted as a JSON string -- `"tier": "gold"`, never `"tier": 3` or `"active": true`. Typed values (numbers, booleans, arrays) are not supported in this version.
+
+### Reserved names
+
+A custom claim may not shadow a standard or structural claim. The following names are rejected on write with `400 invalid_request`:
+
+`iss`, `sub`, `aud`, `exp`, `iat`, `nbf`, `jti`, `auth_time`, `nonce`, `at_hash`, `c_hash`, `azp`, `sid`, `acr`, `amr`, `typ`, `scope`, `client_id`, `token_type`, `active`, and every claim Autentico already emits: `name`, `preferred_username`, `given_name`, `family_name`, `middle_name`, `nickname`, `profile`, `picture`, `website`, `gender`, `birthdate`, `locale`, `zoneinfo`, `updated_at`, `email`, `email_verified`, `phone_number`, `phone_number_verified`, `address`, `groups`, `role`.
+
+Even if a reserved name is inserted directly into the database, the token builder never lets a custom claim overwrite a claim it has already set.
+
+### Naming
+
+Claim names must match `^[a-zA-Z_][a-zA-Z0-9_.:/-]*$` (bare names like `tier`, or collision-resistant namespaced names like `https://app.example.com/tier`). OIDC Core §5.1.2 recommends collision-resistant or private claim names for non-standard claims; bare names are acceptable when Autentico is used within a private subsystem.
+
+## Admin API endpoints
+
+All custom claim endpoints require admin authentication.
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/admin/api/users/{id}/claims` | List a user's custom claims |
+| `POST` | `/admin/api/users/{id}/claims` | Create or update one custom claim |
+| `DELETE` | `/admin/api/users/{id}/claims/{name}` | Remove one custom claim |
+
+### List a user's claims
+
+```bash
+curl https://auth.example.com/admin/api/users/$USER_ID/claims \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+Response:
+
+```json
+{
+  "data": [
+    { "name": "region", "value": "eu", "updated_at": "2026-01-15T10:00:00Z" },
+    { "name": "tier", "value": "gold", "updated_at": "2026-01-15T10:00:00Z" }
+  ]
+}
+```
+
+### Create or update a claim
+
+```bash
+curl -X POST https://auth.example.com/admin/api/users/$USER_ID/claims \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "tier", "value": "gold"}'
+```
+
+| Field | Required | Validation |
+|---|---|---|
+| `name` | Yes | 1--128 characters, matches the name pattern, not a reserved name |
+| `value` | No | Up to 4096 characters |
+
+The operation is an upsert: posting an existing `name` again replaces its value. Returns `201 Created` on success, `404 Not Found` if the user does not exist, `400 invalid_request` for a reserved or malformed name.
+
+### Delete a claim
+
+```bash
+curl -X DELETE https://auth.example.com/admin/api/users/$USER_ID/claims/tier \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+For a namespaced claim name, pass it as the remaining path (`.../claims/https://app.example.com/tier`). Returns `404 Not Found` if the claim does not exist.
+
+## Database table
+
+### `user_claims` table
+
+| Column | Type | Description |
+|---|---|---|
+| `user_id` | TEXT | Foreign key to `users.id` |
+| `claim_name` | TEXT | The claim name |
+| `claim_value` | TEXT | The claim value (string) |
+| `created_at` | DATETIME | When the claim was created |
+| `updated_at` | DATETIME | Last update timestamp |
+
+The primary key is `(user_id, claim_name)` -- one row per pair. Deleting a user cascades to remove all of that user's custom claims.

--- a/docs-web/src/content/docs/users/custom-claims.mdx
+++ b/docs-web/src/content/docs/users/custom-claims.mdx
@@ -36,11 +36,9 @@ Every custom claim value is emitted as a JSON string -- `"tier": "gold"`, never 
 
 ### Reserved names
 
-A custom claim may not shadow a standard or structural claim. The following names are rejected on write with `400 invalid_request`:
+A custom claim may not shadow a registered claim. Any name in the [IANA "JSON Web Token Claims" registry](https://www.iana.org/assignments/jwt/jwt.xhtml) is rejected on write with `400 invalid_request` — this covers the RFC 7519 claims (`iss`, `sub`, `exp`, ...), the OIDC standard claims (`name`, `email`, `address`, ...), and security- and authorization-relevant claims Autentico does not itself emit (`cnf`, `roles`, `entitlements`, `act`, `authorization_details`, `verified_claims`, ...). Transport-specific entries (SIP, CDNI) are not reserved.
 
-`iss`, `sub`, `aud`, `exp`, `iat`, `nbf`, `jti`, `auth_time`, `nonce`, `at_hash`, `c_hash`, `azp`, `sid`, `acr`, `amr`, `typ`, `scope`, `client_id`, `token_type`, `active`, and every claim Autentico already emits: `name`, `preferred_username`, `given_name`, `family_name`, `middle_name`, `nickname`, `profile`, `picture`, `website`, `gender`, `birthdate`, `locale`, `zoneinfo`, `updated_at`, `email`, `email_verified`, `phone_number`, `phone_number_verified`, `address`, `groups`, `role`.
-
-Even if a reserved name is inserted directly into the database, the token builder never lets a custom claim overwrite a claim it has already set.
+As a second layer, even if a reserved name is inserted directly into the database, the token builder never lets a custom claim overwrite a claim it has already set.
 
 ### Naming
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2917,6 +2917,57 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/api/users/lookup": {
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "Resolves a list of user IDs, emails, and/or usernames into full user profiles in a single call. Maximum 100 identifiers total across all fields per request. Designed for external systems (e.g. ABAC policy engines) that need to resolve known identifiers into user data. Returns both matched users and any identifiers that could not be found.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-users"
+                ],
+                "summary": "Batch lookup users by identifiers",
+                "parameters": [
+                    {
+                        "description": "Lookup request with IDs, emails, and/or usernames",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/user.LookupUsersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-user_LookupUsersResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.AuthErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.AuthErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/api/users/{id}": {
             "get": {
                 "security": [
@@ -3057,6 +3108,155 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/api/users/{id}/claims": {
+            "get": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-user-claims"
+                ],
+                "summary": "List custom claims for a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/userclaim.UserClaimResponse"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-user-claims"
+                ],
+                "summary": "Create or update a custom claim for a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Custom claim payload",
+                        "name": "claim",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/userclaim.UserClaimRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/api/users/{id}/claims/{name}": {
+            "delete": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-user-claims"
+                ],
+                "summary": "Delete a custom claim from a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Claim name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/model.ApiError"
                         }
@@ -4817,6 +5017,17 @@ const docTemplate = `{
                 }
             }
         },
+        "model.ApiResponse-user_LookupUsersResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/user.LookupUsersResponse"
+                },
+                "error": {
+                    "$ref": "#/definitions/model.ApiError"
+                }
+            }
+        },
         "model.AuthErrorResponse": {
             "type": "object",
             "properties": {
@@ -5237,6 +5448,66 @@ const docTemplate = `{
                 }
             }
         },
+        "user.LookupNotFound": {
+            "type": "object",
+            "properties": {
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "usernames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "user.LookupUsersRequest": {
+            "type": "object",
+            "properties": {
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "usernames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "user.LookupUsersResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/user.UserResponse"
+                    }
+                },
+                "not_found": {
+                    "$ref": "#/definitions/user.LookupNotFound"
+                }
+            }
+        },
         "user.UserCreateRequest": {
             "type": "object",
             "properties": {
@@ -5422,6 +5693,31 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "zoneinfo": {
+                    "type": "string"
+                }
+            }
+        },
+        "userclaim.UserClaimRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "userclaim.UserClaimResponse": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "value": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2911,6 +2911,57 @@
                 }
             }
         },
+        "/admin/api/users/lookup": {
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "Resolves a list of user IDs, emails, and/or usernames into full user profiles in a single call. Maximum 100 identifiers total across all fields per request. Designed for external systems (e.g. ABAC policy engines) that need to resolve known identifiers into user data. Returns both matched users and any identifiers that could not be found.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-users"
+                ],
+                "summary": "Batch lookup users by identifiers",
+                "parameters": [
+                    {
+                        "description": "Lookup request with IDs, emails, and/or usernames",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/user.LookupUsersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiResponse-user_LookupUsersResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.AuthErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.AuthErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/api/users/{id}": {
             "get": {
                 "security": [
@@ -3051,6 +3102,155 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/api/users/{id}/claims": {
+            "get": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-user-claims"
+                ],
+                "summary": "List custom claims for a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/userclaim.UserClaimResponse"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-user-claims"
+                ],
+                "summary": "Create or update a custom claim for a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Custom claim payload",
+                        "name": "claim",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/userclaim.UserClaimRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.ApiError"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/api/users/{id}/claims/{name}": {
+            "delete": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin-user-claims"
+                ],
+                "summary": "Delete a custom claim from a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Claim name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/model.ApiError"
                         }
@@ -4811,6 +5011,17 @@
                 }
             }
         },
+        "model.ApiResponse-user_LookupUsersResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/user.LookupUsersResponse"
+                },
+                "error": {
+                    "$ref": "#/definitions/model.ApiError"
+                }
+            }
+        },
         "model.AuthErrorResponse": {
             "type": "object",
             "properties": {
@@ -5231,6 +5442,66 @@
                 }
             }
         },
+        "user.LookupNotFound": {
+            "type": "object",
+            "properties": {
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "usernames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "user.LookupUsersRequest": {
+            "type": "object",
+            "properties": {
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "usernames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "user.LookupUsersResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/user.UserResponse"
+                    }
+                },
+                "not_found": {
+                    "$ref": "#/definitions/user.LookupNotFound"
+                }
+            }
+        },
         "user.UserCreateRequest": {
             "type": "object",
             "properties": {
@@ -5416,6 +5687,31 @@
                     "type": "string"
                 },
                 "zoneinfo": {
+                    "type": "string"
+                }
+            }
+        },
+        "userclaim.UserClaimRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "userclaim.UserClaimResponse": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "value": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -554,6 +554,13 @@ definitions:
       message:
         type: string
     type: object
+  model.ApiResponse-user_LookupUsersResponse:
+    properties:
+      data:
+        $ref: '#/definitions/user.LookupUsersResponse'
+      error:
+        $ref: '#/definitions/model.ApiError'
+    type: object
   model.AuthErrorResponse:
     properties:
       error:
@@ -840,6 +847,45 @@ definitions:
       token_type:
         type: string
     type: object
+  user.LookupNotFound:
+    properties:
+      emails:
+        items:
+          type: string
+        type: array
+      ids:
+        items:
+          type: string
+        type: array
+      usernames:
+        items:
+          type: string
+        type: array
+    type: object
+  user.LookupUsersRequest:
+    properties:
+      emails:
+        items:
+          type: string
+        type: array
+      ids:
+        items:
+          type: string
+        type: array
+      usernames:
+        items:
+          type: string
+        type: array
+    type: object
+  user.LookupUsersResponse:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/user.UserResponse'
+        type: array
+      not_found:
+        $ref: '#/definitions/user.LookupNotFound'
+    type: object
   user.UserCreateRequest:
     properties:
       email:
@@ -964,6 +1010,22 @@ definitions:
       website:
         type: string
       zoneinfo:
+        type: string
+    type: object
+  userclaim.UserClaimRequest:
+    properties:
+      name:
+        type: string
+      value:
+        type: string
+    type: object
+  userclaim.UserClaimResponse:
+    properties:
+      name:
+        type: string
+      updated_at:
+        type: string
+      value:
         type: string
     type: object
 host: localhost:9999
@@ -2937,6 +2999,100 @@ paths:
       summary: Update a user
       tags:
       - admin-users
+  /admin/api/users/{id}/claims:
+    get:
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/userclaim.UserClaimResponse'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.ApiError'
+      security:
+      - AdminAuth: []
+      summary: List custom claims for a user
+      tags:
+      - admin-user-claims
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Custom claim payload
+        in: body
+        name: claim
+        required: true
+        schema:
+          $ref: '#/definitions/userclaim.UserClaimRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.ApiError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/model.ApiError'
+      security:
+      - AdminAuth: []
+      summary: Create or update a custom claim for a user
+      tags:
+      - admin-user-claims
+  /admin/api/users/{id}/claims/{name}:
+    delete:
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Claim name
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/model.ApiError'
+      security:
+      - AdminAuth: []
+      summary: Delete a custom claim from a user
+      tags:
+      - admin-user-claims
   /admin/api/users/{id}/deactivate:
     post:
       description: Soft-disables a user account, immediately revoking all tokens and
@@ -3094,6 +3250,42 @@ paths:
       security:
       - AdminAuth: []
       summary: Unlock user account
+      tags:
+      - admin-users
+  /admin/api/users/lookup:
+    post:
+      consumes:
+      - application/json
+      description: Resolves a list of user IDs, emails, and/or usernames into full
+        user profiles in a single call. Maximum 100 identifiers total across all fields
+        per request. Designed for external systems (e.g. ABAC policy engines) that
+        need to resolve known identifiers into user data. Returns both matched users
+        and any identifiers that could not be found.
+      parameters:
+      - description: Lookup request with IDs, emails, and/or usernames
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/user.LookupUsersRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.ApiResponse-user_LookupUsersResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.AuthErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.AuthErrorResponse'
+      security:
+      - AdminAuth: []
+      summary: Batch lookup users by identifiers
       tags:
       - admin-users
   /healthz:

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -50,6 +50,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/signup"
 	"github.com/eugenioenko/autentico/pkg/token"
 	"github.com/eugenioenko/autentico/pkg/user"
+	"github.com/eugenioenko/autentico/pkg/userclaim"
 	"github.com/eugenioenko/autentico/pkg/userinfo"
 	"github.com/eugenioenko/autentico/pkg/wellknown"
 	"github.com/eugenioenko/autentico/view"
@@ -211,6 +212,9 @@ func RunStart(c *cli.Context) error {
 	mux.Handle("POST /admin/api/groups/{id}/members", adminAPI(group.HandleAddMember))
 	mux.Handle("DELETE /admin/api/groups/{id}/members/{user_id}", adminAPI(group.HandleRemoveMember))
 	mux.Handle("GET /admin/api/users/{id}/groups", adminAPI(group.HandleGetUserGroups))
+	mux.Handle("GET /admin/api/users/{id}/claims", adminAPI(userclaim.HandleListUserClaims))
+	mux.Handle("POST /admin/api/users/{id}/claims", adminAPI(userclaim.HandleUpsertUserClaim))
+	mux.Handle("DELETE /admin/api/users/{id}/claims/{name...}", adminAPI(userclaim.HandleDeleteUserClaim))
 	mux.Handle("GET /admin/api/tokens", adminAPI(token.HandleListTokens))
 	mux.Handle("DELETE /admin/api/tokens/{id}", adminAPI(token.HandleRevokeToken))
 	mux.Handle("GET /admin/api/stats", adminAPI(admin.HandleStats))

--- a/pkg/db/migrations/011_user_claims.go
+++ b/pkg/db/migrations/011_user_claims.go
@@ -1,0 +1,15 @@
+package migrations
+
+const migration011 = `
+CREATE TABLE IF NOT EXISTS user_claims (
+    user_id     TEXT NOT NULL,
+    claim_name  TEXT NOT NULL,
+    claim_value TEXT NOT NULL DEFAULT '',
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, claim_name),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_claims_user_id ON user_claims(user_id);
+`

--- a/pkg/db/migrations/migrations.go
+++ b/pkg/db/migrations/migrations.go
@@ -7,7 +7,7 @@ import (
 
 // SchemaVersion is the schema version this binary expects.
 // Increment this and add a new Migration entry each time the schema changes.
-var SchemaVersion = 10
+var SchemaVersion = 11
 
 // Migration represents a single schema change.
 type Migration struct {
@@ -27,6 +27,7 @@ var migrations = []Migration{
 	{Version: 8, SQL: migration008},
 	{Version: 9, SQL: migration009},
 	{Version: 10, SQL: migration010},
+	{Version: 11, SQL: migration011},
 }
 
 func getUserVersion(db *sql.DB) (int, error) {

--- a/pkg/token/generate.go
+++ b/pkg/token/generate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/group"
 	"github.com/eugenioenko/autentico/pkg/key"
 	"github.com/eugenioenko/autentico/pkg/user"
+	"github.com/eugenioenko/autentico/pkg/userclaim"
 )
 
 // acrForUser returns the Authentication Context Class Reference value.
@@ -92,6 +93,21 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 			accessClaims["groups"] = groupNames
 		}
 	}
+
+	// OIDC Core §5.1.2 / RFC 9068 §2.2.2: user-defined custom claims MAY be included
+	// alongside standard claims; they are gated behind the non-standard "custom_claims"
+	// scope and can never override a claim already set above (reserved names are also
+	// rejected at write time in pkg/userclaim).
+	if containsScope(scope, "custom_claims") {
+		if custom, err := userclaim.ClaimMapByUserID(user.ID); err == nil {
+			for name, value := range custom {
+				if _, taken := accessClaims[name]; !taken {
+					accessClaims[name] = value
+				}
+			}
+		}
+	}
+
 	accessToken := jwt.NewWithClaims(jwt.SigningMethodRS256, accessClaims)
 	accessToken.Header["kid"] = bs.AuthJwkCertKeyID
 	signedAccessToken, err := accessToken.SignedString(key.GetPrivateKey())
@@ -192,6 +208,18 @@ func GenerateIDToken(user user.User, sessionID string, nonce string, scope strin
 	if containsScope(scope, "email") {
 		claims["email"] = user.Email
 		claims["email_verified"] = user.IsEmailVerified
+	}
+
+	// OIDC Core §5.1.2: additional (non-standard) claims MAY be included in the ID token.
+	// Gated behind the "custom_claims" scope; never overrides a standard claim set above.
+	if containsScope(scope, "custom_claims") {
+		if custom, err := userclaim.ClaimMapByUserID(user.ID); err == nil {
+			for name, value := range custom {
+				if _, taken := claims[name]; !taken {
+					claims[name] = value
+				}
+			}
+		}
 	}
 
 	idToken := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)

--- a/pkg/token/generate.go
+++ b/pkg/token/generate.go
@@ -99,11 +99,13 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 	// scope and can never override a claim already set above (reserved names are also
 	// rejected at write time in pkg/userclaim).
 	if containsScope(scope, "custom_claims") {
-		if custom, err := userclaim.ClaimMapByUserID(user.ID); err == nil {
-			for name, value := range custom {
-				if _, taken := accessClaims[name]; !taken {
-					accessClaims[name] = value
-				}
+		custom, err := userclaim.ClaimMapByUserID(user.ID)
+		if err != nil {
+			return nil, fmt.Errorf("could not load custom claims: %w", err)
+		}
+		for name, value := range custom {
+			if _, taken := accessClaims[name]; !taken {
+				accessClaims[name] = value
 			}
 		}
 	}
@@ -213,11 +215,13 @@ func GenerateIDToken(user user.User, sessionID string, nonce string, scope strin
 	// OIDC Core §5.1.2: additional (non-standard) claims MAY be included in the ID token.
 	// Gated behind the "custom_claims" scope; never overrides a standard claim set above.
 	if containsScope(scope, "custom_claims") {
-		if custom, err := userclaim.ClaimMapByUserID(user.ID); err == nil {
-			for name, value := range custom {
-				if _, taken := claims[name]; !taken {
-					claims[name] = value
-				}
+		custom, err := userclaim.ClaimMapByUserID(user.ID)
+		if err != nil {
+			return "", fmt.Errorf("could not load custom claims: %w", err)
+		}
+		for name, value := range custom {
+			if _, taken := claims[name]; !taken {
+				claims[name] = value
 			}
 		}
 	}

--- a/pkg/token/generate_customclaims_test.go
+++ b/pkg/token/generate_customclaims_test.go
@@ -91,6 +91,82 @@ func TestGenerateTokens_CustomClaimsCannotOverrideStandardClaim(t *testing.T) {
 	assert.Equal(t, "gold", claims["tier"])
 }
 
+func TestGenerateIDToken_CustomClaimsCannotOverrideStandardClaim(t *testing.T) {
+	testutils.WithTestDB(t)
+	config.Values.AuthAccessTokenExpiration = 15 * time.Minute
+	config.Bootstrap.AppAuthIssuer = "http://localhost/oauth2"
+
+	testutils.InsertTestUser(t, "user-cc-id-override")
+	// Direct insert bypasses write-time reserved-name rejection.
+	_, err := db.GetDB().Exec(`INSERT INTO user_claims (user_id, claim_name, claim_value) VALUES (?, ?, ?)`,
+		"user-cc-id-override", "sub", "evil")
+	require.NoError(t, err)
+	_, err = db.GetDB().Exec(`INSERT INTO user_claims (user_id, claim_name, claim_value) VALUES (?, ?, ?)`,
+		"user-cc-id-override", "iss", "https://evil.example.com")
+	require.NoError(t, err)
+
+	testUser := user.User{ID: "user-cc-id-override", Username: "testuser"}
+
+	idToken, err := GenerateIDToken(testUser, "session-1", "", "openid custom_claims", "my-client", time.Now(), "at")
+	require.NoError(t, err)
+
+	claims := parseIDTokenClaims(t, idToken)
+	assert.Equal(t, "user-cc-id-override", claims["sub"], "custom claim must never override the real sub")
+	assert.Equal(t, "http://localhost/oauth2", claims["iss"], "custom claim must never override the real iss")
+}
+
+func TestGenerateIDToken_NamespacedCustomClaimName(t *testing.T) {
+	testutils.WithTestDB(t)
+	config.Values.AuthAccessTokenExpiration = 15 * time.Minute
+	config.Bootstrap.AppAuthIssuer = "http://localhost/oauth2"
+
+	testutils.InsertTestUser(t, "user-cc-ns")
+	const name = "https://claims.example.com/tier"
+	require.NoError(t, userclaim.UpsertClaim("user-cc-ns", name, "gold"))
+
+	testUser := user.User{ID: "user-cc-ns", Username: "testuser"}
+
+	idToken, err := GenerateIDToken(testUser, "session-1", "", "openid custom_claims", "my-client", time.Now(), "at")
+	require.NoError(t, err)
+
+	claims := parseIDTokenClaims(t, idToken)
+	assert.Equal(t, "gold", claims[name], "namespaced claim name must appear verbatim as the JWT claim key")
+}
+
+func TestGenerateIDToken_CustomClaimValueStaysLiteralString(t *testing.T) {
+	testutils.WithTestDB(t)
+	config.Values.AuthAccessTokenExpiration = 15 * time.Minute
+	config.Bootstrap.AppAuthIssuer = "http://localhost/oauth2"
+
+	testutils.InsertTestUser(t, "user-cc-json")
+	require.NoError(t, userclaim.UpsertClaim("user-cc-json", "meta", `{"x":1}`))
+
+	testUser := user.User{ID: "user-cc-json", Username: "testuser"}
+
+	idToken, err := GenerateIDToken(testUser, "session-1", "", "openid custom_claims", "my-client", time.Now(), "at")
+	require.NoError(t, err)
+
+	claims := parseIDTokenClaims(t, idToken)
+	assert.Equal(t, `{"x":1}`, claims["meta"], "custom claim values are always literal strings, never parsed")
+}
+
+func TestGenerateClientCredentialsToken_NoCustomClaims(t *testing.T) {
+	testutils.WithTestDB(t)
+	config.Values.AuthAccessTokenExpiration = 15 * time.Minute
+	config.Bootstrap.AppAuthIssuer = "http://localhost/oauth2"
+
+	tok, err := GenerateClientCredentialsToken("my-client", "openid custom_claims", config.Get())
+	require.NoError(t, err)
+
+	claims := parseAccessTokenClaims(t, tok.AccessToken)
+	// client_credentials has no resource owner; only the fixed claim set is present.
+	for k := range claims {
+		assert.Contains(t,
+			[]string{"exp", "iat", "auth_time", "jti", "iss", "aud", "sub", "typ", "azp", "sid", "acr", "scope"},
+			k, "unexpected claim %q in client_credentials token", k)
+	}
+}
+
 func parseAccessTokenClaims(t *testing.T, token string) jwt.MapClaims {
 	t.Helper()
 	parsed, err := jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {

--- a/pkg/token/generate_customclaims_test.go
+++ b/pkg/token/generate_customclaims_test.go
@@ -1,0 +1,101 @@
+package token
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/db"
+	"github.com/eugenioenko/autentico/pkg/key"
+	"github.com/eugenioenko/autentico/pkg/user"
+	"github.com/eugenioenko/autentico/pkg/userclaim"
+	testutils "github.com/eugenioenko/autentico/tests/utils"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateIDToken_CustomClaims(t *testing.T) {
+	testutils.WithTestDB(t)
+	config.Values.AuthAccessTokenExpiration = 15 * time.Minute
+	config.Bootstrap.AppAuthIssuer = "http://localhost/oauth2"
+
+	testutils.InsertTestUser(t, "user-cc-1")
+	require.NoError(t, userclaim.UpsertClaim("user-cc-1", "tier", "gold"))
+	require.NoError(t, userclaim.UpsertClaim("user-cc-1", "region", "eu"))
+
+	testUser := user.User{ID: "user-cc-1", Username: "testuser"}
+
+	idToken, err := GenerateIDToken(testUser, "session-1", "", "openid custom_claims", "my-client", time.Now(), "fake-access-token")
+	require.NoError(t, err)
+
+	claims := parseIDTokenClaims(t, idToken)
+	assert.Equal(t, "gold", claims["tier"])
+	assert.Equal(t, "eu", claims["region"])
+}
+
+func TestGenerateIDToken_NoCustomClaimsScope(t *testing.T) {
+	testutils.WithTestDB(t)
+	config.Values.AuthAccessTokenExpiration = 15 * time.Minute
+	config.Bootstrap.AppAuthIssuer = "http://localhost/oauth2"
+
+	testutils.InsertTestUser(t, "user-cc-2")
+	require.NoError(t, userclaim.UpsertClaim("user-cc-2", "tier", "gold"))
+
+	testUser := user.User{ID: "user-cc-2", Username: "testuser"}
+
+	idToken, err := GenerateIDToken(testUser, "session-1", "", "openid profile", "my-client", time.Now(), "fake-access-token")
+	require.NoError(t, err)
+
+	claims := parseIDTokenClaims(t, idToken)
+	assert.Nil(t, claims["tier"], "custom claims must be absent without the custom_claims scope")
+}
+
+func TestGenerateTokens_CustomClaims(t *testing.T) {
+	testutils.WithTestDB(t)
+	config.Values.AuthAccessTokenExpiration = 15 * time.Minute
+	config.Bootstrap.AuthRefreshTokenSecret = "test-secret"
+	config.Bootstrap.AppAuthIssuer = "http://localhost/oauth2"
+
+	testutils.InsertTestUser(t, "user-cc-3")
+	require.NoError(t, userclaim.UpsertClaim("user-cc-3", "tier", "gold"))
+
+	testUser := user.User{ID: "user-cc-3", Username: "testuser", Email: "test@example.com"}
+
+	tokens, err := GenerateTokens(testUser, "", "openid custom_claims", config.Get())
+	require.NoError(t, err)
+
+	claims := parseAccessTokenClaims(t, tokens.AccessToken)
+	assert.Equal(t, "gold", claims["tier"])
+}
+
+func TestGenerateTokens_CustomClaimsCannotOverrideStandardClaim(t *testing.T) {
+	testutils.WithTestDB(t)
+	config.Values.AuthAccessTokenExpiration = 15 * time.Minute
+	config.Bootstrap.AuthRefreshTokenSecret = "test-secret"
+	config.Bootstrap.AppAuthIssuer = "http://localhost/oauth2"
+
+	testutils.InsertTestUser(t, "user-cc-4")
+	require.NoError(t, userclaim.UpsertClaim("user-cc-4", "tier", "gold"))
+	// Bypass write-time validation by inserting directly, simulating a legacy/tampered row.
+	_, err := db.GetDB().Exec(`INSERT INTO user_claims (user_id, claim_name, claim_value) VALUES (?, ?, ?)`, "user-cc-4", "sub", "evil")
+	require.NoError(t, err)
+
+	testUser := user.User{ID: "user-cc-4", Username: "testuser"}
+
+	tokens, err := GenerateTokens(testUser, "", "openid custom_claims", config.Get())
+	require.NoError(t, err)
+
+	claims := parseAccessTokenClaims(t, tokens.AccessToken)
+	assert.Equal(t, "user-cc-4", claims["sub"], "custom claim must never override the real sub")
+	assert.Equal(t, "gold", claims["tier"])
+}
+
+func parseAccessTokenClaims(t *testing.T, token string) jwt.MapClaims {
+	t.Helper()
+	parsed, err := jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
+		return key.GetPublicKey(), nil
+	})
+	require.NoError(t, err)
+	return parsed.Claims.(jwt.MapClaims)
+}

--- a/pkg/userclaim/create.go
+++ b/pkg/userclaim/create.go
@@ -1,0 +1,25 @@
+package userclaim
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/eugenioenko/autentico/pkg/db"
+)
+
+// UpsertClaim inserts a custom claim for a user, or updates its value if the
+// (user_id, claim_name) pair already exists.
+func UpsertClaim(userID, name, value string) error {
+	query := `INSERT INTO user_claims (user_id, claim_name, claim_value) VALUES (?, ?, ?)
+		ON CONFLICT(user_id, claim_name) DO UPDATE SET
+			claim_value = excluded.claim_value,
+			updated_at = CURRENT_TIMESTAMP`
+	_, err := db.GetDB().Exec(query, userID, name, value)
+	if err != nil {
+		if strings.Contains(err.Error(), "FOREIGN KEY constraint failed") {
+			return fmt.Errorf("user not found")
+		}
+		return fmt.Errorf("failed to save claim: %w", err)
+	}
+	return nil
+}

--- a/pkg/userclaim/create_test.go
+++ b/pkg/userclaim/create_test.go
@@ -1,0 +1,51 @@
+package userclaim
+
+import (
+	"testing"
+
+	testutils "github.com/eugenioenko/autentico/tests/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpsertClaim_InsertThenUpdate(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+
+	require.NoError(t, UpsertClaim("user1", "tier", "silver"))
+
+	claims, err := ClaimsByUserID("user1")
+	require.NoError(t, err)
+	require.Len(t, claims, 1)
+	assert.Equal(t, "tier", claims[0].Name)
+	assert.Equal(t, "silver", claims[0].Value)
+	firstUpdatedAt := claims[0].UpdatedAt
+
+	require.NoError(t, UpsertClaim("user1", "tier", "gold"))
+
+	claims, err = ClaimsByUserID("user1")
+	require.NoError(t, err)
+	require.Len(t, claims, 1, "upsert must not create a second row")
+	assert.Equal(t, "gold", claims[0].Value)
+	assert.False(t, claims[0].UpdatedAt.Before(firstUpdatedAt))
+}
+
+func TestUpsertClaim_UnknownUser(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	err := UpsertClaim("nonexistent", "tier", "gold")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "user not found")
+}
+
+func TestUpsertClaim_MultipleClaimsPerUser(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+
+	require.NoError(t, UpsertClaim("user1", "tier", "gold"))
+	require.NoError(t, UpsertClaim("user1", "region", "eu"))
+
+	claims, err := ClaimsByUserID("user1")
+	require.NoError(t, err)
+	assert.Len(t, claims, 2)
+}

--- a/pkg/userclaim/delete.go
+++ b/pkg/userclaim/delete.go
@@ -1,0 +1,25 @@
+package userclaim
+
+import (
+	"fmt"
+
+	"github.com/eugenioenko/autentico/pkg/db"
+)
+
+// DeleteClaim removes a single custom claim from a user.
+func DeleteClaim(userID, name string) error {
+	result, err := db.GetDB().Exec(
+		`DELETE FROM user_claims WHERE user_id = ? AND claim_name = ?`, userID, name,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to delete claim: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check delete result: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("claim not found")
+	}
+	return nil
+}

--- a/pkg/userclaim/delete_test.go
+++ b/pkg/userclaim/delete_test.go
@@ -1,0 +1,44 @@
+package userclaim
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/autentico/pkg/db"
+	testutils "github.com/eugenioenko/autentico/tests/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteClaim_Success(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+	require.NoError(t, UpsertClaim("user1", "tier", "gold"))
+
+	require.NoError(t, DeleteClaim("user1", "tier"))
+
+	claims, err := ClaimsByUserID("user1")
+	require.NoError(t, err)
+	assert.Empty(t, claims)
+}
+
+func TestDeleteClaim_NotFound(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+
+	err := DeleteClaim("user1", "tier")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "claim not found")
+}
+
+func TestDeleteClaim_CascadesOnUserDelete(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+	require.NoError(t, UpsertClaim("user1", "tier", "gold"))
+
+	_, err := db.GetDB().Exec(`DELETE FROM users WHERE id = ?`, "user1")
+	require.NoError(t, err)
+
+	m, err := ClaimMapByUserID("user1")
+	require.NoError(t, err)
+	assert.Empty(t, m)
+}

--- a/pkg/userclaim/handler.go
+++ b/pkg/userclaim/handler.go
@@ -1,0 +1,105 @@
+package userclaim
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/eugenioenko/autentico/pkg/utils"
+)
+
+// HandleListUserClaims godoc
+// @Summary List custom claims for a user
+// @Tags admin-user-claims
+// @Produce json
+// @Param id path string true "User ID"
+// @Security AdminAuth
+// @Success 200 {array} UserClaimResponse
+// @Failure 500 {object} model.ApiError
+// @Router /admin/api/users/{id}/claims [get]
+func HandleListUserClaims(w http.ResponseWriter, r *http.Request) {
+	userID := r.PathValue("id")
+	if userID == "" {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Missing user id")
+		return
+	}
+	claims, err := ClaimsByUserID(userID)
+	if err != nil {
+		slog.Error("userclaim: failed to list claims", "error", err, "user_id", userID)
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", "Failed to list claims")
+		return
+	}
+	utils.SuccessResponse(w, claims, http.StatusOK)
+}
+
+// HandleUpsertUserClaim godoc
+// @Summary Create or update a custom claim for a user
+// @Tags admin-user-claims
+// @Accept json
+// @Produce json
+// @Param id path string true "User ID"
+// @Param claim body UserClaimRequest true "Custom claim payload"
+// @Security AdminAuth
+// @Success 201 {object} map[string]string
+// @Failure 400 {object} model.ApiError
+// @Failure 404 {object} model.ApiError
+// @Router /admin/api/users/{id}/claims [post]
+func HandleUpsertUserClaim(w http.ResponseWriter, r *http.Request) {
+	userID := r.PathValue("id")
+	if userID == "" {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Missing user id")
+		return
+	}
+	var req UserClaimRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Invalid request payload")
+		return
+	}
+	req.Name = strings.TrimSpace(req.Name)
+	// OIDC Core §5.1.2 / RFC 9068 §2.2.2: custom claims must not collide with
+	// standard/structural claims — reserved names are rejected here at write time.
+	if err := ValidateUserClaimRequest(req); err != nil {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if err := UpsertClaim(userID, req.Name, req.Value); err != nil {
+		if strings.Contains(err.Error(), "user not found") {
+			utils.WriteErrorResponse(w, http.StatusNotFound, "not_found", "User not found")
+			return
+		}
+		slog.Error("userclaim: failed to save claim", "error", err, "user_id", userID, "claim", req.Name)
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", "Failed to save claim")
+		return
+	}
+	utils.SuccessResponse(w, map[string]string{"message": "claim saved"}, http.StatusCreated)
+}
+
+// HandleDeleteUserClaim godoc
+// @Summary Delete a custom claim from a user
+// @Tags admin-user-claims
+// @Produce json
+// @Param id path string true "User ID"
+// @Param name path string true "Claim name"
+// @Security AdminAuth
+// @Success 200 {object} map[string]string
+// @Failure 404 {object} model.ApiError
+// @Router /admin/api/users/{id}/claims/{name} [delete]
+func HandleDeleteUserClaim(w http.ResponseWriter, r *http.Request) {
+	userID := r.PathValue("id")
+	name := strings.TrimSpace(r.PathValue("name"))
+	if userID == "" || name == "" {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Missing user id or claim name")
+		return
+	}
+	if err := DeleteClaim(userID, name); err != nil {
+		if strings.Contains(err.Error(), "claim not found") {
+			utils.WriteErrorResponse(w, http.StatusNotFound, "not_found", "Claim not found")
+			return
+		}
+		slog.Error("userclaim: failed to delete claim", "error", err, "user_id", userID, "claim", name)
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", "Failed to delete claim")
+		return
+	}
+	utils.SuccessResponse(w, map[string]string{"message": "claim removed"}, http.StatusOK)
+}

--- a/pkg/userclaim/handler_test.go
+++ b/pkg/userclaim/handler_test.go
@@ -1,0 +1,151 @@
+package userclaim
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eugenioenko/autentico/pkg/model"
+	testutils "github.com/eugenioenko/autentico/tests/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func upsertReq(t *testing.T, userID string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/users/"+userID+"/claims", bytes.NewBuffer(raw))
+	req.SetPathValue("id", userID)
+	rr := httptest.NewRecorder()
+	HandleUpsertUserClaim(rr, req)
+	return rr
+}
+
+func TestHandleUpsertUserClaim_Success(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+
+	rr := upsertReq(t, "user1", UserClaimRequest{Name: "tier", Value: "gold"})
+	assert.Equal(t, http.StatusCreated, rr.Code)
+
+	claims, err := ClaimsByUserID("user1")
+	require.NoError(t, err)
+	require.Len(t, claims, 1)
+	assert.Equal(t, "gold", claims[0].Value)
+}
+
+func TestHandleUpsertUserClaim_UpdatesExisting(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+
+	assert.Equal(t, http.StatusCreated, upsertReq(t, "user1", UserClaimRequest{Name: "tier", Value: "silver"}).Code)
+	assert.Equal(t, http.StatusCreated, upsertReq(t, "user1", UserClaimRequest{Name: "tier", Value: "gold"}).Code)
+
+	claims, _ := ClaimsByUserID("user1")
+	require.Len(t, claims, 1)
+	assert.Equal(t, "gold", claims[0].Value)
+}
+
+func TestHandleUpsertUserClaim_ReservedName(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+
+	rr := upsertReq(t, "user1", UserClaimRequest{Name: "email", Value: "x"})
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	var resp model.AuthErrorResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Contains(t, resp.ErrorDescription, "reserved")
+}
+
+func TestHandleUpsertUserClaim_InvalidBody(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/users/user1/claims", bytes.NewBufferString("not-json"))
+	req.SetPathValue("id", "user1")
+	rr := httptest.NewRecorder()
+	HandleUpsertUserClaim(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestHandleUpsertUserClaim_UnknownUser(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	rr := upsertReq(t, "ghost", UserClaimRequest{Name: "tier", Value: "gold"})
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestHandleListUserClaims_Success(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+	require.NoError(t, UpsertClaim("user1", "tier", "gold"))
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/api/users/user1/claims", nil)
+	req.SetPathValue("id", "user1")
+	rr := httptest.NewRecorder()
+	HandleListUserClaims(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp model.ApiResponse[[]UserClaimResponse]
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Len(t, resp.Data, 1)
+	assert.Equal(t, "tier", resp.Data[0].Name)
+}
+
+func TestHandleListUserClaims_EmptyIsArray(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/api/users/user1/claims", nil)
+	req.SetPathValue("id", "user1")
+	rr := httptest.NewRecorder()
+	HandleListUserClaims(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"data":[]`)
+}
+
+func TestHandleDeleteUserClaim_Success(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+	require.NoError(t, UpsertClaim("user1", "tier", "gold"))
+
+	req := httptest.NewRequest(http.MethodDelete, "/admin/api/users/user1/claims/tier", nil)
+	req.SetPathValue("id", "user1")
+	req.SetPathValue("name", "tier")
+	rr := httptest.NewRecorder()
+	HandleDeleteUserClaim(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	claims, _ := ClaimsByUserID("user1")
+	assert.Empty(t, claims)
+}
+
+func TestHandleDeleteUserClaim_NotFound(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+
+	req := httptest.NewRequest(http.MethodDelete, "/admin/api/users/user1/claims/tier", nil)
+	req.SetPathValue("id", "user1")
+	req.SetPathValue("name", "tier")
+	rr := httptest.NewRecorder()
+	HandleDeleteUserClaim(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestHandleDeleteUserClaim_NamespacedName(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+	require.NoError(t, UpsertClaim("user1", "https://app.example.com/tier", "gold"))
+
+	req := httptest.NewRequest(http.MethodDelete, "/admin/api/users/user1/claims/https://app.example.com/tier", nil)
+	req.SetPathValue("id", "user1")
+	req.SetPathValue("name", "https://app.example.com/tier")
+	rr := httptest.NewRecorder()
+	HandleDeleteUserClaim(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}

--- a/pkg/userclaim/model.go
+++ b/pkg/userclaim/model.go
@@ -1,0 +1,81 @@
+package userclaim
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
+// claimNameRegex allows bare names (tier, employee_id) and collision-resistant
+// namespaced names (https://app.example.com/tier). OIDC Core §5.1.2 RECOMMENDS
+// collision-resistant or private claim names for non-standard claims.
+var claimNameRegex = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_.:/-]*$`)
+
+const maxClaimValueLength = 4096
+
+// reservedClaimNames are claim names a custom claim must never define: structural
+// JWT/OIDC claims whose meaning is fixed, plus every claim Autentico already emits
+// into its access tokens, ID tokens, or UserInfo responses. OIDC Core §5.1.2 /
+// RFC 9068 §2.2.2: additional claims must not collide with standard claims.
+var reservedClaimNames = map[string]bool{
+	// Structural JWT / OIDC claims
+	"iss": true, "sub": true, "aud": true, "exp": true, "iat": true, "nbf": true,
+	"jti": true, "auth_time": true, "nonce": true, "at_hash": true, "c_hash": true,
+	"azp": true, "sid": true, "acr": true, "amr": true, "typ": true, "scope": true,
+	"client_id": true, "token_type": true, "active": true,
+	// Claims Autentico already emits (see pkg/token/generate.go, pkg/userinfo/handler.go)
+	"name": true, "preferred_username": true, "given_name": true, "family_name": true,
+	"middle_name": true, "nickname": true, "profile": true, "picture": true,
+	"website": true, "gender": true, "birthdate": true, "locale": true, "zoneinfo": true,
+	"updated_at": true, "email": true, "email_verified": true, "phone_number": true,
+	"phone_number_verified": true, "address": true, "groups": true, "role": true,
+}
+
+// UserClaim is a single custom claim attached to a user.
+type UserClaim struct {
+	UserID    string
+	Name      string
+	Value     string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// UserClaimResponse is the admin API representation of a custom claim.
+type UserClaimResponse struct {
+	Name      string    `json:"name"`
+	Value     string    `json:"value"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// UserClaimRequest is the admin API payload for creating or updating a claim.
+type UserClaimRequest struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// IsReservedClaimName reports whether name collides with a standard/structural
+// claim and therefore may not be used as a custom claim name.
+func IsReservedClaimName(name string) bool {
+	return reservedClaimNames[strings.ToLower(strings.TrimSpace(name))]
+}
+
+// ValidateUserClaimRequest validates a custom claim create/update payload.
+func ValidateUserClaimRequest(input UserClaimRequest) error {
+	if err := validation.Validate(input.Name,
+		validation.Required,
+		validation.Length(1, 128),
+		validation.Match(claimNameRegex),
+	); err != nil {
+		return fmt.Errorf("name is invalid: %w", err)
+	}
+	if IsReservedClaimName(input.Name) {
+		return fmt.Errorf("name is invalid: %q is a reserved claim name", input.Name)
+	}
+	if len(input.Value) > maxClaimValueLength {
+		return fmt.Errorf("value is invalid: must be at most %d characters", maxClaimValueLength)
+	}
+	return nil
+}

--- a/pkg/userclaim/model.go
+++ b/pkg/userclaim/model.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	validation "github.com/go-ozzo/ozzo-validation"
 )
@@ -80,7 +81,7 @@ func ValidateUserClaimRequest(input UserClaimRequest) error {
 	if IsReservedClaimName(input.Name) {
 		return fmt.Errorf("name is invalid: %q is a reserved claim name", input.Name)
 	}
-	if len(input.Value) > maxClaimValueLength {
+	if utf8.RuneCountInString(input.Value) > maxClaimValueLength {
 		return fmt.Errorf("value is invalid: must be at most %d characters", maxClaimValueLength)
 	}
 	return nil

--- a/pkg/userclaim/model.go
+++ b/pkg/userclaim/model.go
@@ -20,6 +20,12 @@ const maxClaimValueLength = 4096
 // JWT/OIDC claims whose meaning is fixed, plus every claim Autentico already emits
 // into its access tokens, ID tokens, or UserInfo responses. OIDC Core §5.1.2 /
 // RFC 9068 §2.2.2: additional claims must not collide with standard claims.
+//
+// Known gap: this does not block registered claims that Autentico happens not to
+// emit today (e.g. cnf, roles, entitlements, act). The token builder's
+// "never override an existing claim" guard does not cover these because Autentico
+// never sets them, so a relying party could treat an admin-set value as genuine.
+// Tracked in issue #399.
 var reservedClaimNames = map[string]bool{
 	// Structural JWT / OIDC claims
 	"iss": true, "sub": true, "aud": true, "exp": true, "iat": true, "nbf": true,

--- a/pkg/userclaim/model.go
+++ b/pkg/userclaim/model.go
@@ -17,28 +17,55 @@ var claimNameRegex = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_.:/-]*$`)
 
 const maxClaimValueLength = 4096
 
-// reservedClaimNames are claim names a custom claim must never define: structural
-// JWT/OIDC claims whose meaning is fixed, plus every claim Autentico already emits
-// into its access tokens, ID tokens, or UserInfo responses. OIDC Core §5.1.2 /
-// RFC 9068 §2.2.2: additional claims must not collide with standard claims.
+// reservedClaimNames are claim names a custom claim must never define. OIDC Core
+// §5.1.2 / RFC 9068 §2.2.2: additional claims must not collide with standard
+// claims. This is the IANA "JSON Web Token Claims" registry (identity, security,
+// and authorization claims) — a relying party or resource server may trust any of
+// these, so an admin must not be able to forge one. The token builder's "never
+// override an existing claim" guard is not enough on its own: Autentico does not
+// emit most of these, so nothing would stop the forged value from being signed.
 //
-// Known gap: this does not block registered claims that Autentico happens not to
-// emit today (e.g. cnf, roles, entitlements, act). The token builder's
-// "never override an existing claim" guard does not cover these because Autentico
-// never sets them, so a relying party could treat an admin-set value as genuine.
-// Tracked in issue #399.
+// Transport-specific registry entries (SIP RFC 8055/8443, CDNI RFC 9246) are
+// omitted as irrelevant to this IdP. Keep this in sync with the registry:
+// https://www.iana.org/assignments/jwt/jwt.xhtml
 var reservedClaimNames = map[string]bool{
-	// Structural JWT / OIDC claims
-	"iss": true, "sub": true, "aud": true, "exp": true, "iat": true, "nbf": true,
-	"jti": true, "auth_time": true, "nonce": true, "at_hash": true, "c_hash": true,
-	"azp": true, "sid": true, "acr": true, "amr": true, "typ": true, "scope": true,
-	"client_id": true, "token_type": true, "active": true,
-	// Claims Autentico already emits (see pkg/token/generate.go, pkg/userinfo/handler.go)
-	"name": true, "preferred_username": true, "given_name": true, "family_name": true,
-	"middle_name": true, "nickname": true, "profile": true, "picture": true,
-	"website": true, "gender": true, "birthdate": true, "locale": true, "zoneinfo": true,
-	"updated_at": true, "email": true, "email_verified": true, "phone_number": true,
-	"phone_number_verified": true, "address": true, "groups": true, "role": true,
+	// RFC 7519 — registered claim names
+	"iss": true, "sub": true, "aud": true, "exp": true, "nbf": true, "iat": true, "jti": true,
+	// OIDC Core 1.0 — ID token / authentication claims
+	"auth_time": true, "nonce": true, "acr": true, "amr": true, "azp": true,
+	"at_hash": true, "c_hash": true, "sub_jwk": true,
+	// OIDC Core 1.0 §5.1 — standard profile / email / phone / address claims
+	"name": true, "given_name": true, "family_name": true, "middle_name": true,
+	"nickname": true, "preferred_username": true, "profile": true, "picture": true,
+	"website": true, "email": true, "email_verified": true, "gender": true,
+	"birthdate": true, "zoneinfo": true, "locale": true, "phone_number": true,
+	"phone_number_verified": true, "address": true, "updated_at": true,
+	// OIDC aggregated / distributed claims
+	"_claim_names": true, "_claim_sources": true,
+	// OIDC session management / logout (RFC 8471, OIDC BCL/FCL)
+	"sid": true, "events": true,
+	// OIDC Identity Assurance 1.0
+	"verified_claims": true, "place_of_birth": true, "nationalities": true,
+	"birth_family_name": true, "birth_given_name": true, "birth_middle_name": true,
+	"salutation": true, "title": true, "msisdn": true, "also_known_as": true,
+	// RFC 9068 JWT access tokens / RFC 7643 SCIM — authorization attributes
+	"client_id": true, "scope": true, "roles": true, "groups": true, "entitlements": true,
+	// RFC 8693 — OAuth 2.0 Token Exchange
+	"act": true, "may_act": true,
+	// RFC 7800 / RFC 9449 — proof-of-possession & DPoP
+	"cnf": true, "htm": true, "htu": true, "ath": true, "jkt": true,
+	// RFC 9396 — Rich Authorization Requests
+	"authorization_details": true,
+	// RFC 8417 — Security Event Token / RFC 9493 — Subject Identifiers
+	"toe": true, "txn": true, "sub_id": true,
+	// SD-JWT — selective disclosure
+	"_sd": true, "_sd_alg": true, "sd_hash": true,
+	// W3C Verifiable Credentials
+	"vc": true, "vp": true,
+	// RFC 8485 — Vectors of Trust
+	"vot": true, "vtm": true,
+	// Claims Autentico itself emits that are not in the registry above
+	"typ": true, "token_type": true, "active": true, "role": true,
 }
 
 // UserClaim is a single custom claim attached to a user.
@@ -63,7 +90,7 @@ type UserClaimRequest struct {
 	Value string `json:"value"`
 }
 
-// IsReservedClaimName reports whether name collides with a standard/structural
+// IsReservedClaimName reports whether name collides with a registered JWT/OIDC
 // claim and therefore may not be used as a custom claim name.
 func IsReservedClaimName(name string) bool {
 	return reservedClaimNames[strings.ToLower(strings.TrimSpace(name))]

--- a/pkg/userclaim/model_test.go
+++ b/pkg/userclaim/model_test.go
@@ -52,6 +52,12 @@ func TestValidateUserClaimRequest_ValueTooLong(t *testing.T) {
 	assert.Contains(t, err.Error(), "value is invalid")
 }
 
+func TestValidateUserClaimRequest_ValueLengthCountsRunesNotBytes(t *testing.T) {
+	// maxClaimValueLength multi-byte runes = 3x that in bytes; must still pass.
+	err := ValidateUserClaimRequest(UserClaimRequest{Name: "tier", Value: strings.Repeat("é", maxClaimValueLength)})
+	assert.NoError(t, err)
+}
+
 func TestIsReservedClaimName(t *testing.T) {
 	assert.True(t, IsReservedClaimName("sub"))
 	assert.True(t, IsReservedClaimName("  GROUPS  "))

--- a/pkg/userclaim/model_test.go
+++ b/pkg/userclaim/model_test.go
@@ -51,6 +51,12 @@ func TestValidateUserClaimRequest_InvalidName(t *testing.T) {
 	}
 }
 
+func TestValidateUserClaimRequest_NameTooLong(t *testing.T) {
+	err := ValidateUserClaimRequest(UserClaimRequest{Name: "a" + strings.Repeat("b", 128), Value: "x"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "name is invalid")
+}
+
 func TestValidateUserClaimRequest_ValueTooLong(t *testing.T) {
 	err := ValidateUserClaimRequest(UserClaimRequest{Name: "tier", Value: strings.Repeat("a", maxClaimValueLength+1)})
 	assert.Error(t, err)

--- a/pkg/userclaim/model_test.go
+++ b/pkg/userclaim/model_test.go
@@ -29,7 +29,12 @@ func TestValidateUserClaimRequest_EmptyValueAllowed(t *testing.T) {
 }
 
 func TestValidateUserClaimRequest_ReservedNames(t *testing.T) {
-	for _, name := range []string{"sub", "iss", "aud", "exp", "email", "email_verified", "groups", "role", "scope", "SUB", "Email"} {
+	for _, name := range []string{
+		"sub", "iss", "aud", "exp", "email", "email_verified", "groups", "role", "scope", "SUB", "Email",
+		// registered claims Autentico does not emit but a relying party may trust
+		"cnf", "roles", "entitlements", "act", "may_act", "authorization_details",
+		"verified_claims", "vc", "_claim_sources", "sub_jwk", "ATH",
+	} {
 		t.Run(name, func(t *testing.T) {
 			err := ValidateUserClaimRequest(UserClaimRequest{Name: name, Value: "x"})
 			assert.Error(t, err)

--- a/pkg/userclaim/model_test.go
+++ b/pkg/userclaim/model_test.go
@@ -1,0 +1,59 @@
+package userclaim
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateUserClaimRequest_Valid(t *testing.T) {
+	cases := []string{
+		"tier",
+		"employee_id",
+		"department.name",
+		"https://app.example.com/tier",
+		"urn:example:claim",
+		"_private",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateUserClaimRequest(UserClaimRequest{Name: name, Value: "x"})
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateUserClaimRequest_EmptyValueAllowed(t *testing.T) {
+	assert.NoError(t, ValidateUserClaimRequest(UserClaimRequest{Name: "tier", Value: ""}))
+}
+
+func TestValidateUserClaimRequest_ReservedNames(t *testing.T) {
+	for _, name := range []string{"sub", "iss", "aud", "exp", "email", "email_verified", "groups", "role", "scope", "SUB", "Email"} {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateUserClaimRequest(UserClaimRequest{Name: name, Value: "x"})
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "reserved")
+		})
+	}
+}
+
+func TestValidateUserClaimRequest_InvalidName(t *testing.T) {
+	for _, name := range []string{"", "1tier", "has space", "bad$char", "trailing\n"} {
+		t.Run(name, func(t *testing.T) {
+			assert.Error(t, ValidateUserClaimRequest(UserClaimRequest{Name: name, Value: "x"}))
+		})
+	}
+}
+
+func TestValidateUserClaimRequest_ValueTooLong(t *testing.T) {
+	err := ValidateUserClaimRequest(UserClaimRequest{Name: "tier", Value: strings.Repeat("a", maxClaimValueLength+1)})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "value is invalid")
+}
+
+func TestIsReservedClaimName(t *testing.T) {
+	assert.True(t, IsReservedClaimName("sub"))
+	assert.True(t, IsReservedClaimName("  GROUPS  "))
+	assert.False(t, IsReservedClaimName("tier"))
+}

--- a/pkg/userclaim/read.go
+++ b/pkg/userclaim/read.go
@@ -1,0 +1,86 @@
+package userclaim
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/eugenioenko/autentico/pkg/db"
+)
+
+// ClaimsByUserID returns all custom claims for a user, ordered by name.
+// Used by the admin API.
+func ClaimsByUserID(userID string) ([]UserClaimResponse, error) {
+	query := `SELECT claim_name, claim_value, updated_at FROM user_claims
+		WHERE user_id = ? ORDER BY claim_name`
+	rows, err := db.GetDB().Query(query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get claims for user: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	claims := []UserClaimResponse{}
+	for rows.Next() {
+		var c UserClaimResponse
+		if err := rows.Scan(&c.Name, &c.Value, &c.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan claim: %w", err)
+		}
+		claims = append(claims, c)
+	}
+	return claims, rows.Err()
+}
+
+// ClaimMapByUserID returns a user's custom claims as a name -> value map.
+// Used for embedding claims in tokens and the UserInfo response, mirroring
+// group.GroupNamesByUserID.
+func ClaimMapByUserID(userID string) (map[string]string, error) {
+	query := `SELECT claim_name, claim_value FROM user_claims WHERE user_id = ?`
+	rows, err := db.GetDB().Query(query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get claim map for user: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make(map[string]string)
+	for rows.Next() {
+		var name, value string
+		if err := rows.Scan(&name, &value); err != nil {
+			return nil, fmt.Errorf("failed to scan claim: %w", err)
+		}
+		result[name] = value
+	}
+	return result, rows.Err()
+}
+
+// ClaimMapByUserIDs returns custom claims for several users at once, keyed by
+// user ID. Used by list endpoints that enrich many users in one query.
+func ClaimMapByUserIDs(userIDs []string) (map[string]map[string]string, error) {
+	if len(userIDs) == 0 {
+		return map[string]map[string]string{}, nil
+	}
+	placeholders := make([]string, len(userIDs))
+	args := make([]any, len(userIDs))
+	for i, id := range userIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	query := `SELECT user_id, claim_name, claim_value FROM user_claims
+		WHERE user_id IN (` + strings.Join(placeholders, ",") + `)`
+	rows, err := db.GetDB().Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get claim maps: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make(map[string]map[string]string)
+	for rows.Next() {
+		var userID, name, value string
+		if err := rows.Scan(&userID, &name, &value); err != nil {
+			return nil, fmt.Errorf("failed to scan claim: %w", err)
+		}
+		if result[userID] == nil {
+			result[userID] = make(map[string]string)
+		}
+		result[userID][name] = value
+	}
+	return result, rows.Err()
+}

--- a/pkg/userclaim/read_test.go
+++ b/pkg/userclaim/read_test.go
@@ -1,0 +1,65 @@
+package userclaim
+
+import (
+	"testing"
+
+	testutils "github.com/eugenioenko/autentico/tests/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaimMapByUserID(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+	require.NoError(t, UpsertClaim("user1", "tier", "gold"))
+	require.NoError(t, UpsertClaim("user1", "region", "eu"))
+
+	m, err := ClaimMapByUserID("user1")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"tier": "gold", "region": "eu"}, m)
+}
+
+func TestClaimMapByUserID_Empty(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+
+	m, err := ClaimMapByUserID("user1")
+	require.NoError(t, err)
+	assert.Empty(t, m)
+}
+
+func TestClaimMapByUserIDs_Batch(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+	testutils.InsertTestUser(t, "user2")
+	require.NoError(t, UpsertClaim("user1", "tier", "gold"))
+	require.NoError(t, UpsertClaim("user2", "tier", "silver"))
+	require.NoError(t, UpsertClaim("user2", "region", "us"))
+
+	m, err := ClaimMapByUserIDs([]string{"user1", "user2"})
+	require.NoError(t, err)
+	assert.Equal(t, "gold", m["user1"]["tier"])
+	assert.Equal(t, "silver", m["user2"]["tier"])
+	assert.Equal(t, "us", m["user2"]["region"])
+}
+
+func TestClaimMapByUserIDs_EmptyInput(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	m, err := ClaimMapByUserIDs(nil)
+	require.NoError(t, err)
+	assert.Empty(t, m)
+}
+
+func TestClaimsByUserID_OrderedByName(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "user1")
+	require.NoError(t, UpsertClaim("user1", "zeta", "1"))
+	require.NoError(t, UpsertClaim("user1", "alpha", "2"))
+
+	claims, err := ClaimsByUserID("user1")
+	require.NoError(t, err)
+	require.Len(t, claims, 2)
+	assert.Equal(t, "alpha", claims[0].Name)
+	assert.Equal(t, "zeta", claims[1].Name)
+}

--- a/pkg/userinfo/handler.go
+++ b/pkg/userinfo/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/jwtutil"
 	"github.com/eugenioenko/autentico/pkg/session"
 	"github.com/eugenioenko/autentico/pkg/user"
+	"github.com/eugenioenko/autentico/pkg/userclaim"
 	"github.com/eugenioenko/autentico/pkg/utils"
 )
 
@@ -156,6 +157,18 @@ func HandleUserInfo(w http.ResponseWriter, r *http.Request) {
 		groupNames, err := group.GroupNamesByUserID(*tok.UserID)
 		if err == nil && len(groupNames) > 0 {
 			response["groups"] = groupNames
+		}
+	}
+
+	// OIDC Core §5.3.2: additional (non-standard) claims MAY be returned from UserInfo.
+	// Gated behind the "custom_claims" scope; never overrides a standard claim set above.
+	if containsScope(scope, "custom_claims") {
+		if custom, err := userclaim.ClaimMapByUserID(*tok.UserID); err == nil {
+			for name, value := range custom {
+				if _, taken := response[name]; !taken {
+					response[name] = value
+				}
+			}
 		}
 	}
 

--- a/pkg/userinfo/handler.go
+++ b/pkg/userinfo/handler.go
@@ -163,11 +163,14 @@ func HandleUserInfo(w http.ResponseWriter, r *http.Request) {
 	// OIDC Core §5.3.2: additional (non-standard) claims MAY be returned from UserInfo.
 	// Gated behind the "custom_claims" scope; never overrides a standard claim set above.
 	if containsScope(scope, "custom_claims") {
-		if custom, err := userclaim.ClaimMapByUserID(*tok.UserID); err == nil {
-			for name, value := range custom {
-				if _, taken := response[name]; !taken {
-					response[name] = value
-				}
+		custom, err := userclaim.ClaimMapByUserID(*tok.UserID)
+		if err != nil {
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, "server_error", "Unable to fetch user information")
+			return
+		}
+		for name, value := range custom {
+			if _, taken := response[name]; !taken {
+				response[name] = value
 			}
 		}
 	}

--- a/pkg/userinfo/handler_customclaims_test.go
+++ b/pkg/userinfo/handler_customclaims_test.go
@@ -59,3 +59,30 @@ func TestHandleUserInfo_CustomClaims_AbsentWithoutScope(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	assert.NotContains(t, body, "tier")
 }
+
+func TestHandleUserInfo_CustomClaims_CannotOverrideStandardClaim(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	userID := xid.New().String()
+	_, err := db.GetDB().Exec(`INSERT INTO users (id, username, email, password) VALUES (?, 'ccuser3', 'cc3@example.com', 'pass')`, userID)
+	require.NoError(t, err)
+	// Direct insert bypasses write-time reserved-name rejection.
+	_, err = db.GetDB().Exec(`INSERT INTO user_claims (user_id, claim_name, claim_value) VALUES (?, 'sub', 'evil')`, userID)
+	require.NoError(t, err)
+	_, err = db.GetDB().Exec(`INSERT INTO user_claims (user_id, claim_name, claim_value) VALUES (?, 'email', 'attacker@example.com')`, userID)
+	require.NoError(t, err)
+
+	token, err := generateTestTokensWithScope(userID, "openid email custom_claims")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	HandleUserInfo(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, userID, body["sub"], "custom claim must never override the real sub")
+	assert.Equal(t, "cc3@example.com", body["email"], "custom claim must never override the real email")
+}

--- a/pkg/userinfo/handler_customclaims_test.go
+++ b/pkg/userinfo/handler_customclaims_test.go
@@ -1,0 +1,61 @@
+package userinfo
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eugenioenko/autentico/pkg/db"
+	"github.com/eugenioenko/autentico/pkg/userclaim"
+	testutils "github.com/eugenioenko/autentico/tests/utils"
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleUserInfo_CustomClaims_Present(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	userID := xid.New().String()
+	_, err := db.GetDB().Exec(`INSERT INTO users (id, username, email, password) VALUES (?, 'ccuser', 'cc@example.com', 'pass')`, userID)
+	require.NoError(t, err)
+	require.NoError(t, userclaim.UpsertClaim(userID, "tier", "gold"))
+	require.NoError(t, userclaim.UpsertClaim(userID, "region", "eu"))
+
+	token, err := generateTestTokensWithScope(userID, "openid custom_claims")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	HandleUserInfo(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, "gold", body["tier"])
+	assert.Equal(t, "eu", body["region"])
+}
+
+func TestHandleUserInfo_CustomClaims_AbsentWithoutScope(t *testing.T) {
+	testutils.WithTestDB(t)
+
+	userID := xid.New().String()
+	_, err := db.GetDB().Exec(`INSERT INTO users (id, username, email, password) VALUES (?, 'ccuser2', 'cc2@example.com', 'pass')`, userID)
+	require.NoError(t, err)
+	require.NoError(t, userclaim.UpsertClaim(userID, "tier", "gold"))
+
+	token, err := generateTestTokensWithScope(userID, "openid profile")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	HandleUserInfo(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.NotContains(t, body, "tier")
+}

--- a/pkg/wellknown/handler.go
+++ b/pkg/wellknown/handler.go
@@ -47,7 +47,7 @@ func HandleWellKnownConfig(w http.ResponseWriter, r *http.Request) {
 		RegistrationEndpoint: fmt.Sprintf("%s/register", issuer),   // RFC 8414 §2 / RFC 7591
 		EndSessionEndpoint:   fmt.Sprintf("%s/logout", issuer),     // RP-Initiated Logout 1.0 §2.1
 		ScopesSupported: []string{                                  // RFC 8414 §2: RECOMMENDED
-			"openid", "profile", "email", "address", "phone", "offline_access", "groups",
+			"openid", "profile", "email", "address", "phone", "offline_access", "groups", "custom_claims",
 		},
 		TokenEndpointAuthMethodsSupported: []string{                // RFC 8414 §2: OPTIONAL
 			"client_secret_basic", "client_secret_post",

--- a/pkg/wellknown/handler_test.go
+++ b/pkg/wellknown/handler_test.go
@@ -233,6 +233,19 @@ func TestHandleWellKnownConfig_GroupsScope(t *testing.T) {
 	assert.Contains(t, response.ScopesSupported, "groups", "groups must be in scopes_supported")
 }
 
+func TestHandleWellKnownConfig_CustomClaimsScope(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	rr := httptest.NewRecorder()
+
+	HandleWellKnownConfig(rr, req)
+
+	var response model.WellKnownConfigResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	assert.Contains(t, response.ScopesSupported, "custom_claims", "custom_claims must be in scopes_supported")
+}
+
 func TestHandleWellKnownConfig_GroupsClaim(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
 	rr := httptest.NewRecorder()

--- a/rfc/rfc.md
+++ b/rfc/rfc.md
@@ -369,7 +369,7 @@ At the end of each phase, verify that every endpoint or capability introduced by
 | §5.4 | Claims in access token must respect scope | `pkg/token/generate.go` — ✅ Fixed (PR #108) |
 | §5.4 | MAY include email claims in ID token when `email` scope requested | `pkg/token/generate.go` `GenerateIDToken` — ✅ Added (issue #220) |
 | §5.4 | MAY include `given_name`, `family_name` in ID token when `profile` scope requested | `pkg/token/generate.go` `GenerateIDToken` — ✅ Added |
-| §5.1.2 | Additional (non-standard) claims MAY be used alongside standard claims; collision-resistant / private names RECOMMENDED | `pkg/userclaim` — custom claims gated behind `custom_claims` scope; reserved standard/structural names rejected on write; the name pattern permits namespaced URIs but bare names are allowed. ✅ Added (issue #388) |
+| §5.1.2 | Additional (non-standard) claims MAY be used alongside standard claims; collision-resistant / private names RECOMMENDED | `pkg/userclaim` — custom claims gated behind `custom_claims` scope; every name in the IANA JWT Claims registry (identity/security/authz) is rejected on write; the name pattern also permits namespaced URIs. ✅ Added (issue #388) |
 | RFC 9068 §2.2.2 | AS MAY return arbitrary attributes in access tokens for private-subsystem / scope-gated use | `pkg/token/generate.go` `GenerateTokens` — custom claims emitted only when `custom_claims` scope granted; never override a claim already set. ✅ Added (issue #388) |
 | §5.1 | Claims with empty values are omitted, not returned as null | `pkg/token/generate.go` `GenerateIDToken` — ✅ Enforced for `given_name`, `family_name` |
 | RFC 9068 §2.2 | Access tokens SHOULD NOT carry personal data not needed for authorization | `pkg/token/generate.go` `GenerateTokens` — ✅ `given_name`/`family_name` removed from access token; available via ID token and UserInfo |
@@ -389,7 +389,7 @@ At the end of each phase, verify that every endpoint or capability introduced by
 | MAY | §5.4 | Email claims returned in ID token when `email` scope requested | ✅ Added (issue #220) — mirrors Google/Auth0/Okta behavior |
 | MAY | §5.4 | `given_name`, `family_name` returned in ID token when `profile` scope requested | ✅ Added — mirrors Google/Keycloak/Auth0 behavior |
 | MAY | §5.1.2 | Non-standard custom claims in ID token / access token / UserInfo | ✅ Added (issue #388) — gated behind `custom_claims` scope; reserved names rejected on write |
-| SHOULD | §5.1.2 | Collision-resistant / private names for additional claims | ⚠️ Partial — reserved standard/structural names rejected on write; namespaced names supported and recommended but not enforced (bare names like `tier` are allowed) |
+| SHOULD | §5.1.2 | Collision-resistant / private names for additional claims | ✅ Registered claim names (full IANA JWT Claims registry) rejected on write; namespaced names supported. Bare non-registered names like `tier` are allowed by design (private-subsystem use) |
 | SHOULD | §3.1.3.6 | `at_hash` in ID token from token endpoint | ✅ Implemented (2026-04-08) — PR #165 |
 | SHOULD | §3.1.3.7 | `azp` present in ID token | ✅ Verified + annotated (2026-03-30) |
 | SHOULD | §11 | `offline_access` only with `prompt=consent` | ⏭ Skipped — refresh tokens always issued by design |

--- a/rfc/rfc.md
+++ b/rfc/rfc.md
@@ -369,7 +369,7 @@ At the end of each phase, verify that every endpoint or capability introduced by
 | §5.4 | Claims in access token must respect scope | `pkg/token/generate.go` — ✅ Fixed (PR #108) |
 | §5.4 | MAY include email claims in ID token when `email` scope requested | `pkg/token/generate.go` `GenerateIDToken` — ✅ Added (issue #220) |
 | §5.4 | MAY include `given_name`, `family_name` in ID token when `profile` scope requested | `pkg/token/generate.go` `GenerateIDToken` — ✅ Added |
-| §5.1.2 | Additional (non-standard) claims MAY be used alongside standard claims; collision-resistant / private names RECOMMENDED | `pkg/userclaim` — custom claims gated behind `custom_claims` scope; reserved standard/structural names rejected on write; names validated against a collision-resistant pattern. ✅ Added (issue #388) |
+| §5.1.2 | Additional (non-standard) claims MAY be used alongside standard claims; collision-resistant / private names RECOMMENDED | `pkg/userclaim` — custom claims gated behind `custom_claims` scope; reserved standard/structural names rejected on write; the name pattern permits namespaced URIs but bare names are allowed. ✅ Added (issue #388) |
 | RFC 9068 §2.2.2 | AS MAY return arbitrary attributes in access tokens for private-subsystem / scope-gated use | `pkg/token/generate.go` `GenerateTokens` — custom claims emitted only when `custom_claims` scope granted; never override a claim already set. ✅ Added (issue #388) |
 | §5.1 | Claims with empty values are omitted, not returned as null | `pkg/token/generate.go` `GenerateIDToken` — ✅ Enforced for `given_name`, `family_name` |
 | RFC 9068 §2.2 | Access tokens SHOULD NOT carry personal data not needed for authorization | `pkg/token/generate.go` `GenerateTokens` — ✅ `given_name`/`family_name` removed from access token; available via ID token and UserInfo |
@@ -389,7 +389,7 @@ At the end of each phase, verify that every endpoint or capability introduced by
 | MAY | §5.4 | Email claims returned in ID token when `email` scope requested | ✅ Added (issue #220) — mirrors Google/Auth0/Okta behavior |
 | MAY | §5.4 | `given_name`, `family_name` returned in ID token when `profile` scope requested | ✅ Added — mirrors Google/Keycloak/Auth0 behavior |
 | MAY | §5.1.2 | Non-standard custom claims in ID token / access token / UserInfo | ✅ Added (issue #388) — gated behind `custom_claims` scope; reserved names rejected on write |
-| SHOULD | §5.1.2 | Collision-resistant / private names for additional claims | ✅ Enforced — reserved-name rejection + name pattern; namespaced names permitted |
+| SHOULD | §5.1.2 | Collision-resistant / private names for additional claims | ⚠️ Partial — reserved standard/structural names rejected on write; namespaced names supported and recommended but not enforced (bare names like `tier` are allowed) |
 | SHOULD | §3.1.3.6 | `at_hash` in ID token from token endpoint | ✅ Implemented (2026-04-08) — PR #165 |
 | SHOULD | §3.1.3.7 | `azp` present in ID token | ✅ Verified + annotated (2026-03-30) |
 | SHOULD | §11 | `offline_access` only with `prompt=consent` | ⏭ Skipped — refresh tokens always issued by design |

--- a/rfc/rfc.md
+++ b/rfc/rfc.md
@@ -369,6 +369,8 @@ At the end of each phase, verify that every endpoint or capability introduced by
 | §5.4 | Claims in access token must respect scope | `pkg/token/generate.go` — ✅ Fixed (PR #108) |
 | §5.4 | MAY include email claims in ID token when `email` scope requested | `pkg/token/generate.go` `GenerateIDToken` — ✅ Added (issue #220) |
 | §5.4 | MAY include `given_name`, `family_name` in ID token when `profile` scope requested | `pkg/token/generate.go` `GenerateIDToken` — ✅ Added |
+| §5.1.2 | Additional (non-standard) claims MAY be used alongside standard claims; collision-resistant / private names RECOMMENDED | `pkg/userclaim` — custom claims gated behind `custom_claims` scope; reserved standard/structural names rejected on write; names validated against a collision-resistant pattern. ✅ Added (issue #388) |
+| RFC 9068 §2.2.2 | AS MAY return arbitrary attributes in access tokens for private-subsystem / scope-gated use | `pkg/token/generate.go` `GenerateTokens` — custom claims emitted only when `custom_claims` scope granted; never override a claim already set. ✅ Added (issue #388) |
 | §5.1 | Claims with empty values are omitted, not returned as null | `pkg/token/generate.go` `GenerateIDToken` — ✅ Enforced for `given_name`, `family_name` |
 | RFC 9068 §2.2 | Access tokens SHOULD NOT carry personal data not needed for authorization | `pkg/token/generate.go` `GenerateTokens` — ✅ `given_name`/`family_name` removed from access token; available via ID token and UserInfo |
 | §11 | `offline_access` requires `prompt=consent` | ⏭ Skipped — refresh tokens always issued; `offline_access` is effectively always on |
@@ -386,6 +388,8 @@ At the end of each phase, verify that every endpoint or capability introduced by
 | MUST | §5.4 | Access token claims respect requested scope | ✅ Fixed (PR #108) |
 | MAY | §5.4 | Email claims returned in ID token when `email` scope requested | ✅ Added (issue #220) — mirrors Google/Auth0/Okta behavior |
 | MAY | §5.4 | `given_name`, `family_name` returned in ID token when `profile` scope requested | ✅ Added — mirrors Google/Keycloak/Auth0 behavior |
+| MAY | §5.1.2 | Non-standard custom claims in ID token / access token / UserInfo | ✅ Added (issue #388) — gated behind `custom_claims` scope; reserved names rejected on write |
+| SHOULD | §5.1.2 | Collision-resistant / private names for additional claims | ✅ Enforced — reserved-name rejection + name pattern; namespaced names permitted |
 | SHOULD | §3.1.3.6 | `at_hash` in ID token from token endpoint | ✅ Implemented (2026-04-08) — PR #165 |
 | SHOULD | §3.1.3.7 | `azp` present in ID token | ✅ Verified + annotated (2026-03-30) |
 | SHOULD | §11 | `offline_access` only with `prompt=consent` | ⏭ Skipped — refresh tokens always issued by design |
@@ -397,7 +401,7 @@ At the end of each phase, verify that every endpoint or capability introduced by
 
 **Discovery cross-check:**
 - [x] `userinfo_endpoint` present in `/.well-known/openid-configuration` — verified
-- [x] `scopes_supported` lists `openid`, `profile`, `email`, `address`, `phone`, `offline_access` — verified
+- [x] `scopes_supported` lists `openid`, `profile`, `email`, `address`, `phone`, `offline_access`, `groups`, `custom_claims` — verified
 - [x] `claims_supported` lists all claims from UserInfo and ID token — verified
 
 **Tests:**

--- a/tests/e2e/test_server_test.go
+++ b/tests/e2e/test_server_test.go
@@ -83,7 +83,7 @@ func startTestServer(t *testing.T) *TestServer {
 	hashedSecret, _ := bcrypt.GenerateFromPassword([]byte("e2e-secret"), bcrypt.MinCost)
 	_, err = db.GetDB().Exec(`
 		INSERT INTO clients (id, client_id, client_name, client_secret, client_type, redirect_uris, post_logout_redirect_uris, grant_types, response_types, scopes, is_active)
-		VALUES ('e2e-conf-id', 'e2e-confidential', 'E2E Confidential Client', ?, 'confidential', '["http://localhost:3000/callback"]', '[]', '["authorization_code","password","refresh_token"]', '["code","token"]', 'openid profile email offline_access groups', TRUE)
+		VALUES ('e2e-conf-id', 'e2e-confidential', 'E2E Confidential Client', ?, 'confidential', '["http://localhost:3000/callback"]', '[]', '["authorization_code","password","refresh_token"]', '["code","token"]', 'openid profile email offline_access groups custom_claims', TRUE)
 	`, string(hashedSecret))
 	if err != nil {
 		t.Fatalf("Failed to seed e2e-confidential client: %v", err)

--- a/tests/e2e/test_server_test.go
+++ b/tests/e2e/test_server_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/signup"
 	"github.com/eugenioenko/autentico/pkg/token"
 	"github.com/eugenioenko/autentico/pkg/user"
+	"github.com/eugenioenko/autentico/pkg/userclaim"
 	"github.com/eugenioenko/autentico/pkg/userinfo"
 	"github.com/eugenioenko/autentico/pkg/wellknown"
 	"github.com/gorilla/csrf"
@@ -54,7 +55,7 @@ func startTestServer(t *testing.T) *TestServer {
 	// Seed the shared "test-client" used across E2E tests
 	_, err = db.GetDB().Exec(`
 		INSERT INTO clients (id, client_id, client_name, client_type, redirect_uris, post_logout_redirect_uris, grant_types, response_types, scopes, is_active)
-		VALUES ('test-client-id', 'test-client', 'E2E Test Client', 'public', '["http://localhost:3000/callback"]', '[]', '["authorization_code","password","refresh_token"]', '["code","token"]', 'openid profile email offline_access groups', TRUE)
+		VALUES ('test-client-id', 'test-client', 'E2E Test Client', 'public', '["http://localhost:3000/callback"]', '[]', '["authorization_code","password","refresh_token"]', '["code","token"]', 'openid profile email offline_access groups custom_claims', TRUE)
 	`)
 	if err != nil {
 		t.Fatalf("Failed to seed test-client: %v", err)
@@ -199,6 +200,9 @@ func startTestServer(t *testing.T) *TestServer {
 	mux.Handle("POST /admin/api/groups/{id}/members", middleware.AdminAuthMiddleware(http.HandlerFunc(group.HandleAddMember)))
 	mux.Handle("DELETE /admin/api/groups/{id}/members/{user_id}", middleware.AdminAuthMiddleware(http.HandlerFunc(group.HandleRemoveMember)))
 	mux.Handle("GET /admin/api/users/{id}/groups", middleware.AdminAuthMiddleware(http.HandlerFunc(group.HandleGetUserGroups)))
+	mux.Handle("GET /admin/api/users/{id}/claims", middleware.AdminAuthMiddleware(http.HandlerFunc(userclaim.HandleListUserClaims)))
+	mux.Handle("POST /admin/api/users/{id}/claims", middleware.AdminAuthMiddleware(http.HandlerFunc(userclaim.HandleUpsertUserClaim)))
+	mux.Handle("DELETE /admin/api/users/{id}/claims/{name...}", middleware.AdminAuthMiddleware(http.HandlerFunc(userclaim.HandleDeleteUserClaim)))
 
 	// Apply CORS + logging middleware and start server
 	server.Config.Handler = middleware.CORSMiddleware(middleware.LoggingMiddleware(mux))

--- a/tests/e2e/user_claims_test.go
+++ b/tests/e2e/user_claims_test.go
@@ -87,6 +87,42 @@ func TestUserClaims_AdminCRUD(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp3.StatusCode)
 }
 
+// TestUserClaims_DeleteNamespacedName exercises the {name...} route through the
+// real mux: a namespaced claim name contains "//", which net/http.ServeMux
+// path-cleans and 301-redirects unless the client percent-encodes it.
+func TestUserClaims_DeleteNamespacedName(t *testing.T) {
+	ts := startTestServer(t)
+	_, adminToken := createTestAdmin(t, ts, "ccnsadmin", "password123", "ccns@test.com")
+	usr := createTestUser(t, "ccnsuser", "password123", "ccnsuser@test.com")
+
+	const name = "https://app.example.com/tier"
+	adminUpsertClaim(t, ts, adminToken, usr.ID, name, "gold")
+
+	req, _ := http.NewRequest("DELETE",
+		ts.BaseURL+"/admin/api/users/"+usr.ID+"/claims/"+url.PathEscape(name), nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	resp, err := ts.Client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	claims := listUserClaims(t, ts, adminToken, usr.ID)
+	assert.Empty(t, claims)
+}
+
+func listUserClaims(t *testing.T, ts *TestServer, adminToken, userID string) []userclaim.UserClaimResponse {
+	t.Helper()
+	req, _ := http.NewRequest("GET", ts.BaseURL+"/admin/api/users/"+userID+"/claims", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	resp, err := ts.Client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	var listResp model.ApiResponse[[]userclaim.UserClaimResponse]
+	require.NoError(t, json.Unmarshal(body, &listResp))
+	return listResp.Data
+}
+
 func TestUserClaims_EmittedWithScope(t *testing.T) {
 	ts := startTestServer(t)
 	_, adminToken := createTestAdmin(t, ts, "ccadmin2", "password123", "ccadmin2@test.com")

--- a/tests/e2e/user_claims_test.go
+++ b/tests/e2e/user_claims_test.go
@@ -131,6 +131,27 @@ func TestUserClaims_AbsentWithoutScope(t *testing.T) {
 	assert.Nil(t, atClaims["tier"])
 }
 
+func TestUserClaims_ScopeRejectedWhenNotAllowedForClient(t *testing.T) {
+	ts := startTestServer(t)
+	seedScopedClient(t) // scoped-e2e-client: scopes = "openid profile", no custom_claims
+	createTestUser(t, "ccscopeuser", "password123", "ccscope@test.com")
+
+	form := url.Values{}
+	form.Set("grant_type", "password")
+	form.Set("client_id", "scoped-e2e-client")
+	form.Set("username", "ccscopeuser")
+	form.Set("password", "password123")
+	form.Set("scope", "openid custom_claims")
+
+	resp, err := ts.Client.PostForm(ts.BaseURL+"/oauth2/token", form)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Contains(t, string(body), "invalid_scope")
+}
+
 func TestUserClaims_RefreshReReadsLive(t *testing.T) {
 	ts := startTestServer(t)
 	_, adminToken := createTestAdmin(t, ts, "ccadmin4", "password123", "ccadmin4@test.com")

--- a/tests/e2e/user_claims_test.go
+++ b/tests/e2e/user_claims_test.go
@@ -215,3 +215,69 @@ func TestUserClaims_RefreshReReadsLive(t *testing.T) {
 	atClaims := decodeJWTPayload(t, refreshed.AccessToken)
 	assert.Equal(t, "platinum", atClaims["tier"], "refreshed token must reflect the current claim value")
 }
+
+func TestUserClaims_DroppedOnRefreshDownscope(t *testing.T) {
+	ts := startTestServer(t)
+	_, adminToken := createTestAdmin(t, ts, "ccadmin5", "password123", "ccadmin5@test.com")
+	usr := createTestUser(t, "ccuser4", "password123", "ccuser4@test.com")
+
+	adminUpsertClaim(t, ts, adminToken, usr.ID, "tier", "gold")
+	tr := passwordToken(t, ts, "ccuser4", "password123", "openid custom_claims offline_access")
+
+	// Refresh narrowing the scope to drop custom_claims.
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("client_id", "test-client")
+	form.Set("refresh_token", tr.RefreshToken)
+	form.Set("scope", "openid")
+	resp, err := ts.Client.PostForm(ts.BaseURL+"/oauth2/token", form)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "refresh failed: %s", string(body))
+	var refreshed token.TokenResponse
+	require.NoError(t, json.Unmarshal(body, &refreshed))
+
+	assert.Nil(t, decodeJWTPayload(t, refreshed.AccessToken)["tier"],
+		"custom claims must be gone once custom_claims is dropped on refresh")
+	assert.Nil(t, decodeJWTPayload(t, refreshed.IDToken)["tier"])
+}
+
+func TestUserClaims_NotInIntrospectionResponse(t *testing.T) {
+	ts := startTestServer(t)
+	_, adminToken := createTestAdmin(t, ts, "ccadmin6", "password123", "ccadmin6@test.com")
+	usr := createTestUser(t, "ccuser5", "password123", "ccuser5@test.com")
+	adminUpsertClaim(t, ts, adminToken, usr.ID, "tier", "gold")
+
+	// ROPC on the confidential client so it can introspect its own token.
+	form := url.Values{}
+	form.Set("grant_type", "password")
+	form.Set("username", "ccuser5")
+	form.Set("password", "password123")
+	form.Set("scope", "openid custom_claims")
+	tokReq, _ := http.NewRequest("POST", ts.BaseURL+"/oauth2/token", strings.NewReader(form.Encode()))
+	tokReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokReq.SetBasicAuth("e2e-confidential", "e2e-secret")
+	tokResp, err := ts.Client.Do(tokReq)
+	require.NoError(t, err)
+	defer func() { _ = tokResp.Body.Close() }()
+	tb, _ := io.ReadAll(tokResp.Body)
+	require.Equal(t, http.StatusOK, tokResp.StatusCode, "token: %s", string(tb))
+	var tr token.TokenResponse
+	require.NoError(t, json.Unmarshal(tb, &tr))
+	require.Equal(t, "gold", decodeJWTPayload(t, tr.AccessToken)["tier"], "sanity: claim is in the token")
+
+	iForm := url.Values{}
+	iForm.Set("token", tr.AccessToken)
+	iReq, _ := http.NewRequest("POST", ts.BaseURL+"/oauth2/introspect", strings.NewReader(iForm.Encode()))
+	iReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	iReq.SetBasicAuth("e2e-confidential", "e2e-secret")
+	iResp, err := ts.Client.Do(iReq)
+	require.NoError(t, err)
+	defer func() { _ = iResp.Body.Close() }()
+	ib, _ := io.ReadAll(iResp.Body)
+	var introspect map[string]interface{}
+	require.NoError(t, json.Unmarshal(ib, &introspect))
+	assert.True(t, introspect["active"].(bool), "sanity: token is active: %s", string(ib))
+	assert.NotContains(t, introspect, "tier", "introspection must not surface custom claims")
+}

--- a/tests/e2e/user_claims_test.go
+++ b/tests/e2e/user_claims_test.go
@@ -1,0 +1,160 @@
+package e2e
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/autentico/pkg/model"
+	"github.com/eugenioenko/autentico/pkg/token"
+	"github.com/eugenioenko/autentico/pkg/userclaim"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func adminUpsertClaim(t *testing.T, ts *TestServer, adminToken, userID, name, value string) {
+	t.Helper()
+	body, _ := json.Marshal(userclaim.UserClaimRequest{Name: name, Value: value})
+	req, _ := http.NewRequest("POST", ts.BaseURL+"/admin/api/users/"+userID+"/claims", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	resp, err := ts.Client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	respBody, _ := io.ReadAll(resp.Body)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "upsert claim failed: %s", string(respBody))
+}
+
+func passwordToken(t *testing.T, ts *TestServer, username, password, scope string) token.TokenResponse {
+	t.Helper()
+	form := url.Values{}
+	form.Set("grant_type", "password")
+	form.Set("client_id", "test-client")
+	form.Set("username", username)
+	form.Set("password", password)
+	form.Set("scope", scope)
+
+	resp, err := ts.Client.PostForm(ts.BaseURL+"/oauth2/token", form)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "token request failed: %s", string(body))
+	var tr token.TokenResponse
+	require.NoError(t, json.Unmarshal(body, &tr))
+	return tr
+}
+
+func TestUserClaims_AdminCRUD(t *testing.T) {
+	ts := startTestServer(t)
+	_, adminToken := createTestAdmin(t, ts, "ccadmin", "password123", "ccadmin@test.com")
+	usr := createTestUser(t, "cccruduser", "password123", "cccrud@test.com")
+
+	adminUpsertClaim(t, ts, adminToken, usr.ID, "tier", "gold")
+	adminUpsertClaim(t, ts, adminToken, usr.ID, "tier", "platinum") // upsert
+
+	// List
+	req, _ := http.NewRequest("GET", ts.BaseURL+"/admin/api/users/"+usr.ID+"/claims", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	resp, err := ts.Client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	var listResp model.ApiResponse[[]userclaim.UserClaimResponse]
+	require.NoError(t, json.Unmarshal(body, &listResp))
+	require.Len(t, listResp.Data, 1)
+	assert.Equal(t, "tier", listResp.Data[0].Name)
+	assert.Equal(t, "platinum", listResp.Data[0].Value)
+
+	// Reserved name rejected
+	rb, _ := json.Marshal(userclaim.UserClaimRequest{Name: "email", Value: "x"})
+	req, _ = http.NewRequest("POST", ts.BaseURL+"/admin/api/users/"+usr.ID+"/claims", strings.NewReader(string(rb)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	resp2, err := ts.Client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp2.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp2.StatusCode)
+
+	// Delete
+	req, _ = http.NewRequest("DELETE", ts.BaseURL+"/admin/api/users/"+usr.ID+"/claims/tier", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	resp3, err := ts.Client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp3.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp3.StatusCode)
+}
+
+func TestUserClaims_EmittedWithScope(t *testing.T) {
+	ts := startTestServer(t)
+	_, adminToken := createTestAdmin(t, ts, "ccadmin2", "password123", "ccadmin2@test.com")
+	usr := createTestUser(t, "ccuser", "password123", "ccuser@test.com")
+
+	adminUpsertClaim(t, ts, adminToken, usr.ID, "tier", "gold")
+	adminUpsertClaim(t, ts, adminToken, usr.ID, "region", "eu")
+
+	tr := passwordToken(t, ts, "ccuser", "password123", "openid custom_claims")
+
+	idClaims := decodeJWTPayload(t, tr.IDToken)
+	assert.Equal(t, "gold", idClaims["tier"])
+	assert.Equal(t, "eu", idClaims["region"])
+
+	atClaims := decodeJWTPayload(t, tr.AccessToken)
+	assert.Equal(t, "gold", atClaims["tier"])
+
+	// UserInfo
+	req, _ := http.NewRequest("GET", ts.BaseURL+"/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+tr.AccessToken)
+	uiResp, err := ts.Client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = uiResp.Body.Close() }()
+	uiBody, _ := io.ReadAll(uiResp.Body)
+	var userinfo map[string]interface{}
+	require.NoError(t, json.Unmarshal(uiBody, &userinfo))
+	assert.Equal(t, "gold", userinfo["tier"])
+}
+
+func TestUserClaims_AbsentWithoutScope(t *testing.T) {
+	ts := startTestServer(t)
+	_, adminToken := createTestAdmin(t, ts, "ccadmin3", "password123", "ccadmin3@test.com")
+	usr := createTestUser(t, "ccuser2", "password123", "ccuser2@test.com")
+
+	adminUpsertClaim(t, ts, adminToken, usr.ID, "tier", "gold")
+
+	tr := passwordToken(t, ts, "ccuser2", "password123", "openid profile")
+
+	idClaims := decodeJWTPayload(t, tr.IDToken)
+	assert.Nil(t, idClaims["tier"])
+	atClaims := decodeJWTPayload(t, tr.AccessToken)
+	assert.Nil(t, atClaims["tier"])
+}
+
+func TestUserClaims_RefreshReReadsLive(t *testing.T) {
+	ts := startTestServer(t)
+	_, adminToken := createTestAdmin(t, ts, "ccadmin4", "password123", "ccadmin4@test.com")
+	usr := createTestUser(t, "ccuser3", "password123", "ccuser3@test.com")
+
+	adminUpsertClaim(t, ts, adminToken, usr.ID, "tier", "gold")
+	tr := passwordToken(t, ts, "ccuser3", "password123", "openid custom_claims offline_access")
+	require.NotEmpty(t, tr.RefreshToken)
+
+	// Change the claim, then refresh
+	adminUpsertClaim(t, ts, adminToken, usr.ID, "tier", "platinum")
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("client_id", "test-client")
+	form.Set("refresh_token", tr.RefreshToken)
+	resp, err := ts.Client.PostForm(ts.BaseURL+"/oauth2/token", form)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "refresh failed: %s", string(body))
+	var refreshed token.TokenResponse
+	require.NoError(t, json.Unmarshal(body, &refreshed))
+
+	atClaims := decodeJWTPayload(t, refreshed.AccessToken)
+	assert.Equal(t, "platinum", atClaims["tier"], "refreshed token must reflect the current claim value")
+}

--- a/tests/security/server_test.go
+++ b/tests/security/server_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/eugenioenko/autentico/pkg/signup"
 	"github.com/eugenioenko/autentico/pkg/token"
 	"github.com/eugenioenko/autentico/pkg/user"
+	"github.com/eugenioenko/autentico/pkg/userclaim"
 	"github.com/eugenioenko/autentico/pkg/userinfo"
 	"github.com/eugenioenko/autentico/pkg/wellknown"
 	"github.com/gorilla/csrf"
@@ -181,6 +182,9 @@ func startTestServer(t *testing.T) *TestServer {
 	mux.Handle("PUT /admin/api/settings", middleware.AdminAuthMiddleware(http.HandlerFunc(appsettings.HandlePutSettings)))
 	mux.Handle("GET /admin/api/stats", middleware.AdminAuthMiddleware(http.HandlerFunc(admin.HandleStats)))
 	mux.Handle("GET /admin/api/groups", middleware.AdminAuthMiddleware(http.HandlerFunc(group.HandleListGroups)))
+	mux.Handle("GET /admin/api/users/{id}/claims", middleware.AdminAuthMiddleware(http.HandlerFunc(userclaim.HandleListUserClaims)))
+	mux.Handle("POST /admin/api/users/{id}/claims", middleware.AdminAuthMiddleware(http.HandlerFunc(userclaim.HandleUpsertUserClaim)))
+	mux.Handle("DELETE /admin/api/users/{id}/claims/{name...}", middleware.AdminAuthMiddleware(http.HandlerFunc(userclaim.HandleDeleteUserClaim)))
 	mux.Handle("GET /admin/api/deletion-requests", middleware.AdminAuthMiddleware(http.HandlerFunc(deletion.HandleListDeletionRequests)))
 
 	mux.Handle("POST /admin/api/federation/providers", middleware.AdminAuthMiddleware(http.HandlerFunc(federation.HandleCreateProvider)))


### PR DESCRIPTION
## Summary

Implements [Discussion #388](https://github.com/eugenioenko/autentico/discussions/388) — arbitrary key/value claims that an admin can attach to a user. When a client is granted the new (non-standard) `custom_claims` scope, that user's claims are merged into the **access token**, **ID token**, and **UserInfo** response.

Design decisions (all confirmed with the maintainer):
- Storage: dedicated `user_claims` table, **one row per `(user_id, claim_name)`** — the key/value layout requested in the discussion, and idiomatic (mirrors `user_groups`).
- Emission is gated behind the `custom_claims` scope, exactly like `groups`. A client requesting it without `custom_claims` in its allowed `scopes` is rejected like any other disallowed scope.
- Reserved / standard claim names are **rejected on write** (400). The token builder also never lets a custom claim overwrite a claim it already set.
- **Values are strings only** in this version. Typed values (bool/number/array) are a non-breaking follow-up (`ALTER TABLE ... ADD COLUMN value_type`).
- No per-client allow-list, no per-claim destination toggles — kept to what the issue needs.

### Spec basis (`rfc/`)
- OIDC Core §5.1.2 / §5.3.2 — additional (non-standard) claims **MAY** be used alongside standard ones; collision-resistant / private names RECOMMENDED.
- RFC 9068 §2.2.2 — an AS **MAY** return arbitrary attributes in access tokens for scope-gated / private-subsystem use; no client mechanism to request specific claims.
- Nothing here is required or forbidden by the specs; the `custom_claims` scope is a local convention mirroring the existing (non-standard) `groups` scope.

## Changes

**Backend**
- `pkg/db/migrations/011_user_claims.go` — new table, FK cascade on user delete; `SchemaVersion` → 11
- `pkg/userclaim/` — new package: `model.go` (validation, reserved-name set, name pattern), `create.go` (upsert), `delete.go`, `read.go` (`ClaimsByUserID`, `ClaimMapByUserID`, batch), `handler.go` (3 Swagger-annotated admin handlers)
- `pkg/cli/start.go` + both test servers — `GET/POST /admin/api/users/{id}/claims`, `DELETE .../claims/{name...}` (wildcard supports namespaced claim names)
- `pkg/token/generate.go` — merge into access + ID token when `custom_claims` granted; never overrides an existing claim
- `pkg/userinfo/handler.go` — same merge into the UserInfo response
- `pkg/wellknown/handler.go` — `custom_claims` added to `scopes_supported`

**Admin UI**
- `UserClaimsDrawer` on the Users page (name/value row editor, per-row delete), opened from an ID-card icon in the row actions
- `groups` and `custom_claims` added to the scope options in the client create/edit forms (both were missing `groups` too)

**Docs**
- New `users/custom-claims.mdx` + sidebar entry; updated `protocol/scopes.mdx`, `architecture/database-schema.mdx`, `architecture/package-structure.mdx`, `api-reference/endpoints.mdx`, `README.md`, `CLAUDE.md`
- `rfc/rfc.md` Phase 6 — added OIDC Core §5.1.2 / RFC 9068 §2.2.2 rows
- `make generate-docs` — swagger regenerated (additive)

## Test plan

- `make test` — full suite green (`go test -p 1 ./...`, 0 failures)
- `make lint` — 0 issues
- `admin-ui`: `tsc -b` + `vite build` clean
- New coverage:
  - `pkg/userclaim/*_test.go` — validation (valid/reserved/malformed names, oversize value), upsert insert-then-update, FK on unknown user, delete + cascade, read helpers
  - `pkg/token/generate_customclaims_test.go` — claims in access + ID token only with the scope; a claim named `sub` (inserted directly) does **not** override the real `sub`
  - `pkg/userinfo/handler_customclaims_test.go` — present with scope, absent without
  - `pkg/wellknown/handler_test.go` — `custom_claims` in `scopes_supported`
  - `tests/e2e/user_claims_test.go` — admin CRUD, reserved-name → 400, emission across ID token + access token + UserInfo, and refresh re-reading the current claim value

### Manual verification
1. `make build && rm -f autentico.db && ./autentico start --auto-setup &`
2. `./autentico onboard --username admin --password secret --email admin@test.com --enable-admin-password-grant`, get an admin token via ROPC
3. `curl -X POST localhost:9999/admin/api/users/$UID/claims -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{"name":"tier","value":"gold"}'`
4. Reserved-name check: same with `{"name":"email",...}` → `400`
5. Register the debug client with `custom_claims` in its scopes; run the auth-code flow with `scope=openid custom_claims`; decode the tokens → `tier: "gold"` present. Repeat without `custom_claims` → absent.
6. `curl localhost:9999/.well-known/openid-configuration | jq .scopes_supported` → includes `custom_claims`
7. Admin UI → Users → claims drawer → add / edit / delete rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom per-user claims with create, update, list, and delete support through the admin interface and API.
  * Added a Claims action to user management for viewing and editing claims.
  * Added the `custom_claims` scope, allowing claims in ID tokens, access tokens, and UserInfo responses when authorized.
  * Added `groups` and `custom_claims` as selectable client scopes.

* **Documentation**
  * Added documentation covering custom claims, API endpoints, scopes, validation, and database storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->