### PR TITLE
OpenCloud OIDC: Add opencloudRoles Claim

### DIFF
--- a/admin-ui/src/components/clients/ClientCreateForm.tsx
+++ b/admin-ui/src/components/clients/ClientCreateForm.tsx
@@ -23,6 +23,7 @@ import {
 import { useCreateClient } from "../../hooks/useClients";
 import type { ClientCreateRequest, ClientResponse } from "../../types/client";
 import { tip, overrideTip } from "./clientTips";
+import { isValidRedirectURI } from "../../lib/redirectUri";
 
 interface ClientCreateFormProps {
   open: boolean;
@@ -64,6 +65,14 @@ const SCOPE_OPTIONS = [
   { label: "groups", value: "groups" },
   { label: "custom_claims", value: "custom_claims" },
 ];
+
+const redirectUriRule = {
+  validator: async (_: unknown, value?: string) => {
+    if (!value || !isValidRedirectURI(value)) {
+      return Promise.reject(new Error("Must be a valid redirect URI"));
+    }
+  },
+};
 
 export default function ClientCreateForm({
   open,
@@ -201,7 +210,7 @@ export default function ClientCreateForm({
                         noStyle
                         rules={[
                           { required: true, message: "URI is required" },
-                          { type: "url", message: "Must be a valid URL" },
+                          redirectUriRule,
                         ]}
                       >
                         <Input
@@ -248,7 +257,7 @@ export default function ClientCreateForm({
                         noStyle
                         rules={[
                           { required: true, message: "URI is required" },
-                          { type: "url", message: "Must be a valid URL" },
+                          redirectUriRule,
                         ]}
                       >
                         <Input

--- a/admin-ui/src/components/clients/ClientEditForm.tsx
+++ b/admin-ui/src/components/clients/ClientEditForm.tsx
@@ -21,6 +21,7 @@ import type {
   ClientInfoResponse,
   ClientUpdateRequest,
 } from "../../types/client";
+import { isValidRedirectURI } from "../../lib/redirectUri";
 
 interface ClientEditFormProps {
   open: boolean;
@@ -58,6 +59,14 @@ const SCOPE_OPTIONS = [
   { label: "groups", value: "groups" },
   { label: "custom_claims", value: "custom_claims" },
 ];
+
+const redirectUriRule = {
+  validator: async (_: unknown, value?: string) => {
+    if (!value || !isValidRedirectURI(value)) {
+      return Promise.reject(new Error("Must be a valid redirect URI"));
+    }
+  },
+};
 
 export default function ClientEditForm({
   open,
@@ -184,7 +193,7 @@ export default function ClientEditForm({
                       noStyle
                       rules={[
                         { required: true, message: "URI is required" },
-                        { type: "url", message: "Must be a valid URL" },
+                        redirectUriRule,
                       ]}
                     >
                       <Input style={{ width: "100%" }} />
@@ -228,7 +237,7 @@ export default function ClientEditForm({
                       noStyle
                       rules={[
                         { required: true, message: "URI is required" },
-                        { type: "url", message: "Must be a valid URL" },
+                        redirectUriRule,
                       ]}
                     >
                       <Input style={{ width: "100%" }} />

--- a/admin-ui/src/lib/redirectUri.ts
+++ b/admin-ui/src/lib/redirectUri.ts
@@ -8,7 +8,11 @@ export function isValidRedirectURI(uri: string): boolean {
     if (!scheme) return false;
 
     if (scheme === "http" || scheme === "https") {
-      return parsedURI.host !== "";
+      // Keep the authority check on the original URI. The WHATWG URL parser
+      // may normalize malformed input such as "http:///callback" into a URL
+      // with "callback" as its host.
+      const authority = uri.slice(`${scheme}://`.length).split(/[/?#]/, 1)[0];
+      return uri.startsWith(`${scheme}://`) && authority !== "" && parsedURI.host !== "";
     }
 
     // Private-use/native-app schemes may use either an authority

--- a/admin-ui/src/lib/redirectUri.ts
+++ b/admin-ui/src/lib/redirectUri.ts
@@ -1,0 +1,21 @@
+export function isValidRedirectURI(uri: string): boolean {
+  if (!uri) return false;
+
+  try {
+    const parsedURI = new URL(uri);
+    const scheme = parsedURI.protocol.replace(/:$/, "").toLowerCase();
+
+    if (!scheme) return false;
+
+    if (scheme === "http" || scheme === "https") {
+      return parsedURI.host !== "";
+    }
+
+    // Private-use/native-app schemes may use either an authority
+    // (myapp://callback) or an absolute path without an authority
+    // (app.immich:///oauth-callback).
+    return parsedURI.host !== "" || parsedURI.pathname.startsWith("/");
+  } catch {
+    return false;
+  }
+}

--- a/pkg/authorize/model.go
+++ b/pkg/authorize/model.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/eugenioenko/autentico/pkg/authzsig"
 	validation "github.com/go-ozzo/ozzo-validation"
-	"github.com/go-ozzo/ozzo-validation/is"
 )
 
 type AuthorizeRequest struct {
@@ -25,7 +24,9 @@ type AuthorizeRequest struct {
 func ValidateAuthorizeRequest(input AuthorizeRequest) error {
 	return validation.ValidateStruct(&input,
 		validation.Field(&input.ResponseType, validation.Required),
-		validation.Field(&input.RedirectURI, validation.Required, is.URL),
+		// Redirect URI syntax is validated by the authorize handler using
+		// utils.IsValidRedirectURI, which supports both web and native app URIs.
+		validation.Field(&input.RedirectURI, validation.Required),
 		// RFC 6749 §3.3: validate scope token syntax
 		validation.Field(&input.Scope, validation.By(validateScopeSyntax)),
 	)

--- a/pkg/authorize/model_test.go
+++ b/pkg/authorize/model_test.go
@@ -36,6 +36,16 @@ func TestValidateAuthorizeRequest_ValidScopes(t *testing.T) {
 	}
 }
 
+func TestValidateAuthorizeRequest_NativeRedirectURI(t *testing.T) {
+	req := AuthorizeRequest{
+		ResponseType: "code",
+		RedirectURI:  "oc://ios.opencloud.eu",
+		Scope:        "openid profile email custom_claims",
+	}
+
+	assert.NoError(t, ValidateAuthorizeRequest(req))
+}
+
 func TestValidateAuthorizeRequest_InvalidScopeSyntax(t *testing.T) {
 	base := AuthorizeRequest{
 		ResponseType: "code",
@@ -50,7 +60,7 @@ func TestValidateAuthorizeRequest_InvalidScopeSyntax(t *testing.T) {
 		{"contains backslash", `openid profile\bad`},
 		{"contains double-quote", `openid "profile"`},
 		{"contains control character", "openid \x01bad"},
-		{"contains non-ASCII", "openid prof\xc3\xadle"},
+		{"contains non-ASCII", "openid prof\xc3\adle"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -7,8 +7,8 @@ import (
 	"regexp"
 
 	"github.com/eugenioenko/autentico/pkg/config"
+	"github.com/eugenioenko/autentico/pkg/utils"
 	validation "github.com/go-ozzo/ozzo-validation"
-	"github.com/go-ozzo/ozzo-validation/is"
 )
 
 // noHTMLPattern rejects strings containing HTML tag characters as defense-in-depth
@@ -67,7 +67,7 @@ type ClientCreateRequest struct {
 	ConsentRequired             *bool    `json:"consent_required,omitempty"`
 }
 
-// ClientUpdateRequest represents the request body for updating a client
+// ClientUpdateRequest represents a request to update a client
 type ClientUpdateRequest struct {
 	ClientName              string   `json:"client_name,omitempty"`
 	RedirectURIs            []string `json:"redirect_uris,omitempty"`
@@ -234,8 +234,8 @@ func ValidateClientCreateRequest(input ClientCreateRequest) error {
 // ValidateRedirectURIs validates that all redirect URIs are valid URLs
 func ValidateRedirectURIs(uris []string) error {
 	for _, uri := range uris {
-		if err := validation.Validate(uri, validation.Required, is.URL); err != nil {
-			return err
+		if uri == "" || !utils.IsValidRedirectURI(uri) {
+			return validation.Errors{"redirect_uri": validation.ErrInvalid}
 		}
 	}
 	return nil

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"time"
 
 	"regexp"
@@ -231,11 +232,13 @@ func ValidateClientCreateRequest(input ClientCreateRequest) error {
 	)
 }
 
-// ValidateRedirectURIs validates that all redirect URIs are valid URLs
+// ValidateRedirectURIs validates that all redirect URIs are valid URLs.
+// Private-use/native-app redirect URIs are accepted by utils.IsValidRedirectURI,
+// including absolute-path forms such as app.immich:///oauth-callback.
 func ValidateRedirectURIs(uris []string) error {
 	for _, uri := range uris {
 		if uri == "" || !utils.IsValidRedirectURI(uri) {
-			return validation.Errors{"redirect_uri": validation.ErrInvalid}
+			return validation.Errors{"redirect_uri": errors.New("must be a valid redirect URI")}
 		}
 	}
 	return nil

--- a/pkg/client/model_test.go
+++ b/pkg/client/model_test.go
@@ -85,6 +85,14 @@ func TestValidateClientCreateRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "native app redirect URI",
+			request: ClientCreateRequest{
+				ClientName:   "Immich Mobile",
+				RedirectURIs: []string{"app.immich:///oauth-callback"},
+			},
+			wantErr: false,
+		},
+		{
 			name: "missing client name",
 			request: ClientCreateRequest{
 				RedirectURIs: []string{"http://localhost:3000/callback"},
@@ -151,6 +159,11 @@ func TestValidateRedirectURIs(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "native app URI",
+			uris:    []string{"app.immich:///oauth-callback"},
+			wantErr: false,
+		},
+		{
 			name:    "invalid URI",
 			uris:    []string{"not-a-valid-uri"},
 			wantErr: true,
@@ -189,6 +202,13 @@ func TestValidateClientUpdateRequest(t *testing.T) {
 			name: "valid update",
 			request: ClientUpdateRequest{
 				ClientName: "Updated Name",
+			},
+			wantErr: false,
+		},
+		{
+			name: "native app redirect URI",
+			request: ClientUpdateRequest{
+				RedirectURIs: []string{"app.immich:///oauth-callback"},
 			},
 			wantErr: false,
 		},

--- a/pkg/consent/handler.go
+++ b/pkg/consent/handler.go
@@ -112,7 +112,7 @@ func handleConsentPost(w http.ResponseWriter, r *http.Request) {
 		if params.State != "" {
 			q.Set("state", params.State)
 		}
-		http.Redirect(w, r, params.RedirectURI+"?"+q.Encode(), http.StatusFound)
+		http.Redirect(w, r, params.RedirectURI+"?"+q.Encode(), http.StatusSeeOther)
 		return
 	}
 
@@ -157,7 +157,16 @@ func handleConsentPost(w http.ResponseWriter, r *http.Request) {
 	if params.State != "" {
 		redirectParams.Set("state", params.State)
 	}
-	http.Redirect(w, r, params.RedirectURI+"?"+redirectParams.Encode(), http.StatusFound)
+	redirectURL := params.RedirectURI + "?" + redirectParams.Encode()
+	slog.Info("consent: authorization approved",
+		"request_id", reqid.Get(r.Context()),
+		"client_id", params.ClientID,
+		"redirect_uri", params.RedirectURI,
+		"state", params.State,
+		"auth_code_created", true,
+		"location", redirectURL,
+	)
+	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 }
 
 func renderConsentPage(w http.ResponseWriter, r *http.Request, params ConsentParams, clientName, userID string) {

--- a/pkg/login/model.go
+++ b/pkg/login/model.go
@@ -6,7 +6,6 @@ import (
 	"github.com/eugenioenko/autentico/pkg/config"
 
 	validation "github.com/go-ozzo/ozzo-validation"
-	"github.com/go-ozzo/ozzo-validation/is"
 )
 
 type LoginRequest struct {
@@ -51,7 +50,6 @@ func ValidateLoginRequest(input LoginRequest) error {
 	err = validation.Validate(
 		input.RedirectURI,
 		validation.Required,
-		is.URL,
 	)
 	if err != nil {
 		return fmt.Errorf("redirect URI is invalid: %w", err)

--- a/pkg/login/model_test.go
+++ b/pkg/login/model_test.go
@@ -1,0 +1,26 @@
+package login
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/autentico/pkg/config"
+	testutils "github.com/eugenioenko/autentico/tests/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateLoginRequest_NativeRedirectURI(t *testing.T) {
+	testutils.WithConfigOverride(t, func() {
+		config.Values.ValidationMinUsernameLength = 1
+		config.Values.ValidationMaxUsernameLength = 255
+		config.Values.ValidationMinPasswordLength = 1
+		config.Values.ValidationMaxPasswordLength = 255
+
+		req := LoginRequest{
+			Username:    "testuser",
+			Password:    "password123",
+			RedirectURI: "oc://ios.opencloud.eu",
+		}
+
+		assert.NoError(t, ValidateLoginRequest(req))
+	})
+}

--- a/pkg/mfa/handler.go
+++ b/pkg/mfa/handler.go
@@ -39,311 +39,128 @@ func HandleMfa(w http.ResponseWriter, r *http.Request) {
 
 func handleMfaGet(w http.ResponseWriter, r *http.Request) {
 	challengeID := r.URL.Query().Get("challenge_id")
-	if challengeID == "" {
-		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Missing challenge_id")
-		return
-	}
-
+	if challengeID == "" { utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Missing challenge_id"); return }
 	challenge, err := MfaChallengeByIDIncludingExpired(challengeID)
-	if err != nil {
-		redirectToLoginWithError(w, r, nil, "Verification session not found. Please log in again.")
-		return
-	}
-	if challenge.Used || time.Now().After(challenge.ExpiresAt) {
-		redirectToLoginWithError(w, r, challenge, "Verification session has expired. Please log in again.")
-		return
-	}
-
+	if err != nil { redirectToLoginWithError(w, r, nil, "Verification session not found. Please log in again."); return }
+	if challenge.Used || time.Now().After(challenge.ExpiresAt) { redirectToLoginWithError(w, r, challenge, "Verification session has expired. Please log in again."); return }
 	cfg := config.Get()
-	if handleMethodSwitch(w, r, challenge, cfg) {
-		return
-	}
-
+	if handleMethodSwitch(w, r, challenge, cfg) { return }
 	if challenge.Method == "totp" {
 		usr, err := user.UserByID(challenge.UserID)
-		if err != nil {
-			slog.Error("mfa: failed to get user for TOTP challenge", "request_id", reqid.Get(r.Context()), "error", err)
-			redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
-			return
-		}
+		if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
 		if !usr.TotpVerified {
-			if cfg.MfaMethod != "totp" {
-				redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
-				return
-			}
-			renderEnrollPage(w, r, challenge, usr, cfg, "")
-			return
+			if cfg.MfaMethod != "totp" { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
+			renderEnrollPage(w, r, challenge, usr, cfg, ""); return
 		}
 	}
-
 	if challenge.Method == "email" {
 		usr, err := user.UserByID(challenge.UserID)
-		if err != nil {
-			redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
-			return
-		}
+		if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
 		isResend := challenge.OtpSentAt != nil
 		const otpCooldown = 60 * time.Second
-		if isResend && time.Since(*challenge.OtpSentAt) < otpCooldown {
-			renderVerifyPage(w, r, challenge, cfg, "", "Code was already sent. Please check your email.")
-			return
-		}
+		if isResend && time.Since(*challenge.OtpSentAt) < otpCooldown { renderVerifyPage(w, r, challenge, cfg, "", "Code was already sent. Please check your email."); return }
 		otp, err := GenerateEmailOTP()
-		if err != nil {
-			renderVerifyPage(w, r, challenge, cfg, "Failed to generate verification code. Please try again.", "")
-			return
-		}
+		if err != nil { renderVerifyPage(w, r, challenge, cfg, "Failed to generate verification code. Please try again.", ""); return }
 		hashedOTP := utils.HashSHA256(otp)
 		challenge.Code = hashedOTP
-		if err := UpdateChallengeCode(challenge.ID, hashedOTP); err != nil {
-			slog.Error("mfa: failed to update email OTP", "request_id", reqid.Get(r.Context()), "error", err)
-			renderVerifyPage(w, r, challenge, cfg, "Failed to prepare verification code. Please try again.", "")
-			return
-		}
-		if err := email.SendEmailOTP(usr.Email, otp); err != nil {
-			renderVerifyPage(w, r, challenge, cfg, "Failed to send verification code. Please try again.", "")
-			return
-		}
-		if isResend {
-			renderVerifyPage(w, r, challenge, cfg, "", "A new code has been sent to your email")
-			return
-		}
+		if err := UpdateChallengeCode(challenge.ID, hashedOTP); err != nil { renderVerifyPage(w, r, challenge, cfg, "Failed to prepare verification code. Please try again.", ""); return }
+		if err := email.SendEmailOTP(usr.Email, otp); err != nil { renderVerifyPage(w, r, challenge, cfg, "Failed to send verification code. Please try again.", ""); return }
+		if isResend { renderVerifyPage(w, r, challenge, cfg, "", "A new code has been sent to your email"); return }
 	}
 	renderVerifyPage(w, r, challenge, cfg, "", "")
 }
 
 func handleMfaPost(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		redirectToLoginWithError(w, r, nil, "Invalid request. Please log in again.")
-		return
-	}
-	challengeID := r.FormValue("challenge_id")
-	code := r.FormValue("code")
-	totpSecret := r.FormValue("totp_secret")
-	if challengeID == "" || code == "" {
-		redirectToLoginWithError(w, r, nil, "Invalid request. Please log in again.")
-		return
-	}
-
+	if err := r.ParseForm(); err != nil { redirectToLoginWithError(w, r, nil, "Invalid request. Please log in again."); return }
+	challengeID, code, totpSecret := r.FormValue("challenge_id"), r.FormValue("code"), r.FormValue("totp_secret")
+	if challengeID == "" || code == "" { redirectToLoginWithError(w, r, nil, "Invalid request. Please log in again."); return }
 	challenge, err := MfaChallengeByIDIncludingExpired(challengeID)
-	if err != nil {
-		redirectToLoginWithError(w, r, nil, "Verification session not found. Please log in again.")
-		return
-	}
-	if challenge.Used || time.Now().After(challenge.ExpiresAt) {
-		redirectToLoginWithError(w, r, challenge, "Verification session has expired. Please log in again.")
-		return
-	}
-
+	if err != nil { redirectToLoginWithError(w, r, nil, "Verification session not found. Please log in again."); return }
+	if challenge.Used || time.Now().After(challenge.ExpiresAt) { redirectToLoginWithError(w, r, challenge, "Verification session has expired. Please log in again."); return }
 	cfg := config.Get()
 	usr, err := user.UserByID(challenge.UserID)
-	if err != nil {
-		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
-		return
-	}
-
+	if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
 	switch challenge.Method {
 	case "totp":
 		if !usr.TotpVerified {
-			if totpSecret == "" {
-				renderEnrollPage(w, r, challenge, usr, cfg, "Missing TOTP secret")
-				return
-			}
-			if !ValidateTotpCode(totpSecret, code) {
-				audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "totp", "phase", "enrollment"), utils.GetClientIP(r))
-				renderEnrollPage(w, r, challenge, usr, cfg, "Invalid verification code")
-				return
-			}
-			if err := user.SaveTotpSecret(usr.ID, totpSecret); err != nil {
-				renderEnrollPage(w, r, challenge, usr, cfg, "Failed to save authenticator. Please try again.")
-				return
-			}
+			if totpSecret == "" { renderEnrollPage(w, r, challenge, usr, cfg, "Missing TOTP secret"); return }
+			if !ValidateTotpCode(totpSecret, code) { audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "totp", "phase", "enrollment"), utils.GetClientIP(r)); renderEnrollPage(w, r, challenge, usr, cfg, "Invalid verification code"); return }
+			if err := user.SaveTotpSecret(usr.ID, totpSecret); err != nil { renderEnrollPage(w, r, challenge, usr, cfg, "Failed to save authenticator. Please try again."); return }
 			audit.Log(audit.EventMfaEnrolled, usr, audit.TargetUser, usr.ID, audit.Detail("method", "totp"), utils.GetClientIP(r))
 		} else if !ValidateTotpCode(usr.TotpSecret, code) {
-			_ = IncrementFailedAttempts(challenge.ID)
-			audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "totp"), utils.GetClientIP(r))
-			if challenge.FailedAttempts+1 >= 5 {
-				_ = MarkChallengeUsed(challenge.ID)
-				redirectToLoginWithError(w, r, challenge, "Too many failed attempts. Please log in again.")
-				return
-			}
-			renderVerifyPage(w, r, challenge, cfg, "Invalid verification code", "")
-			return
+			_ = IncrementFailedAttempts(challenge.ID); audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "totp"), utils.GetClientIP(r))
+			if challenge.FailedAttempts+1 >= 5 { _ = MarkChallengeUsed(challenge.ID); redirectToLoginWithError(w, r, challenge, "Too many failed attempts. Please log in again."); return }
+			renderVerifyPage(w, r, challenge, cfg, "Invalid verification code", ""); return
 		}
 	case "email":
 		if utils.HashSHA256(code) != challenge.Code {
-			_ = IncrementFailedAttempts(challenge.ID)
-			audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "email"), utils.GetClientIP(r))
-			if challenge.FailedAttempts+1 >= 5 {
-				_ = MarkChallengeUsed(challenge.ID)
-				redirectToLoginWithError(w, r, challenge, "Too many failed attempts. Please log in again.")
-				return
-			}
-			renderVerifyPage(w, r, challenge, cfg, "Invalid verification code", "")
-			return
+			_ = IncrementFailedAttempts(challenge.ID); audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "email"), utils.GetClientIP(r))
+			if challenge.FailedAttempts+1 >= 5 { _ = MarkChallengeUsed(challenge.ID); redirectToLoginWithError(w, r, challenge, "Too many failed attempts. Please log in again."); return }
+			renderVerifyPage(w, r, challenge, cfg, "Invalid verification code", ""); return
 		}
 	default:
-		redirectToLoginWithError(w, r, challenge, "Unknown authentication method. Please log in again.")
-		return
+		redirectToLoginWithError(w, r, challenge, "Unknown authentication method. Please log in again."); return
 	}
 
 	if cfg.TrustDeviceEnabled && r.FormValue("trust_device") == "on" {
 		deviceID, genErr := authcode.GenerateSecureCode()
-		if genErr == nil {
-			ua := r.UserAgent()
-			if len(ua) > 200 {
-				ua = ua[:200]
-			}
-			dev := trusteddevice.TrustedDevice{ID: deviceID, UserID: usr.ID, DeviceName: ua, ExpiresAt: time.Now().Add(cfg.TrustDeviceExpiration)}
-			if trusteddevice.CreateTrustedDevice(dev) == nil {
-				trusteddevice.SetCookie(w, deviceID, cfg.TrustDeviceExpiration)
-			}
-		}
+		if genErr == nil { ua := r.UserAgent(); if len(ua) > 200 { ua = ua[:200] }; dev := trusteddevice.TrustedDevice{ID: deviceID, UserID: usr.ID, DeviceName: ua, ExpiresAt: time.Now().Add(cfg.TrustDeviceExpiration)}; if trusteddevice.CreateTrustedDevice(dev) == nil { trusteddevice.SetCookie(w, deviceID, cfg.TrustDeviceExpiration) } }
 	}
-
 	var loginState LoginState
-	if err := json.Unmarshal([]byte(challenge.LoginState), &loginState); err != nil {
-		slog.Error("mfa: failed to restore login state", "request_id", reqid.Get(r.Context()), "error", err)
-		redirectToLoginWithError(w, r, challenge, "Session expired. Please log in again.")
-		return
-	}
-
+	if err := json.Unmarshal([]byte(challenge.LoginState), &loginState); err != nil { slog.Error("mfa: failed to restore login state", "request_id", reqid.Get(r.Context()), "error", err); redirectToLoginWithError(w, r, challenge, "Session expired. Please log in again."); return }
 	idpSessionID := idpsession.FinalizeLogin(w, r, usr.ID)
 	registeredClient, clientErr := client.ClientByClientID(loginState.ClientID)
 	if clientErr == nil && consent.NeedsConsent(registeredClient.ConsentRequired, usr.ID, loginState.ClientID, loginState.Scope, loginState.Prompt) {
-		consent.RedirectToConsent(w, r, consent.ConsentParams{
-			RedirectURI: loginState.RedirectURI, State: loginState.State, ClientID: loginState.ClientID,
-			Scope: loginState.Scope, Nonce: loginState.Nonce, CodeChallenge: loginState.CodeChallenge,
-			CodeChallengeMethod: loginState.CodeChallengeMethod, Prompt: loginState.Prompt,
-		})
-		return
+		consent.RedirectToConsent(w, r, consent.ConsentParams{RedirectURI: loginState.RedirectURI, State: loginState.State, ClientID: loginState.ClientID, Scope: loginState.Scope, Nonce: loginState.Nonce, CodeChallenge: loginState.CodeChallenge, CodeChallengeMethod: loginState.CodeChallengeMethod, Prompt: loginState.Prompt}); return
 	}
-
 	authorizationCode, err := authcode.GenerateSecureCode()
-	if err != nil {
-		slog.Error("mfa: failed to generate authorization code", "request_id", reqid.Get(r.Context()), "error", err)
-		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
-		return
-	}
-	ac := authcode.AuthCode{
-		Code: authorizationCode, UserID: usr.ID, ClientID: loginState.ClientID, RedirectURI: loginState.RedirectURI,
-		Scope: loginState.Scope, Nonce: loginState.Nonce, CodeChallenge: loginState.CodeChallenge,
-		CodeChallengeMethod: loginState.CodeChallengeMethod, ExpiresAt: time.Now().Add(cfg.AuthAuthorizationCodeExpiration),
-		Used: false, IdpSessionID: idpSessionID,
-	}
-	if err := authcode.CreateAuthCode(ac); err != nil {
-		slog.Error("mfa: failed to create authorization code", "request_id", reqid.Get(r.Context()), "error", err)
-		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
-		return
-	}
-
-	// Consume the MFA challenge only after the OAuth authorization code has been
-	// durably created. This prevents a failed post-MFA OAuth step from turning
-	// a still-valid challenge into a misleading "session expired" state.
+	if err != nil { slog.Error("mfa: failed to generate authorization code", "request_id", reqid.Get(r.Context()), "error", err); redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
+	ac := authcode.AuthCode{Code: authorizationCode, UserID: usr.ID, ClientID: loginState.ClientID, RedirectURI: loginState.RedirectURI, Scope: loginState.Scope, Nonce: loginState.Nonce, CodeChallenge: loginState.CodeChallenge, CodeChallengeMethod: loginState.CodeChallengeMethod, ExpiresAt: time.Now().Add(cfg.AuthAuthorizationCodeExpiration), Used: false, IdpSessionID: idpSessionID}
+	if err := authcode.CreateAuthCode(ac); err != nil { slog.Error("mfa: failed to create authorization code", "request_id", reqid.Get(r.Context()), "error", err); redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
 	if err := MarkChallengeUsed(challenge.ID); err != nil {
 		slog.Error("mfa: failed to mark challenge used after auth code creation", "request_id", reqid.Get(r.Context()), "challenge_id", challenge.ID, "error", err)
-		// The authorization code already exists; do not issue a second one. The
-		// client can retry the OAuth authorization flow rather than replaying MFA.
-		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
-		return
+		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return
 	}
-
 	audit.Log(audit.EventMfaSuccess, usr, audit.TargetUser, usr.ID, audit.Detail("method", challenge.Method), utils.GetClientIP(r))
-	params := url.Values{}
-	params.Set("code", ac.Code)
-	if loginState.State != "" {
-		params.Set("state", loginState.State)
-	}
+	params := url.Values{}; params.Set("code", ac.Code); if loginState.State != "" { params.Set("state", loginState.State) }
 	redirectURL := loginState.RedirectURI + "?" + params.Encode()
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
 func handleMethodSwitch(w http.ResponseWriter, r *http.Request, challenge *MfaChallenge, cfg *config.Config) bool {
 	switchTo := r.URL.Query().Get("switch_to")
-	if switchTo == "" || cfg.MfaMethod != "both" || cfg.SmtpHost == "" {
-		return false
-	}
+	if switchTo == "" || cfg.MfaMethod != "both" || cfg.SmtpHost == "" { return false }
 	switched := false
-	switch switchTo {
-	case "totp":
-		if challenge.Method != "totp" {
-			usr, err := user.UserByID(challenge.UserID)
-			if err != nil {
-				redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
-				return true
-			}
-			if usr.TotpVerified { switched = true }
-		}
-	case "email":
-		if challenge.Method != "email" { switched = true }
-	}
+	switch switchTo { case "totp": if challenge.Method != "totp" { usr, err := user.UserByID(challenge.UserID); if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return true }; if usr.TotpVerified { switched = true } }; case "email": if challenge.Method != "email" { switched = true } }
 	if !switched { return false }
-	if err := MarkChallengeUsed(challenge.ID); err != nil {
-		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
-		return true
-	}
-	newChallengeID, err := authcode.GenerateSecureCode()
-	if err != nil {
-		renderVerifyPage(w, r, challenge, cfg, "Something went wrong. Please try again.", "")
-		return true
-	}
+	if err := MarkChallengeUsed(challenge.ID); err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return true }
+	newChallengeID, err := authcode.GenerateSecureCode(); if err != nil { renderVerifyPage(w, r, challenge, cfg, "Something went wrong. Please try again.", ""); return true }
 	newChallenge := MfaChallenge{ID: newChallengeID, UserID: challenge.UserID, Method: switchTo, LoginState: challenge.LoginState, ExpiresAt: challenge.ExpiresAt}
-	if err := CreateMfaChallenge(newChallenge); err != nil {
-		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
-		return true
-	}
-	mfaURL := config.GetBootstrap().AppOAuthPath + "/mfa?challenge_id=" + newChallengeID
-	http.Redirect(w, r, mfaURL, http.StatusFound)
-	return true
+	if err := CreateMfaChallenge(newChallenge); err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return true }
+	mfaURL := fmt.Sprintf("%s/mfa?challenge_id=%s", config.GetBootstrap().AppOAuthPath, newChallengeID)
+	http.Redirect(w, r, mfaURL, http.StatusFound); return true
 }
 
 func renderVerifyPage(w http.ResponseWriter, r *http.Request, challenge *MfaChallenge, cfg *config.Config, errorMsg string, infoMsg string) {
 	tmpl, err := view.ParseTemplate("mfa")
 	if err != nil { slog.Error("mfa: failed to parse verify template", "request_id", reqid.Get(r.Context()), "error", err); http.Error(w, "Internal Server Error", http.StatusInternalServerError); return }
-	canSwitch := cfg.MfaMethod == "both" && cfg.SmtpHost != ""
-	userTotpVerified := false
+	canSwitch := cfg.MfaMethod == "both" && cfg.SmtpHost != ""; userTotpVerified := false
 	if canSwitch { if usr, err := user.UserByID(challenge.UserID); err == nil { userTotpVerified = usr.TotpVerified } }
-	data := map[string]any{
-		"ChallengeID": challenge.ID, "Method": challenge.Method, "Message": infoMsg, "Error": errorMsg,
-		csrf.TemplateTag: csrf.TemplateField(r), "ThemeTitle": cfg.Theme.Title, "ThemeLogoUrl": cfg.Theme.LogoUrl,
-		"TrustDeviceEnabled": cfg.TrustDeviceEnabled, "TrustDeviceDays": int(cfg.TrustDeviceExpiration.Hours()/24),
-		"CanSwitch": canSwitch, "UserTotpVerified": userTotpVerified,
-	}
-	view.InjectNonce(r, data)
-	if err := tmpl.ExecuteTemplate(w, "layout", data); err != nil { slog.Error("mfa: failed to execute verify template", "request_id", reqid.Get(r.Context()), "error", err) }
+	data := map[string]any{"ChallengeID": challenge.ID, "Method": challenge.Method, "Message": infoMsg, "Error": errorMsg, csrf.TemplateTag: csrf.TemplateField(r), "ThemeTitle": cfg.Theme.Title, "ThemeLogoUrl": cfg.Theme.LogoUrl, "TrustDeviceEnabled": cfg.TrustDeviceEnabled, "TrustDeviceDays": int(cfg.TrustDeviceExpiration.Hours()/24), "CanSwitch": canSwitch, "UserTotpVerified": userTotpVerified}
+	view.InjectNonce(r, data); if err := tmpl.ExecuteTemplate(w, "layout", data); err != nil { slog.Error("mfa: failed to execute verify template", "request_id", reqid.Get(r.Context()), "error", err) }
 }
 
 func renderEnrollPage(w http.ResponseWriter, r *http.Request, challenge *MfaChallenge, usr *user.User, cfg *config.Config, errorMsg string) {
-	secret, otpauthURL, err := GenerateTotpSecret(usr.Username, cfg.Theme.Title)
-	if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
-	png, err := qrcode.Encode(otpauthURL, qrcode.Medium, 200)
-	if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
+	secret, otpauthURL, err := GenerateTotpSecret(usr.Username, cfg.Theme.Title); if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
+	png, err := qrcode.Encode(otpauthURL, qrcode.Medium, 200); if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
 	qrDataURI := "data:image/png;base64," + base64.StdEncoding.EncodeToString(png)
-	tmpl, err := view.ParseTemplate("mfa_enroll")
-	if err != nil { http.Error(w, "Internal Server Error", http.StatusInternalServerError); return }
-	data := map[string]any{
-		"ChallengeID": challenge.ID, "TotpSecret": secret, "QRCodeDataURI": template.URL(qrDataURI), "Error": errorMsg,
-		csrf.TemplateTag: csrf.TemplateField(r), "ThemeTitle": cfg.Theme.Title, "ThemeLogoUrl": cfg.Theme.LogoUrl,
-	}
-	view.InjectNonce(r, data)
-	if err := tmpl.ExecuteTemplate(w, "layout", data); err != nil { slog.Error("mfa: failed to execute enroll template", "request_id", reqid.Get(r.Context()), "error", err) }
+	tmpl, err := view.ParseTemplate("mfa_enroll"); if err != nil { http.Error(w, "Internal Server Error", http.StatusInternalServerError); return }
+	data := map[string]any{"ChallengeID": challenge.ID, "TotpSecret": secret, "QRCodeDataURI": template.URL(qrDataURI), "Error": errorMsg, csrf.TemplateTag: csrf.TemplateField(r), "ThemeTitle": cfg.Theme.Title, "ThemeLogoUrl": cfg.Theme.LogoUrl}
+	view.InjectNonce(r, data); if err := tmpl.ExecuteTemplate(w, "layout", data); err != nil { slog.Error("mfa: failed to execute enroll template", "request_id", reqid.Get(r.Context()), "error", err) }
 }
 
 func redirectToLoginWithError(w http.ResponseWriter, r *http.Request, challenge *MfaChallenge, errorMsg string) {
-	params := url.Values{}
-	params.Set("response_type", "code")
-	params.Set("error", errorMsg)
-	if challenge != nil {
-		var loginState LoginState
-		if err := json.Unmarshal([]byte(challenge.LoginState), &loginState); err == nil {
-			params.Set("client_id", loginState.ClientID)
-			params.Set("redirect_uri", loginState.RedirectURI)
-			params.Set("state", loginState.State)
-			params.Set("scope", loginState.Scope)
-			if loginState.Nonce != "" { params.Set("nonce", loginState.Nonce) }
-			if loginState.CodeChallenge != "" { params.Set("code_challenge", loginState.CodeChallenge); params.Set("code_challenge_method", loginState.CodeChallengeMethod) }
-		}
-	}
-	redirectURL := config.GetBootstrap().AppOAuthPath + "/authorize?" + params.Encode()
-	http.Redirect(w, r, redirectURL, http.StatusFound)
+	params := url.Values{}; params.Set("response_type", "code"); params.Set("error", errorMsg)
+	if challenge != nil { var loginState LoginState; if err := json.Unmarshal([]byte(challenge.LoginState), &loginState); err == nil { params.Set("client_id", loginState.ClientID); params.Set("redirect_uri", loginState.RedirectURI); params.Set("state", loginState.State); params.Set("scope", loginState.Scope); if loginState.Nonce != "" { params.Set("nonce", loginState.Nonce) }; if loginState.CodeChallenge != "" { params.Set("code_challenge", loginState.CodeChallenge); params.Set("code_challenge_method", loginState.CodeChallengeMethod) } } }
+	redirectURL := config.GetBootstrap().AppOAuthPath + "/authorize?" + params.Encode(); http.Redirect(w, r, redirectURL, http.StatusFound)
 }

--- a/pkg/mfa/handler.go
+++ b/pkg/mfa/handler.go
@@ -3,7 +3,6 @@ package mfa
 import (
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"html/template"
 	"log/slog"
 	"net/http"
@@ -26,6 +25,20 @@ import (
 	qrcode "github.com/skip2/go-qrcode"
 )
 
+// HandleMfa handles multi-factor authentication requests.
+// CSRF-protected form — not included in public API docs.
+//
+// Methods: GET, POST
+// Route: /oauth2/mfa
+// Accept: x-www-form-urlencoded
+// Produce: html
+// Param challenge_id query string false "MFA challenge ID (GET)"
+// Param challenge_id formData string false "MFA challenge ID (POST)"
+// Param code formData string false "Verification code (POST)"
+// Param totp_secret formData string false "TOTP secret for enrollment (POST)"
+// Param trust_device formData string false "Whether to trust the device (POST)"
+// Success 200 "MFA form (GET)"
+// Success 302 "Redirect back to client with code after success (POST)"
 func HandleMfa(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
@@ -39,128 +52,422 @@ func HandleMfa(w http.ResponseWriter, r *http.Request) {
 
 func handleMfaGet(w http.ResponseWriter, r *http.Request) {
 	challengeID := r.URL.Query().Get("challenge_id")
-	if challengeID == "" { utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Missing challenge_id"); return }
+	if challengeID == "" {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "invalid_request", "Missing challenge_id")
+		return
+	}
+
 	challenge, err := MfaChallengeByIDIncludingExpired(challengeID)
-	if err != nil { redirectToLoginWithError(w, r, nil, "Verification session not found. Please log in again."); return }
-	if challenge.Used || time.Now().After(challenge.ExpiresAt) { redirectToLoginWithError(w, r, challenge, "Verification session has expired. Please log in again."); return }
+	if err != nil {
+		redirectToLoginWithError(w, r, nil, "Verification session not found. Please log in again.")
+		return
+	}
+
+	if challenge.Used || time.Now().After(challenge.ExpiresAt) {
+		redirectToLoginWithError(w, r, challenge, "Verification session has expired. Please log in again.")
+		return
+	}
+
 	cfg := config.Get()
-	if handleMethodSwitch(w, r, challenge, cfg) { return }
+
+	if handleMethodSwitch(w, r, challenge, cfg) {
+		return
+	}
+
 	if challenge.Method == "totp" {
 		usr, err := user.UserByID(challenge.UserID)
-		if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
+		if err != nil {
+			slog.Error("mfa: failed to get user for TOTP challenge", "request_id", reqid.Get(r.Context()), "error", err)
+			redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
+			return
+		}
+
 		if !usr.TotpVerified {
-			if cfg.MfaMethod != "totp" { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
-			renderEnrollPage(w, r, challenge, usr, cfg, ""); return
+			if cfg.MfaMethod != "totp" {
+				slog.Warn("mfa: TOTP challenge for unenrolled user with mfa_method!=totp",
+					"request_id", reqid.Get(r.Context()), "user_id", challenge.UserID, "mfa_method", cfg.MfaMethod)
+				redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
+				return
+			}
+			renderEnrollPage(w, r, challenge, usr, cfg, "")
+			return
 		}
 	}
+
 	if challenge.Method == "email" {
 		usr, err := user.UserByID(challenge.UserID)
-		if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
+		if err != nil {
+			slog.Error("mfa: failed to get user for email OTP challenge", "request_id", reqid.Get(r.Context()), "error", err)
+			redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
+			return
+		}
 		isResend := challenge.OtpSentAt != nil
 		const otpCooldown = 60 * time.Second
-		if isResend && time.Since(*challenge.OtpSentAt) < otpCooldown { renderVerifyPage(w, r, challenge, cfg, "", "Code was already sent. Please check your email."); return }
+		if isResend && time.Since(*challenge.OtpSentAt) < otpCooldown {
+			renderVerifyPage(w, r, challenge, cfg, "", "Code was already sent. Please check your email.")
+			return
+		}
 		otp, err := GenerateEmailOTP()
-		if err != nil { renderVerifyPage(w, r, challenge, cfg, "Failed to generate verification code. Please try again.", ""); return }
+		if err != nil {
+			slog.Error("mfa: failed to generate email OTP", "request_id", reqid.Get(r.Context()), "error", err)
+			renderVerifyPage(w, r, challenge, cfg, "Failed to generate verification code. Please try again.", "")
+			return
+		}
 		hashedOTP := utils.HashSHA256(otp)
 		challenge.Code = hashedOTP
-		if err := UpdateChallengeCode(challenge.ID, hashedOTP); err != nil { renderVerifyPage(w, r, challenge, cfg, "Failed to prepare verification code. Please try again.", ""); return }
-		if err := email.SendEmailOTP(usr.Email, otp); err != nil { renderVerifyPage(w, r, challenge, cfg, "Failed to send verification code. Please try again.", ""); return }
-		if isResend { renderVerifyPage(w, r, challenge, cfg, "", "A new code has been sent to your email"); return }
+		_ = UpdateChallengeCode(challenge.ID, hashedOTP)
+		if err := email.SendEmailOTP(usr.Email, otp); err != nil {
+			slog.Error("mfa: failed to send verification email", "request_id", reqid.Get(r.Context()), "error", err)
+			renderVerifyPage(w, r, challenge, cfg, "Failed to send verification code. Please try again.", "")
+			return
+		}
+		if isResend {
+			renderVerifyPage(w, r, challenge, cfg, "", "A new code has been sent to your email")
+			return
+		}
 	}
+
 	renderVerifyPage(w, r, challenge, cfg, "", "")
 }
 
 func handleMfaPost(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil { redirectToLoginWithError(w, r, nil, "Invalid request. Please log in again."); return }
-	challengeID, code, totpSecret := r.FormValue("challenge_id"), r.FormValue("code"), r.FormValue("totp_secret")
-	if challengeID == "" || code == "" { redirectToLoginWithError(w, r, nil, "Invalid request. Please log in again."); return }
+	if err := r.ParseForm(); err != nil {
+		redirectToLoginWithError(w, r, nil, "Invalid request. Please log in again.")
+		return
+	}
+
+	challengeID := r.FormValue("challenge_id")
+	code := r.FormValue("code")
+	totpSecret := r.FormValue("totp_secret")
+
+	if challengeID == "" || code == "" {
+		redirectToLoginWithError(w, r, nil, "Invalid request. Please log in again.")
+		return
+	}
+
 	challenge, err := MfaChallengeByIDIncludingExpired(challengeID)
-	if err != nil { redirectToLoginWithError(w, r, nil, "Verification session not found. Please log in again."); return }
-	if challenge.Used || time.Now().After(challenge.ExpiresAt) { redirectToLoginWithError(w, r, challenge, "Verification session has expired. Please log in again."); return }
+	if err != nil {
+		redirectToLoginWithError(w, r, nil, "Verification session not found. Please log in again.")
+		return
+	}
+
+	if challenge.Used || time.Now().After(challenge.ExpiresAt) {
+		redirectToLoginWithError(w, r, challenge, "Verification session has expired. Please log in again.")
+		return
+	}
+
 	cfg := config.Get()
+
 	usr, err := user.UserByID(challenge.UserID)
-	if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
+	if err != nil {
+		slog.Error("mfa: failed to get user for verification", "request_id", reqid.Get(r.Context()), "error", err)
+		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
+		return
+	}
+
 	switch challenge.Method {
 	case "totp":
 		if !usr.TotpVerified {
-			if totpSecret == "" { renderEnrollPage(w, r, challenge, usr, cfg, "Missing TOTP secret"); return }
-			if !ValidateTotpCode(totpSecret, code) { audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "totp", "phase", "enrollment"), utils.GetClientIP(r)); renderEnrollPage(w, r, challenge, usr, cfg, "Invalid verification code"); return }
-			if err := user.SaveTotpSecret(usr.ID, totpSecret); err != nil { renderEnrollPage(w, r, challenge, usr, cfg, "Failed to save authenticator. Please try again."); return }
+			if totpSecret == "" {
+				renderEnrollPage(w, r, challenge, usr, cfg, "Missing TOTP secret")
+				return
+			}
+			if !ValidateTotpCode(totpSecret, code) {
+				slog.Warn("mfa: invalid TOTP code during enrollment", "request_id", reqid.Get(r.Context()), "ip", utils.GetClientIP(r))
+				audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "totp", "phase", "enrollment"), utils.GetClientIP(r))
+				renderEnrollPage(w, r, challenge, usr, cfg, "Invalid verification code")
+				return
+			}
+			if err := user.SaveTotpSecret(usr.ID, totpSecret); err != nil {
+				slog.Error("mfa: failed to save TOTP secret", "request_id", reqid.Get(r.Context()), "error", err)
+				renderEnrollPage(w, r, challenge, usr, cfg, "Failed to save authenticator. Please try again.")
+				return
+			}
 			audit.Log(audit.EventMfaEnrolled, usr, audit.TargetUser, usr.ID, audit.Detail("method", "totp"), utils.GetClientIP(r))
-		} else if !ValidateTotpCode(usr.TotpSecret, code) {
-			_ = IncrementFailedAttempts(challenge.ID); audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "totp"), utils.GetClientIP(r))
-			if challenge.FailedAttempts+1 >= 5 { _ = MarkChallengeUsed(challenge.ID); redirectToLoginWithError(w, r, challenge, "Too many failed attempts. Please log in again."); return }
-			renderVerifyPage(w, r, challenge, cfg, "Invalid verification code", ""); return
+		} else {
+			if !ValidateTotpCode(usr.TotpSecret, code) {
+				_ = IncrementFailedAttempts(challenge.ID)
+				slog.Warn("mfa: invalid TOTP verification code", "request_id", reqid.Get(r.Context()), "ip", utils.GetClientIP(r), "attempts", challenge.FailedAttempts+1)
+				audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "totp"), utils.GetClientIP(r))
+				if challenge.FailedAttempts+1 >= 5 {
+					_ = MarkChallengeUsed(challenge.ID)
+					redirectToLoginWithError(w, r, challenge, "Too many failed attempts. Please log in again.")
+					return
+				}
+				renderVerifyPage(w, r, challenge, cfg, "Invalid verification code", "")
+				return
+			}
 		}
 	case "email":
-		if utils.HashSHA256(code) != challenge.Code {
-			_ = IncrementFailedAttempts(challenge.ID); audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "email"), utils.GetClientIP(r))
-			if challenge.FailedAttempts+1 >= 5 { _ = MarkChallengeUsed(challenge.ID); redirectToLoginWithError(w, r, challenge, "Too many failed attempts. Please log in again."); return }
-			renderVerifyPage(w, r, challenge, cfg, "Invalid verification code", ""); return
+		hashedCode := utils.HashSHA256(code)
+		if hashedCode != challenge.Code {
+			_ = IncrementFailedAttempts(challenge.ID)
+			slog.Warn("mfa: invalid email OTP code", "request_id", reqid.Get(r.Context()), "ip", utils.GetClientIP(r), "attempts", challenge.FailedAttempts+1)
+			audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "email"), utils.GetClientIP(r))
+			if challenge.FailedAttempts+1 >= 5 {
+				_ = MarkChallengeUsed(challenge.ID)
+				redirectToLoginWithError(w, r, challenge, "Too many failed attempts. Please log in again.")
+				return
+			}
+			renderVerifyPage(w, r, challenge, cfg, "Invalid verification code", "")
+			return
 		}
 	default:
-		redirectToLoginWithError(w, r, challenge, "Unknown authentication method. Please log in again."); return
+		redirectToLoginWithError(w, r, challenge, "Unknown authentication method. Please log in again.")
+		return
 	}
 
+	// Save trusted device if requested
 	if cfg.TrustDeviceEnabled && r.FormValue("trust_device") == "on" {
 		deviceID, genErr := authcode.GenerateSecureCode()
-		if genErr == nil { ua := r.UserAgent(); if len(ua) > 200 { ua = ua[:200] }; dev := trusteddevice.TrustedDevice{ID: deviceID, UserID: usr.ID, DeviceName: ua, ExpiresAt: time.Now().Add(cfg.TrustDeviceExpiration)}; if trusteddevice.CreateTrustedDevice(dev) == nil { trusteddevice.SetCookie(w, deviceID, cfg.TrustDeviceExpiration) } }
+		if genErr == nil {
+			ua := r.UserAgent()
+			if len(ua) > 200 {
+				ua = ua[:200]
+			}
+			dev := trusteddevice.TrustedDevice{
+				ID:         deviceID,
+				UserID:     usr.ID,
+				DeviceName: ua,
+				ExpiresAt:  time.Now().Add(cfg.TrustDeviceExpiration),
+			}
+			if trusteddevice.CreateTrustedDevice(dev) == nil {
+				trusteddevice.SetCookie(w, deviceID, cfg.TrustDeviceExpiration)
+			}
+		}
 	}
+
+	// Restore login state and complete the OAuth flow
 	var loginState LoginState
-	if err := json.Unmarshal([]byte(challenge.LoginState), &loginState); err != nil { slog.Error("mfa: failed to restore login state", "request_id", reqid.Get(r.Context()), "error", err); redirectToLoginWithError(w, r, challenge, "Session expired. Please log in again."); return }
+	if err := json.Unmarshal([]byte(challenge.LoginState), &loginState); err != nil {
+		slog.Error("mfa: failed to restore login state", "request_id", reqid.Get(r.Context()), "error", err)
+		redirectToLoginWithError(w, r, challenge, "Session expired. Please log in again.")
+		return
+	}
+
 	idpSessionID := idpsession.FinalizeLogin(w, r, usr.ID)
+
+	// OIDC Core §3.1.2.4: check if consent is needed before issuing auth code
 	registeredClient, clientErr := client.ClientByClientID(loginState.ClientID)
 	if clientErr == nil && consent.NeedsConsent(registeredClient.ConsentRequired, usr.ID, loginState.ClientID, loginState.Scope, loginState.Prompt) {
-		consent.RedirectToConsent(w, r, consent.ConsentParams{RedirectURI: loginState.RedirectURI, State: loginState.State, ClientID: loginState.ClientID, Scope: loginState.Scope, Nonce: loginState.Nonce, CodeChallenge: loginState.CodeChallenge, CodeChallengeMethod: loginState.CodeChallengeMethod, Prompt: loginState.Prompt}); return
+		consent.RedirectToConsent(w, r, consent.ConsentParams{
+			RedirectURI:         loginState.RedirectURI,
+			State:               loginState.State,
+			ClientID:            loginState.ClientID,
+			Scope:               loginState.Scope,
+			Nonce:               loginState.Nonce,
+			CodeChallenge:       loginState.CodeChallenge,
+			CodeChallengeMethod: loginState.CodeChallengeMethod,
+			Prompt:              loginState.Prompt,
+		})
+		return
 	}
+
 	authorizationCode, err := authcode.GenerateSecureCode()
-	if err != nil { slog.Error("mfa: failed to generate authorization code", "request_id", reqid.Get(r.Context()), "error", err); redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
-	ac := authcode.AuthCode{Code: authorizationCode, UserID: usr.ID, ClientID: loginState.ClientID, RedirectURI: loginState.RedirectURI, Scope: loginState.Scope, Nonce: loginState.Nonce, CodeChallenge: loginState.CodeChallenge, CodeChallengeMethod: loginState.CodeChallengeMethod, ExpiresAt: time.Now().Add(cfg.AuthAuthorizationCodeExpiration), Used: false, IdpSessionID: idpSessionID}
-	if err := authcode.CreateAuthCode(ac); err != nil { slog.Error("mfa: failed to create authorization code", "request_id", reqid.Get(r.Context()), "error", err); redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
+	if err != nil {
+		slog.Error("mfa: failed to generate authorization code", "request_id", reqid.Get(r.Context()), "error", err)
+		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
+		return
+	}
+
+	ac := authcode.AuthCode{
+		Code:                authorizationCode,
+		UserID:              usr.ID,
+		ClientID:            loginState.ClientID,
+		RedirectURI:         loginState.RedirectURI,
+		Scope:               loginState.Scope,
+		Nonce:               loginState.Nonce,
+		CodeChallenge:       loginState.CodeChallenge,
+		CodeChallengeMethod: loginState.CodeChallengeMethod,
+		ExpiresAt:            time.Now().Add(cfg.AuthAuthorizationCodeExpiration),
+		Used:                false,
+		IdpSessionID:        idpSessionID,
+	}
+
+	if err := authcode.CreateAuthCode(ac); err != nil {
+		slog.Error("mfa: failed to create authorization code", "request_id", reqid.Get(r.Context()), "error", err)
+		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
+		return
+	}
+
+	// Consume the MFA challenge only after the authorization code has been
+	// durably created. This prevents failures after MFA verification from
+	// turning a still-valid challenge into a misleading expired state.
 	if err := MarkChallengeUsed(challenge.ID); err != nil {
 		slog.Error("mfa: failed to mark challenge used after auth code creation", "request_id", reqid.Get(r.Context()), "challenge_id", challenge.ID, "error", err)
-		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return
+		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
+		return
 	}
+
 	audit.Log(audit.EventMfaSuccess, usr, audit.TargetUser, usr.ID, audit.Detail("method", challenge.Method), utils.GetClientIP(r))
-	params := url.Values{}; params.Set("code", ac.Code); if loginState.State != "" { params.Set("state", loginState.State) }
+
+	// Encode the authorization response using net/url rather than string
+	// concatenation. This preserves state exactly even when it contains URL
+	// reserved characters.
+	params := url.Values{}
+	params.Set("code", ac.Code)
+	if loginState.State != "" {
+		params.Set("state", loginState.State)
+	}
 	redirectURL := loginState.RedirectURI + "?" + params.Encode()
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
 func handleMethodSwitch(w http.ResponseWriter, r *http.Request, challenge *MfaChallenge, cfg *config.Config) bool {
 	switchTo := r.URL.Query().Get("switch_to")
-	if switchTo == "" || cfg.MfaMethod != "both" || cfg.SmtpHost == "" { return false }
+	if switchTo == "" || cfg.MfaMethod != "both" || cfg.SmtpHost == "" {
+		return false
+	}
+
 	switched := false
-	switch switchTo { case "totp": if challenge.Method != "totp" { usr, err := user.UserByID(challenge.UserID); if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return true }; if usr.TotpVerified { switched = true } }; case "email": if challenge.Method != "email" { switched = true } }
-	if !switched { return false }
-	if err := MarkChallengeUsed(challenge.ID); err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return true }
-	newChallengeID, err := authcode.GenerateSecureCode(); if err != nil { renderVerifyPage(w, r, challenge, cfg, "Something went wrong. Please try again.", ""); return true }
-	newChallenge := MfaChallenge{ID: newChallengeID, UserID: challenge.UserID, Method: switchTo, LoginState: challenge.LoginState, ExpiresAt: challenge.ExpiresAt}
-	if err := CreateMfaChallenge(newChallenge); err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return true }
-	mfaURL := fmt.Sprintf("%s/mfa?challenge_id=%s", config.GetBootstrap().AppOAuthPath, newChallengeID)
-	http.Redirect(w, r, mfaURL, http.StatusFound); return true
+	switch switchTo {
+	case "totp":
+		if challenge.Method != "totp" {
+			usr, err := user.UserByID(challenge.UserID)
+			if err != nil {
+				slog.Error("mfa: failed to get user for method switch", "request_id", reqid.Get(r.Context()), "error", err)
+				redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
+				return true
+			}
+			if usr.TotpVerified {
+				switched = true
+			}
+		}
+	case "email":
+		if challenge.Method != "email" {
+			switched = true
+		}
+	}
+
+	if !switched {
+		return false
+	}
+
+	if err := MarkChallengeUsed(challenge.ID); err != nil {
+		slog.Error("mfa: failed to mark old challenge as used during switch", "request_id", reqid.Get(r.Context()), "error", err)
+		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
+		return true
+	}
+	newChallengeID, err := authcode.GenerateSecureCode()
+	if err != nil {
+		slog.Error("mfa: failed to generate challenge ID for switch", "request_id", reqid.Get(r.Context()), "error", err)
+		renderVerifyPage(w, r, challenge, cfg, "Something went wrong. Please try again.", "")
+		return true
+	}
+	newChallenge := MfaChallenge{
+		ID:         newChallengeID,
+		UserID:     challenge.UserID,
+		Method:     switchTo,
+		LoginState: challenge.LoginState,
+		ExpiresAt:  challenge.ExpiresAt,
+	}
+	if err := CreateMfaChallenge(newChallenge); err != nil {
+		slog.Error("mfa: failed to create switched challenge", "request_id", reqid.Get(r.Context()), "error", err)
+		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
+		return true
+	}
+	mfaURL := config.GetBootstrap().AppOAuthPath + "/mfa?challenge_id=" + newChallengeID
+	http.Redirect(w, r, mfaURL, http.StatusFound)
+	return true
 }
 
 func renderVerifyPage(w http.ResponseWriter, r *http.Request, challenge *MfaChallenge, cfg *config.Config, errorMsg string, infoMsg string) {
 	tmpl, err := view.ParseTemplate("mfa")
-	if err != nil { slog.Error("mfa: failed to parse verify template", "request_id", reqid.Get(r.Context()), "error", err); http.Error(w, "Internal Server Error", http.StatusInternalServerError); return }
-	canSwitch := cfg.MfaMethod == "both" && cfg.SmtpHost != ""; userTotpVerified := false
-	if canSwitch { if usr, err := user.UserByID(challenge.UserID); err == nil { userTotpVerified = usr.TotpVerified } }
-	data := map[string]any{"ChallengeID": challenge.ID, "Method": challenge.Method, "Message": infoMsg, "Error": errorMsg, csrf.TemplateTag: csrf.TemplateField(r), "ThemeTitle": cfg.Theme.Title, "ThemeLogoUrl": cfg.Theme.LogoUrl, "TrustDeviceEnabled": cfg.TrustDeviceEnabled, "TrustDeviceDays": int(cfg.TrustDeviceExpiration.Hours()/24), "CanSwitch": canSwitch, "UserTotpVerified": userTotpVerified}
-	view.InjectNonce(r, data); if err := tmpl.ExecuteTemplate(w, "layout", data); err != nil { slog.Error("mfa: failed to execute verify template", "request_id", reqid.Get(r.Context()), "error", err) }
+	if err != nil {
+		slog.Error("mfa: failed to parse verify template", "request_id", reqid.Get(r.Context()), "error", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	canSwitch := cfg.MfaMethod == "both" && cfg.SmtpHost != ""
+	userTotpVerified := false
+	if canSwitch {
+		if usr, err := user.UserByID(challenge.UserID); err == nil {
+			userTotpVerified = usr.TotpVerified
+		}
+	}
+
+	data := map[string]any{
+		"ChallengeID":        challenge.ID,
+		"Method":             challenge.Method,
+		"Message":            infoMsg,
+		"Error":              errorMsg,
+		csrf.TemplateTag:      csrf.TemplateField(r),
+		"ThemeTitle":         cfg.Theme.Title,
+		"ThemeLogoUrl":       cfg.Theme.LogoUrl,
+		"TrustDeviceEnabled": cfg.TrustDeviceEnabled,
+		"TrustDeviceDays":    int(cfg.TrustDeviceExpiration.Hours() / 24),
+		"CanSwitch":          canSwitch,
+		"UserTotpVerified":   userTotpVerified,
+	}
+	view.InjectNonce(r, data)
+
+	if err := tmpl.ExecuteTemplate(w, "layout", data); err != nil {
+		slog.Error("mfa: failed to execute verify template", "request_id", reqid.Get(r.Context()), "error", err)
+	}
 }
 
 func renderEnrollPage(w http.ResponseWriter, r *http.Request, challenge *MfaChallenge, usr *user.User, cfg *config.Config, errorMsg string) {
-	secret, otpauthURL, err := GenerateTotpSecret(usr.Username, cfg.Theme.Title); if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
-	png, err := qrcode.Encode(otpauthURL, qrcode.Medium, 200); if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
+	secret, otpauthURL, err := GenerateTotpSecret(usr.Username, cfg.Theme.Title)
+	if err != nil {
+		slog.Error("mfa: failed to generate TOTP secret", "request_id", reqid.Get(r.Context()), "error", err)
+		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
+		return
+	}
+
+	png, err := qrcode.Encode(otpauthURL, qrcode.Medium, 200)
+	if err != nil {
+		slog.Error("mfa: failed to generate QR code", "request_id", reqid.Get(r.Context()), "error", err)
+		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
+		return
+	}
 	qrDataURI := "data:image/png;base64," + base64.StdEncoding.EncodeToString(png)
-	tmpl, err := view.ParseTemplate("mfa_enroll"); if err != nil { http.Error(w, "Internal Server Error", http.StatusInternalServerError); return }
-	data := map[string]any{"ChallengeID": challenge.ID, "TotpSecret": secret, "QRCodeDataURI": template.URL(qrDataURI), "Error": errorMsg, csrf.TemplateTag: csrf.TemplateField(r), "ThemeTitle": cfg.Theme.Title, "ThemeLogoUrl": cfg.Theme.LogoUrl}
-	view.InjectNonce(r, data); if err := tmpl.ExecuteTemplate(w, "layout", data); err != nil { slog.Error("mfa: failed to execute enroll template", "request_id", reqid.Get(r.Context()), "error", err) }
+
+	tmpl, err := view.ParseTemplate("mfa_enroll")
+	if err != nil {
+		slog.Error("mfa: failed to parse enroll template", "request_id", reqid.Get(r.Context()), "error", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	data := map[string]any{
+		"ChallengeID":    challenge.ID,
+		"TotpSecret":     secret,
+		"QRCodeDataURI":  template.URL(qrDataURI),
+		"Error":          errorMsg,
+		csrf.TemplateTag:  csrf.TemplateField(r),
+		"ThemeTitle":     cfg.Theme.Title,
+		"ThemeLogoUrl":   cfg.Theme.LogoUrl,
+	}
+	view.InjectNonce(r, data)
+
+	if err := tmpl.ExecuteTemplate(w, "layout", data); err != nil {
+		slog.Error("mfa: failed to execute enroll template", "request_id", reqid.Get(r.Context()), "error", err)
+	}
 }
 
 func redirectToLoginWithError(w http.ResponseWriter, r *http.Request, challenge *MfaChallenge, errorMsg string) {
-	params := url.Values{}; params.Set("response_type", "code"); params.Set("error", errorMsg)
-	if challenge != nil { var loginState LoginState; if err := json.Unmarshal([]byte(challenge.LoginState), &loginState); err == nil { params.Set("client_id", loginState.ClientID); params.Set("redirect_uri", loginState.RedirectURI); params.Set("state", loginState.State); params.Set("scope", loginState.Scope); if loginState.Nonce != "" { params.Set("nonce", loginState.Nonce) }; if loginState.CodeChallenge != "" { params.Set("code_challenge", loginState.CodeChallenge); params.Set("code_challenge_method", loginState.CodeChallengeMethod) } } }
-	redirectURL := config.GetBootstrap().AppOAuthPath + "/authorize?" + params.Encode(); http.Redirect(w, r, redirectURL, http.StatusFound)
+	params := url.Values{}
+	params.Set("response_type", "code")
+	params.Set("error", errorMsg)
+
+	if challenge != nil {
+		var loginState LoginState
+		if err := json.Unmarshal([]byte(challenge.LoginState), &loginState); err == nil {
+			params.Set("client_id", loginState.ClientID)
+			params.Set("redirect_uri", loginState.RedirectURI)
+			params.Set("state", loginState.State)
+			params.Set("scope", loginState.Scope)
+			if loginState.Nonce != "" {
+				params.Set("nonce", loginState.Nonce)
+			}
+			if loginState.CodeChallenge != "" {
+				params.Set("code_challenge", loginState.CodeChallenge)
+				params.Set("code_challenge_method", loginState.CodeChallengeMethod)
+			}
+		}
+	}
+
+	redirectURL := config.GetBootstrap().AppOAuthPath + "/authorize?" + params.Encode()
+	http.Redirect(w, r, redirectURL, http.StatusFound)
 }

--- a/pkg/mfa/handler.go
+++ b/pkg/mfa/handler.go
@@ -26,20 +26,6 @@ import (
 	qrcode "github.com/skip2/go-qrcode"
 )
 
-// HandleMfa handles multi-factor authentication requests.
-// CSRF-protected form — not included in public API docs.
-//
-// Methods: GET, POST
-// Route: /oauth2/mfa
-// Accept: x-www-form-urlencoded
-// Produce: html
-// Param challenge_id query string false "MFA challenge ID (GET)"
-// Param challenge_id formData string false "MFA challenge ID (POST)"
-// Param code formData string false "Verification code (POST)"
-// Param totp_secret formData string false "TOTP secret for enrollment (POST)"
-// Param trust_device formData string false "Whether to trust the device (POST)"
-// Success 200 "MFA form (GET)"
-// Success 302 "Redirect back to client with code after success (POST)"
 func HandleMfa(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
@@ -63,14 +49,12 @@ func handleMfaGet(w http.ResponseWriter, r *http.Request) {
 		redirectToLoginWithError(w, r, nil, "Verification session not found. Please log in again.")
 		return
 	}
-
 	if challenge.Used || time.Now().After(challenge.ExpiresAt) {
 		redirectToLoginWithError(w, r, challenge, "Verification session has expired. Please log in again.")
 		return
 	}
 
 	cfg := config.Get()
-
 	if handleMethodSwitch(w, r, challenge, cfg) {
 		return
 	}
@@ -82,11 +66,8 @@ func handleMfaGet(w http.ResponseWriter, r *http.Request) {
 			redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
 			return
 		}
-
 		if !usr.TotpVerified {
 			if cfg.MfaMethod != "totp" {
-				slog.Warn("mfa: TOTP challenge for unenrolled user with mfa_method!=totp",
-					"request_id", reqid.Get(r.Context()), "user_id", challenge.UserID, "mfa_method", cfg.MfaMethod)
 				redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
 				return
 			}
@@ -98,7 +79,6 @@ func handleMfaGet(w http.ResponseWriter, r *http.Request) {
 	if challenge.Method == "email" {
 		usr, err := user.UserByID(challenge.UserID)
 		if err != nil {
-			slog.Error("mfa: failed to get user for email OTP challenge", "request_id", reqid.Get(r.Context()), "error", err)
 			redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
 			return
 		}
@@ -110,15 +90,17 @@ func handleMfaGet(w http.ResponseWriter, r *http.Request) {
 		}
 		otp, err := GenerateEmailOTP()
 		if err != nil {
-			slog.Error("mfa: failed to generate email OTP", "request_id", reqid.Get(r.Context()), "error", err)
 			renderVerifyPage(w, r, challenge, cfg, "Failed to generate verification code. Please try again.", "")
 			return
 		}
 		hashedOTP := utils.HashSHA256(otp)
 		challenge.Code = hashedOTP
-		_ = UpdateChallengeCode(challenge.ID, hashedOTP)
+		if err := UpdateChallengeCode(challenge.ID, hashedOTP); err != nil {
+			slog.Error("mfa: failed to update email OTP", "request_id", reqid.Get(r.Context()), "error", err)
+			renderVerifyPage(w, r, challenge, cfg, "Failed to prepare verification code. Please try again.", "")
+			return
+		}
 		if err := email.SendEmailOTP(usr.Email, otp); err != nil {
-			slog.Error("mfa: failed to send verification email", "request_id", reqid.Get(r.Context()), "error", err)
 			renderVerifyPage(w, r, challenge, cfg, "Failed to send verification code. Please try again.", "")
 			return
 		}
@@ -127,7 +109,6 @@ func handleMfaGet(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-
 	renderVerifyPage(w, r, challenge, cfg, "", "")
 }
 
@@ -136,11 +117,9 @@ func handleMfaPost(w http.ResponseWriter, r *http.Request) {
 		redirectToLoginWithError(w, r, nil, "Invalid request. Please log in again.")
 		return
 	}
-
 	challengeID := r.FormValue("challenge_id")
 	code := r.FormValue("code")
 	totpSecret := r.FormValue("totp_secret")
-
 	if challengeID == "" || code == "" {
 		redirectToLoginWithError(w, r, nil, "Invalid request. Please log in again.")
 		return
@@ -151,17 +130,14 @@ func handleMfaPost(w http.ResponseWriter, r *http.Request) {
 		redirectToLoginWithError(w, r, nil, "Verification session not found. Please log in again.")
 		return
 	}
-
 	if challenge.Used || time.Now().After(challenge.ExpiresAt) {
 		redirectToLoginWithError(w, r, challenge, "Verification session has expired. Please log in again.")
 		return
 	}
 
 	cfg := config.Get()
-
 	usr, err := user.UserByID(challenge.UserID)
 	if err != nil {
-		slog.Error("mfa: failed to get user for verification", "request_id", reqid.Get(r.Context()), "error", err)
 		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
 		return
 	}
@@ -169,43 +145,34 @@ func handleMfaPost(w http.ResponseWriter, r *http.Request) {
 	switch challenge.Method {
 	case "totp":
 		if !usr.TotpVerified {
-			// Enrollment flow: validate against the secret from the form
 			if totpSecret == "" {
 				renderEnrollPage(w, r, challenge, usr, cfg, "Missing TOTP secret")
 				return
 			}
 			if !ValidateTotpCode(totpSecret, code) {
-				slog.Warn("mfa: invalid TOTP code during enrollment", "request_id", reqid.Get(r.Context()), "ip", utils.GetClientIP(r))
 				audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "totp", "phase", "enrollment"), utils.GetClientIP(r))
 				renderEnrollPage(w, r, challenge, usr, cfg, "Invalid verification code")
 				return
 			}
 			if err := user.SaveTotpSecret(usr.ID, totpSecret); err != nil {
-				slog.Error("mfa: failed to save TOTP secret", "request_id", reqid.Get(r.Context()), "error", err)
 				renderEnrollPage(w, r, challenge, usr, cfg, "Failed to save authenticator. Please try again.")
 				return
 			}
 			audit.Log(audit.EventMfaEnrolled, usr, audit.TargetUser, usr.ID, audit.Detail("method", "totp"), utils.GetClientIP(r))
-		} else {
-			// Verification flow: validate against stored secret
-			if !ValidateTotpCode(usr.TotpSecret, code) {
-				_ = IncrementFailedAttempts(challenge.ID)
-				slog.Warn("mfa: invalid TOTP verification code", "request_id", reqid.Get(r.Context()), "ip", utils.GetClientIP(r), "attempts", challenge.FailedAttempts+1)
-				audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "totp"), utils.GetClientIP(r))
-				if challenge.FailedAttempts+1 >= 5 {
-					_ = MarkChallengeUsed(challenge.ID)
-					redirectToLoginWithError(w, r, challenge, "Too many failed attempts. Please log in again.")
-					return
-				}
-				renderVerifyPage(w, r, challenge, cfg, "Invalid verification code", "")
+		} else if !ValidateTotpCode(usr.TotpSecret, code) {
+			_ = IncrementFailedAttempts(challenge.ID)
+			audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "totp"), utils.GetClientIP(r))
+			if challenge.FailedAttempts+1 >= 5 {
+				_ = MarkChallengeUsed(challenge.ID)
+				redirectToLoginWithError(w, r, challenge, "Too many failed attempts. Please log in again.")
 				return
 			}
+			renderVerifyPage(w, r, challenge, cfg, "Invalid verification code", "")
+			return
 		}
 	case "email":
-		hashedCode := utils.HashSHA256(code)
-		if hashedCode != challenge.Code {
+		if utils.HashSHA256(code) != challenge.Code {
 			_ = IncrementFailedAttempts(challenge.ID)
-			slog.Warn("mfa: invalid email OTP code", "request_id", reqid.Get(r.Context()), "ip", utils.GetClientIP(r), "attempts", challenge.FailedAttempts+1)
 			audit.Log(audit.EventMfaFailed, usr, audit.TargetUser, usr.ID, audit.Detail("method", "email"), utils.GetClientIP(r))
 			if challenge.FailedAttempts+1 >= 5 {
 				_ = MarkChallengeUsed(challenge.ID)
@@ -220,10 +187,6 @@ func handleMfaPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = MarkChallengeUsed(challenge.ID)
-	audit.Log(audit.EventMfaSuccess, usr, audit.TargetUser, usr.ID, audit.Detail("method", challenge.Method), utils.GetClientIP(r))
-
-	// Save trusted device if requested
 	if cfg.TrustDeviceEnabled && r.FormValue("trust_device") == "on" {
 		deviceID, genErr := authcode.GenerateSecureCode()
 		if genErr == nil {
@@ -231,19 +194,13 @@ func handleMfaPost(w http.ResponseWriter, r *http.Request) {
 			if len(ua) > 200 {
 				ua = ua[:200]
 			}
-			dev := trusteddevice.TrustedDevice{
-				ID:         deviceID,
-				UserID:     usr.ID,
-				DeviceName: ua,
-				ExpiresAt:  time.Now().Add(cfg.TrustDeviceExpiration),
-			}
+			dev := trusteddevice.TrustedDevice{ID: deviceID, UserID: usr.ID, DeviceName: ua, ExpiresAt: time.Now().Add(cfg.TrustDeviceExpiration)}
 			if trusteddevice.CreateTrustedDevice(dev) == nil {
 				trusteddevice.SetCookie(w, deviceID, cfg.TrustDeviceExpiration)
 			}
 		}
 	}
 
-	// Restore login state and complete the OAuth flow
 	var loginState LoginState
 	if err := json.Unmarshal([]byte(challenge.LoginState), &loginState); err != nil {
 		slog.Error("mfa: failed to restore login state", "request_id", reqid.Get(r.Context()), "error", err)
@@ -252,19 +209,12 @@ func handleMfaPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	idpSessionID := idpsession.FinalizeLogin(w, r, usr.ID)
-
-	// OIDC Core §3.1.2.4: check if consent is needed before issuing auth code
 	registeredClient, clientErr := client.ClientByClientID(loginState.ClientID)
 	if clientErr == nil && consent.NeedsConsent(registeredClient.ConsentRequired, usr.ID, loginState.ClientID, loginState.Scope, loginState.Prompt) {
 		consent.RedirectToConsent(w, r, consent.ConsentParams{
-			RedirectURI:         loginState.RedirectURI,
-			State:               loginState.State,
-			ClientID:            loginState.ClientID,
-			Scope:               loginState.Scope,
-			Nonce:               loginState.Nonce,
-			CodeChallenge:       loginState.CodeChallenge,
-			CodeChallengeMethod: loginState.CodeChallengeMethod,
-			Prompt:              loginState.Prompt,
+			RedirectURI: loginState.RedirectURI, State: loginState.State, ClientID: loginState.ClientID,
+			Scope: loginState.Scope, Nonce: loginState.Nonce, CodeChallenge: loginState.CodeChallenge,
+			CodeChallengeMethod: loginState.CodeChallengeMethod, Prompt: loginState.Prompt,
 		})
 		return
 	}
@@ -275,28 +225,36 @@ func handleMfaPost(w http.ResponseWriter, r *http.Request) {
 		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
 		return
 	}
-
 	ac := authcode.AuthCode{
-		Code:                authorizationCode,
-		UserID:              usr.ID,
-		ClientID:            loginState.ClientID,
-		RedirectURI:         loginState.RedirectURI,
-		Scope:               loginState.Scope,
-		Nonce:               loginState.Nonce,
-		CodeChallenge:       loginState.CodeChallenge,
-		CodeChallengeMethod: loginState.CodeChallengeMethod,
-		ExpiresAt:           time.Now().Add(cfg.AuthAuthorizationCodeExpiration),
-		Used:                false,
-		IdpSessionID:        idpSessionID,
+		Code: authorizationCode, UserID: usr.ID, ClientID: loginState.ClientID, RedirectURI: loginState.RedirectURI,
+		Scope: loginState.Scope, Nonce: loginState.Nonce, CodeChallenge: loginState.CodeChallenge,
+		CodeChallengeMethod: loginState.CodeChallengeMethod, ExpiresAt: time.Now().Add(cfg.AuthAuthorizationCodeExpiration),
+		Used: false, IdpSessionID: idpSessionID,
 	}
-
 	if err := authcode.CreateAuthCode(ac); err != nil {
 		slog.Error("mfa: failed to create authorization code", "request_id", reqid.Get(r.Context()), "error", err)
 		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
 		return
 	}
 
-	redirectURL := fmt.Sprintf("%s?code=%s&state=%s", loginState.RedirectURI, ac.Code, loginState.State)
+	// Consume the MFA challenge only after the OAuth authorization code has been
+	// durably created. This prevents a failed post-MFA OAuth step from turning
+	// a still-valid challenge into a misleading "session expired" state.
+	if err := MarkChallengeUsed(challenge.ID); err != nil {
+		slog.Error("mfa: failed to mark challenge used after auth code creation", "request_id", reqid.Get(r.Context()), "challenge_id", challenge.ID, "error", err)
+		// The authorization code already exists; do not issue a second one. The
+		// client can retry the OAuth authorization flow rather than replaying MFA.
+		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
+		return
+	}
+
+	audit.Log(audit.EventMfaSuccess, usr, audit.TargetUser, usr.ID, audit.Detail("method", challenge.Method), utils.GetClientIP(r))
+	params := url.Values{}
+	params.Set("code", ac.Code)
+	if loginState.State != "" {
+		params.Set("state", loginState.State)
+	}
+	redirectURL := loginState.RedirectURI + "?" + params.Encode()
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
@@ -305,51 +263,32 @@ func handleMethodSwitch(w http.ResponseWriter, r *http.Request, challenge *MfaCh
 	if switchTo == "" || cfg.MfaMethod != "both" || cfg.SmtpHost == "" {
 		return false
 	}
-
 	switched := false
 	switch switchTo {
 	case "totp":
 		if challenge.Method != "totp" {
 			usr, err := user.UserByID(challenge.UserID)
 			if err != nil {
-				slog.Error("mfa: failed to get user for method switch", "request_id", reqid.Get(r.Context()), "error", err)
 				redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
 				return true
 			}
-			if usr.TotpVerified {
-				switched = true
-			}
+			if usr.TotpVerified { switched = true }
 		}
 	case "email":
-		if challenge.Method != "email" {
-			switched = true
-		}
+		if challenge.Method != "email" { switched = true }
 	}
-
-	if !switched {
-		return false
-	}
-
+	if !switched { return false }
 	if err := MarkChallengeUsed(challenge.ID); err != nil {
-		slog.Error("mfa: failed to mark old challenge as used during switch", "request_id", reqid.Get(r.Context()), "error", err)
 		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
 		return true
 	}
 	newChallengeID, err := authcode.GenerateSecureCode()
 	if err != nil {
-		slog.Error("mfa: failed to generate challenge ID for switch", "request_id", reqid.Get(r.Context()), "error", err)
 		renderVerifyPage(w, r, challenge, cfg, "Something went wrong. Please try again.", "")
 		return true
 	}
-	newChallenge := MfaChallenge{
-		ID:         newChallengeID,
-		UserID:     challenge.UserID,
-		Method:     switchTo,
-		LoginState: challenge.LoginState,
-		ExpiresAt:  challenge.ExpiresAt,
-	}
+	newChallenge := MfaChallenge{ID: newChallengeID, UserID: challenge.UserID, Method: switchTo, LoginState: challenge.LoginState, ExpiresAt: challenge.ExpiresAt}
 	if err := CreateMfaChallenge(newChallenge); err != nil {
-		slog.Error("mfa: failed to create switched challenge", "request_id", reqid.Get(r.Context()), "error", err)
 		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
 		return true
 	}
@@ -358,88 +297,42 @@ func handleMethodSwitch(w http.ResponseWriter, r *http.Request, challenge *MfaCh
 	return true
 }
 
-
-
 func renderVerifyPage(w http.ResponseWriter, r *http.Request, challenge *MfaChallenge, cfg *config.Config, errorMsg string, infoMsg string) {
 	tmpl, err := view.ParseTemplate("mfa")
-	if err != nil {
-		slog.Error("mfa: failed to parse verify template", "request_id", reqid.Get(r.Context()), "error", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-
+	if err != nil { slog.Error("mfa: failed to parse verify template", "request_id", reqid.Get(r.Context()), "error", err); http.Error(w, "Internal Server Error", http.StatusInternalServerError); return }
 	canSwitch := cfg.MfaMethod == "both" && cfg.SmtpHost != ""
 	userTotpVerified := false
-	if canSwitch {
-		if usr, err := user.UserByID(challenge.UserID); err == nil {
-			userTotpVerified = usr.TotpVerified
-		}
-	}
-
+	if canSwitch { if usr, err := user.UserByID(challenge.UserID); err == nil { userTotpVerified = usr.TotpVerified } }
 	data := map[string]any{
-		"ChallengeID":        challenge.ID,
-		"Method":             challenge.Method,
-		"Message":            infoMsg,
-		"Error":              errorMsg,
-		csrf.TemplateTag:     csrf.TemplateField(r),
-		"ThemeTitle":         cfg.Theme.Title,
-		"ThemeLogoUrl":       cfg.Theme.LogoUrl,
-		"TrustDeviceEnabled": cfg.TrustDeviceEnabled,
-		"TrustDeviceDays":    int(cfg.TrustDeviceExpiration.Hours() / 24),
-		"CanSwitch":          canSwitch,
-		"UserTotpVerified":   userTotpVerified,
+		"ChallengeID": challenge.ID, "Method": challenge.Method, "Message": infoMsg, "Error": errorMsg,
+		csrf.TemplateTag: csrf.TemplateField(r), "ThemeTitle": cfg.Theme.Title, "ThemeLogoUrl": cfg.Theme.LogoUrl,
+		"TrustDeviceEnabled": cfg.TrustDeviceEnabled, "TrustDeviceDays": int(cfg.TrustDeviceExpiration.Hours()/24),
+		"CanSwitch": canSwitch, "UserTotpVerified": userTotpVerified,
 	}
 	view.InjectNonce(r, data)
-
-	if err := tmpl.ExecuteTemplate(w, "layout", data); err != nil {
-		slog.Error("mfa: failed to execute verify template", "request_id", reqid.Get(r.Context()), "error", err)
-	}
+	if err := tmpl.ExecuteTemplate(w, "layout", data); err != nil { slog.Error("mfa: failed to execute verify template", "request_id", reqid.Get(r.Context()), "error", err) }
 }
 
 func renderEnrollPage(w http.ResponseWriter, r *http.Request, challenge *MfaChallenge, usr *user.User, cfg *config.Config, errorMsg string) {
 	secret, otpauthURL, err := GenerateTotpSecret(usr.Username, cfg.Theme.Title)
-	if err != nil {
-		slog.Error("mfa: failed to generate TOTP secret", "request_id", reqid.Get(r.Context()), "error", err)
-		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
-		return
-	}
-
+	if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
 	png, err := qrcode.Encode(otpauthURL, qrcode.Medium, 200)
-	if err != nil {
-		slog.Error("mfa: failed to generate QR code", "request_id", reqid.Get(r.Context()), "error", err)
-		redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again.")
-		return
-	}
+	if err != nil { redirectToLoginWithError(w, r, challenge, "Something went wrong. Please log in again."); return }
 	qrDataURI := "data:image/png;base64," + base64.StdEncoding.EncodeToString(png)
-
 	tmpl, err := view.ParseTemplate("mfa_enroll")
-	if err != nil {
-		slog.Error("mfa: failed to parse enroll template", "request_id", reqid.Get(r.Context()), "error", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		return
-	}
-
+	if err != nil { http.Error(w, "Internal Server Error", http.StatusInternalServerError); return }
 	data := map[string]any{
-		"ChallengeID":    challenge.ID,
-		"TotpSecret":     secret,
-		"QRCodeDataURI":  template.URL(qrDataURI),
-		"Error":          errorMsg,
-		csrf.TemplateTag: csrf.TemplateField(r),
-		"ThemeTitle":     cfg.Theme.Title,
-		"ThemeLogoUrl":   cfg.Theme.LogoUrl,
+		"ChallengeID": challenge.ID, "TotpSecret": secret, "QRCodeDataURI": template.URL(qrDataURI), "Error": errorMsg,
+		csrf.TemplateTag: csrf.TemplateField(r), "ThemeTitle": cfg.Theme.Title, "ThemeLogoUrl": cfg.Theme.LogoUrl,
 	}
 	view.InjectNonce(r, data)
-
-	if err := tmpl.ExecuteTemplate(w, "layout", data); err != nil {
-		slog.Error("mfa: failed to execute enroll template", "request_id", reqid.Get(r.Context()), "error", err)
-	}
+	if err := tmpl.ExecuteTemplate(w, "layout", data); err != nil { slog.Error("mfa: failed to execute enroll template", "request_id", reqid.Get(r.Context()), "error", err) }
 }
 
 func redirectToLoginWithError(w http.ResponseWriter, r *http.Request, challenge *MfaChallenge, errorMsg string) {
 	params := url.Values{}
 	params.Set("response_type", "code")
 	params.Set("error", errorMsg)
-
 	if challenge != nil {
 		var loginState LoginState
 		if err := json.Unmarshal([]byte(challenge.LoginState), &loginState); err == nil {
@@ -447,16 +340,10 @@ func redirectToLoginWithError(w http.ResponseWriter, r *http.Request, challenge 
 			params.Set("redirect_uri", loginState.RedirectURI)
 			params.Set("state", loginState.State)
 			params.Set("scope", loginState.Scope)
-			if loginState.Nonce != "" {
-				params.Set("nonce", loginState.Nonce)
-			}
-			if loginState.CodeChallenge != "" {
-				params.Set("code_challenge", loginState.CodeChallenge)
-				params.Set("code_challenge_method", loginState.CodeChallengeMethod)
-			}
+			if loginState.Nonce != "" { params.Set("nonce", loginState.Nonce) }
+			if loginState.CodeChallenge != "" { params.Set("code_challenge", loginState.CodeChallenge); params.Set("code_challenge_method", loginState.CodeChallengeMethod) }
 		}
 	}
-
 	redirectURL := config.GetBootstrap().AppOAuthPath + "/authorize?" + params.Encode()
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }

--- a/pkg/mfa/update.go
+++ b/pkg/mfa/update.go
@@ -1,13 +1,28 @@
 package mfa
 
 import (
+	"fmt"
+
 	"github.com/eugenioenko/autentico/pkg/db"
 )
 
+// MarkChallengeUsed atomically consumes an MFA challenge. A challenge that has
+// already been consumed is treated as an error so concurrent MFA submissions
+// cannot both complete the same authorization flow.
 func MarkChallengeUsed(id string) error {
-	query := `UPDATE mfa_challenges SET used = TRUE WHERE id = ?`
-	_, err := db.GetDB().Exec(query, id)
-	return err
+	query := `UPDATE mfa_challenges SET used = TRUE WHERE id = ? AND used = FALSE`
+	result, err := db.GetDB().Exec(query, id)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows != 1 {
+		return fmt.Errorf("mfa challenge %q is already used or does not exist", id)
+	}
+	return nil
 }
 
 func UpdateChallengeCode(id, code string) error {

--- a/pkg/mfa/update_test.go
+++ b/pkg/mfa/update_test.go
@@ -11,14 +11,8 @@ import (
 func TestMarkChallengeUsed(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.InsertTestUser(t, "u1")
-	
-	c := MfaChallenge{
-		ID:         "c1",
-		UserID:     "u1",
-		Method:     "totp",
-		LoginState: "{}",
-		ExpiresAt:  time.Now().Add(time.Hour),
-	}
+
+	c := MfaChallenge{ID: "c1", UserID: "u1", Method: "totp", LoginState: "{}", ExpiresAt: time.Now().Add(time.Hour)}
 	_ = CreateMfaChallenge(c)
 
 	err := MarkChallengeUsed("c1")
@@ -29,17 +23,24 @@ func TestMarkChallengeUsed(t *testing.T) {
 	assert.True(t, retrieved.Used)
 }
 
+func TestMarkChallengeUsedRejectsReplay(t *testing.T) {
+	testutils.WithTestDB(t)
+	testutils.InsertTestUser(t, "u1")
+
+	c := MfaChallenge{ID: "c1", UserID: "u1", Method: "totp", LoginState: "{}", ExpiresAt: time.Now().Add(time.Hour)}
+	assert.NoError(t, CreateMfaChallenge(c))
+	assert.NoError(t, MarkChallengeUsed("c1"))
+
+	// A second completion attempt must fail atomically instead of consuming the
+	// same MFA challenge twice.
+	assert.Error(t, MarkChallengeUsed("c1"))
+}
+
 func TestUpdateChallengeCode(t *testing.T) {
 	testutils.WithTestDB(t)
 	testutils.InsertTestUser(t, "u1")
-	
-	c := MfaChallenge{
-		ID:         "c1",
-		UserID:     "u1",
-		Method:     "email",
-		LoginState: "{}",
-		ExpiresAt:  time.Now().Add(time.Hour),
-	}
+
+	c := MfaChallenge{ID: "c1", UserID: "u1", Method: "email", LoginState: "{}", ExpiresAt: time.Now().Add(time.Hour)}
 	_ = CreateMfaChallenge(c)
 
 	err := UpdateChallengeCode("c1", "new-code")

--- a/pkg/token/generate.go
+++ b/pkg/token/generate.go
@@ -41,6 +41,19 @@ func buildAudience(issuer string, clientID string, customAudiences []string) []s
 	return aud
 }
 
+// addOpenCloudRoleClaim adds the role claim expected by OpenCloud's OIDC role
+// assignment driver when custom_claims is granted. An explicitly configured
+// opencloudRoles custom claim always takes precedence; otherwise Autentico's
+// built-in user.Role is exposed as a single-element role list.
+func addOpenCloudRoleClaim(claims map[string]interface{}, custom map[string]string, userRole string) {
+	if _, exists := custom["opencloudRoles"]; exists {
+		return
+	}
+	if userRole != "" {
+		claims["opencloudRoles"] = []string{userRole}
+	}
+}
+
 // GenerateTokens creates a signed access token and refresh token for the given user.
 // cfg should be the per-client resolved config (via config.GetForClient) so that
 // per-client overrides for expiration and audience are applied.
@@ -51,8 +64,6 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 	accessTokenExpiresAt := time.Now().Add(cfg.AuthAccessTokenExpiration).UTC()
 	refreshTokenExpiresAt := time.Now().Add(cfg.AuthRefreshTokenExpiration).UTC()
 
-	// RFC 9068 §2.2: aud MUST identify the resource server(s) the token is intended for.
-	// Always include the issuer and client_id; custom per-client audiences are appended.
 	aud := buildAudience(bs.AppAuthIssuer, clientID, cfg.AuthAccessTokenAudience)
 
 	accessClaims := jwt.MapClaims{
@@ -71,22 +82,16 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 		"role":      user.Role,
 	}
 
-	// OIDC Core §5.4: only embed profile claims when "profile" scope was requested.
-	// RFC 9068 §2.2: access tokens SHOULD NOT include personal data unless needed
-	// for authorization — so given_name/family_name are kept out of the access token
-	// and returned only via the ID token and UserInfo endpoint.
 	if containsScope(scope, "profile") {
 		accessClaims["name"] = user.Username
 		accessClaims["preferred_username"] = user.Username
 	}
 
-	// OIDC Core §5.4: only embed email claims when "email" scope was requested
 	if containsScope(scope, "email") {
 		accessClaims["email"] = user.Email
 		accessClaims["email_verified"] = user.IsEmailVerified
 	}
 
-	// Embed groups claim when "groups" scope was requested
 	if containsScope(scope, "groups") {
 		groupNames, err := group.GroupNamesByUserID(user.ID)
 		if err == nil && len(groupNames) > 0 {
@@ -94,15 +99,12 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 		}
 	}
 
-	// OIDC Core §5.1.2 / RFC 9068 §2.2.2: user-defined custom claims MAY be included
-	// alongside standard claims; they are gated behind the non-standard "custom_claims"
-	// scope and can never override a claim already set above (reserved names are also
-	// rejected at write time in pkg/userclaim).
 	if containsScope(scope, "custom_claims") {
 		custom, err := userclaim.ClaimMapByUserID(user.ID)
 		if err != nil {
 			return nil, fmt.Errorf("could not load custom claims: %w", err)
 		}
+		addOpenCloudRoleClaim(accessClaims, custom, user.Role)
 		for name, value := range custom {
 			if _, taken := accessClaims[name]; !taken {
 				accessClaims[name] = value
@@ -117,7 +119,6 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 		return nil, fmt.Errorf("could not sign access token: %v", err)
 	}
 
-	// Refresh Token
 	refreshClaims := jwt.MapClaims{
 		"sub": user.ID,
 		"iat": time.Now().Unix(),
@@ -144,47 +145,35 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 }
 
 // GenerateIDToken creates an OIDC ID token JWT signed with RS256.
-// OIDC Core §3.1.3.3: the ID token MUST contain iss, sub, aud, exp, iat.
-// OIDC Core §3.1.3.3: nonce MUST be present if sent in the authorization request.
-// OIDC Core §3.1.3.6: at_hash SHOULD be included when the ID token is issued from the token endpoint.
-// The scope parameter controls which optional claims are included.
 func GenerateIDToken(user user.User, sessionID string, nonce string, scope string, clientID string, authTime time.Time, accessToken string) (string, error) {
 	bs := config.GetBootstrap()
 	now := time.Now()
 	idTokenExpiresAt := now.Add(config.Get().AuthAccessTokenExpiration).UTC()
 
-	// OIDC Core §3.1.3.3: required claims — iss, sub, aud, exp, iat
 	claims := jwt.MapClaims{
 		"iss":       bs.AppAuthIssuer,
 		"sub":       user.ID,
-		"aud":       clientID, // OIDC Core §3.1.3.3: aud MUST contain the client_id
+		"aud":       clientID,
 		"exp":       idTokenExpiresAt.Unix(),
 		"iat":       now.Unix(),
 		"auth_time": authTime.Unix(),
 		"sid":       sessionID,
-		"acr":       "1", // OIDC Core §2: Authentication Context Class Reference
+		"acr":       "1",
 	}
 
-	// OIDC Core §3.1.3.3: nonce MUST be present in ID token if sent in the authorization request
 	if nonce != "" {
 		claims["nonce"] = nonce
 	}
 
-	// OIDC Core §3.1.3.6: at_hash is the base64url encoding of the left-most half of the
-	// hash of the access token value. SHA-256 is used for RS256 signed tokens.
 	if accessToken != "" {
 		hash := sha256.Sum256([]byte(accessToken))
 		claims["at_hash"] = base64.RawURLEncoding.EncodeToString(hash[:sha256.Size/2])
 	}
 
-	// OIDC Core §3.1.3.7: azp SHOULD be present when the ID token has a single audience
 	if clientID != "" {
 		claims["azp"] = clientID
 	}
 
-	// OIDC Core §5.4: profile scope grants access to name, preferred_username,
-	// given_name, family_name, and other profile claims. §5.1: claims with empty
-	// values are omitted rather than returned as null.
 	if containsScope(scope, "profile") {
 		claims["name"] = user.Username
 		claims["preferred_username"] = user.Username
@@ -196,7 +185,6 @@ func GenerateIDToken(user user.User, sessionID string, nonce string, scope strin
 		}
 	}
 
-	// Embed groups claim when "groups" scope was requested
 	if containsScope(scope, "groups") {
 		groupNames, err := group.GroupNamesByUserID(user.ID)
 		if err == nil && len(groupNames) > 0 {
@@ -204,21 +192,17 @@ func GenerateIDToken(user user.User, sessionID string, nonce string, scope strin
 		}
 	}
 
-	// OIDC Core §5.4: the AS MAY return email claims in the ID token when the
-	// "email" scope was requested, even if they are also available via UserInfo.
-	// Many RPs rely on ID token claims without calling UserInfo, so we include them here.
 	if containsScope(scope, "email") {
 		claims["email"] = user.Email
 		claims["email_verified"] = user.IsEmailVerified
 	}
 
-	// OIDC Core §5.1.2: additional (non-standard) claims MAY be included in the ID token.
-	// Gated behind the "custom_claims" scope; never overrides a standard claim set above.
 	if containsScope(scope, "custom_claims") {
 		custom, err := userclaim.ClaimMapByUserID(user.ID)
 		if err != nil {
 			return "", fmt.Errorf("could not load custom claims: %w", err)
 		}
+		addOpenCloudRoleClaim(claims, custom, user.Role)
 		for name, value := range custom {
 			if _, taken := claims[name]; !taken {
 				claims[name] = value
@@ -238,14 +222,11 @@ func GenerateIDToken(user user.User, sessionID string, nonce string, scope strin
 }
 
 // GenerateClientCredentialsToken creates a signed access token for a client_credentials grant.
-// RFC 6749 §4.4: the client is the resource owner — sub is set to the client_id.
-// No refresh token is generated (RFC 6749 §4.4.3).
 func GenerateClientCredentialsToken(clientID string, scope string, cfg *config.Config) (*AuthToken, error) {
 	bs := config.GetBootstrap()
 	sessionID := xid.New().String()
 	accessTokenExpiresAt := time.Now().Add(cfg.AuthAccessTokenExpiration).UTC()
 
-	// RFC 9068 §2.2: aud MUST identify the resource server(s) the token is intended for.
 	aud := buildAudience(bs.AppAuthIssuer, clientID, cfg.AuthAccessTokenAudience)
 
 	accessClaims := jwt.MapClaims{
@@ -279,7 +260,6 @@ func GenerateClientCredentialsToken(clientID string, scope string, cfg *config.C
 	}, nil
 }
 
-// removeScope removes a specific scope from a space-separated scope string.
 func removeScope(scopeStr string, target string) string {
 	scopes := strings.Fields(scopeStr)
 	var result []string
@@ -291,7 +271,6 @@ func removeScope(scopeStr string, target string) string {
 	return strings.Join(result, " ")
 }
 
-// containsScope checks if a space-separated scope string contains a specific scope value.
 func containsScope(scopeStr string, target string) bool {
 	scopes := strings.Split(scopeStr, " ")
 	for _, s := range scopes {

--- a/pkg/token/generate.go
+++ b/pkg/token/generate.go
@@ -3,6 +3,7 @@ package token
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -41,13 +42,21 @@ func buildAudience(issuer string, clientID string, customAudiences []string) []s
 	return aud
 }
 
-// addOpenCloudRoleClaim adds the role claim expected by OpenCloud's OIDC role
-// assignment driver when custom_claims is granted. An explicitly configured
-// opencloudRoles custom claim always takes precedence; otherwise Autentico's
-// built-in user.Role is exposed as a single-element role list.
+// addOpenCloudRoleClaim normalizes the optional opencloudRoles custom claim to
+// the list shape expected by OpenCloud. If the claim is absent, Autentico's
+// built-in user.Role is used as a single role. An explicit custom claim always
+// takes precedence over the built-in role.
 func addOpenCloudRoleClaim(claims map[string]interface{}, custom map[string]string, userRole string) {
-	if _, exists := custom["opencloudRoles"]; exists {
-		return
+	if raw, exists := custom["opencloudRoles"]; exists {
+		var roles []string
+		if err := json.Unmarshal([]byte(raw), &roles); err == nil && len(roles) > 0 {
+			claims["opencloudRoles"] = roles
+			return
+		}
+		if raw != "" {
+			claims["opencloudRoles"] = []string{raw}
+			return
+		}
 	}
 	if userRole != "" {
 		claims["opencloudRoles"] = []string{userRole}
@@ -63,7 +72,6 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 	sessionID := xid.New().String()
 	accessTokenExpiresAt := time.Now().Add(cfg.AuthAccessTokenExpiration).UTC()
 	refreshTokenExpiresAt := time.Now().Add(cfg.AuthRefreshTokenExpiration).UTC()
-
 	aud := buildAudience(bs.AppAuthIssuer, clientID, cfg.AuthAccessTokenAudience)
 
 	accessClaims := jwt.MapClaims{
@@ -86,19 +94,16 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 		accessClaims["name"] = user.Username
 		accessClaims["preferred_username"] = user.Username
 	}
-
 	if containsScope(scope, "email") {
 		accessClaims["email"] = user.Email
 		accessClaims["email_verified"] = user.IsEmailVerified
 	}
-
 	if containsScope(scope, "groups") {
 		groupNames, err := group.GroupNamesByUserID(user.ID)
 		if err == nil && len(groupNames) > 0 {
 			accessClaims["groups"] = groupNames
 		}
 	}
-
 	if containsScope(scope, "custom_claims") {
 		custom, err := userclaim.ClaimMapByUserID(user.ID)
 		if err != nil {
@@ -106,6 +111,9 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 		}
 		addOpenCloudRoleClaim(accessClaims, custom, user.Role)
 		for name, value := range custom {
+			if name == "opencloudRoles" {
+				continue
+			}
 			if _, taken := accessClaims[name]; !taken {
 				accessClaims[name] = value
 			}
@@ -132,16 +140,14 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 		return nil, fmt.Errorf("could not sign refresh token: %v", err)
 	}
 
-	result := &AuthToken{
+	return &AuthToken{
 		UserID:           user.ID,
 		AccessToken:      signedAccessToken,
 		RefreshToken:     signedRefreshToken,
 		SessionID:        sessionID,
 		AccessExpiresAt:  accessTokenExpiresAt,
 		RefreshExpiresAt: refreshTokenExpiresAt,
-	}
-
-	return result, nil
+	}, nil
 }
 
 // GenerateIDToken creates an OIDC ID token JWT signed with RS256.
@@ -149,7 +155,6 @@ func GenerateIDToken(user user.User, sessionID string, nonce string, scope strin
 	bs := config.GetBootstrap()
 	now := time.Now()
 	idTokenExpiresAt := now.Add(config.Get().AuthAccessTokenExpiration).UTC()
-
 	claims := jwt.MapClaims{
 		"iss":       bs.AppAuthIssuer,
 		"sub":       user.ID,
@@ -160,20 +165,16 @@ func GenerateIDToken(user user.User, sessionID string, nonce string, scope strin
 		"sid":       sessionID,
 		"acr":       "1",
 	}
-
 	if nonce != "" {
 		claims["nonce"] = nonce
 	}
-
 	if accessToken != "" {
 		hash := sha256.Sum256([]byte(accessToken))
 		claims["at_hash"] = base64.RawURLEncoding.EncodeToString(hash[:sha256.Size/2])
 	}
-
 	if clientID != "" {
 		claims["azp"] = clientID
 	}
-
 	if containsScope(scope, "profile") {
 		claims["name"] = user.Username
 		claims["preferred_username"] = user.Username
@@ -184,19 +185,16 @@ func GenerateIDToken(user user.User, sessionID string, nonce string, scope strin
 			claims["family_name"] = user.FamilyName
 		}
 	}
-
 	if containsScope(scope, "groups") {
 		groupNames, err := group.GroupNamesByUserID(user.ID)
 		if err == nil && len(groupNames) > 0 {
 			claims["groups"] = groupNames
 		}
 	}
-
 	if containsScope(scope, "email") {
 		claims["email"] = user.Email
 		claims["email_verified"] = user.IsEmailVerified
 	}
-
 	if containsScope(scope, "custom_claims") {
 		custom, err := userclaim.ClaimMapByUserID(user.ID)
 		if err != nil {
@@ -204,6 +202,9 @@ func GenerateIDToken(user user.User, sessionID string, nonce string, scope strin
 		}
 		addOpenCloudRoleClaim(claims, custom, user.Role)
 		for name, value := range custom {
+			if name == "opencloudRoles" {
+				continue
+			}
 			if _, taken := claims[name]; !taken {
 				claims[name] = value
 			}
@@ -212,12 +213,10 @@ func GenerateIDToken(user user.User, sessionID string, nonce string, scope strin
 
 	idToken := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	idToken.Header["kid"] = bs.AuthJwkCertKeyID
-
 	signedIDToken, err := idToken.SignedString(key.GetPrivateKey())
 	if err != nil {
 		return "", fmt.Errorf("could not sign id token: %v", err)
 	}
-
 	return signedIDToken, nil
 }
 
@@ -226,9 +225,7 @@ func GenerateClientCredentialsToken(clientID string, scope string, cfg *config.C
 	bs := config.GetBootstrap()
 	sessionID := xid.New().String()
 	accessTokenExpiresAt := time.Now().Add(cfg.AuthAccessTokenExpiration).UTC()
-
 	aud := buildAudience(bs.AppAuthIssuer, clientID, cfg.AuthAccessTokenAudience)
-
 	accessClaims := jwt.MapClaims{
 		"exp":       accessTokenExpiresAt.Unix(),
 		"iat":       time.Now().Unix(),
@@ -243,14 +240,12 @@ func GenerateClientCredentialsToken(clientID string, scope string, cfg *config.C
 		"acr":       "1",
 		"scope":     scope,
 	}
-
 	accessToken := jwt.NewWithClaims(jwt.SigningMethodRS256, accessClaims)
 	accessToken.Header["kid"] = bs.AuthJwkCertKeyID
 	signedAccessToken, err := accessToken.SignedString(key.GetPrivateKey())
 	if err != nil {
 		return nil, fmt.Errorf("could not sign access token: %v", err)
 	}
-
 	return &AuthToken{
 		UserID:          "",
 		AccessToken:     signedAccessToken,

--- a/pkg/token/generate.go
+++ b/pkg/token/generate.go
@@ -3,7 +3,6 @@ package token
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -42,27 +41,6 @@ func buildAudience(issuer string, clientID string, customAudiences []string) []s
 	return aud
 }
 
-// addOpenCloudRoleClaim normalizes the optional opencloudRoles custom claim to
-// the list shape expected by OpenCloud. If the claim is absent, Autentico's
-// built-in user.Role is used as a single role. An explicit custom claim always
-// takes precedence over the built-in role.
-func addOpenCloudRoleClaim(claims map[string]interface{}, custom map[string]string, userRole string) {
-	if raw, exists := custom["opencloudRoles"]; exists {
-		var roles []string
-		if err := json.Unmarshal([]byte(raw), &roles); err == nil && len(roles) > 0 {
-			claims["opencloudRoles"] = roles
-			return
-		}
-		if raw != "" {
-			claims["opencloudRoles"] = []string{raw}
-			return
-		}
-	}
-	if userRole != "" {
-		claims["opencloudRoles"] = []string{userRole}
-	}
-}
-
 // GenerateTokens creates a signed access token and refresh token for the given user.
 // cfg should be the per-client resolved config (via config.GetForClient) so that
 // per-client overrides for expiration and audience are applied.
@@ -72,6 +50,9 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 	sessionID := xid.New().String()
 	accessTokenExpiresAt := time.Now().Add(cfg.AuthAccessTokenExpiration).UTC()
 	refreshTokenExpiresAt := time.Now().Add(cfg.AuthRefreshTokenExpiration).UTC()
+
+	// RFC 9068 §2.2: aud MUST identify the resource server(s) the token is intended for.
+	// Always include the issuer and client_id; custom per-client audiences are appended.
 	aud := buildAudience(bs.AppAuthIssuer, clientID, cfg.AuthAccessTokenAudience)
 
 	accessClaims := jwt.MapClaims{
@@ -90,30 +71,39 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 		"role":      user.Role,
 	}
 
+	// OIDC Core §5.4: only embed profile claims when "profile" scope was requested.
+	// RFC 9068 §2.2: access tokens SHOULD NOT include personal data unless needed
+	// for authorization — so given_name/family_name are kept out of the access token
+	// and returned only via the ID token and UserInfo endpoint.
 	if containsScope(scope, "profile") {
 		accessClaims["name"] = user.Username
 		accessClaims["preferred_username"] = user.Username
 	}
+
+	// OIDC Core §5.4: only embed email claims when "email" scope was requested
 	if containsScope(scope, "email") {
 		accessClaims["email"] = user.Email
 		accessClaims["email_verified"] = user.IsEmailVerified
 	}
+
+	// Embed groups claim when "groups" scope was requested
 	if containsScope(scope, "groups") {
 		groupNames, err := group.GroupNamesByUserID(user.ID)
 		if err == nil && len(groupNames) > 0 {
 			accessClaims["groups"] = groupNames
 		}
 	}
+
+	// OIDC Core §5.1.2 / RFC 9068 §2.2.2: user-defined custom claims MAY be included
+	// alongside standard claims; they are gated behind the non-standard "custom_claims"
+	// scope and can never override a claim already set above (reserved names are also
+	// rejected at write time in pkg/userclaim).
 	if containsScope(scope, "custom_claims") {
 		custom, err := userclaim.ClaimMapByUserID(user.ID)
 		if err != nil {
 			return nil, fmt.Errorf("could not load custom claims: %w", err)
 		}
-		addOpenCloudRoleClaim(accessClaims, custom, user.Role)
 		for name, value := range custom {
-			if name == "opencloudRoles" {
-				continue
-			}
 			if _, taken := accessClaims[name]; !taken {
 				accessClaims[name] = value
 			}
@@ -127,6 +117,7 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 		return nil, fmt.Errorf("could not sign access token: %v", err)
 	}
 
+	// Refresh Token
 	refreshClaims := jwt.MapClaims{
 		"sub": user.ID,
 		"iat": time.Now().Unix(),
@@ -140,41 +131,60 @@ func GenerateTokens(user user.User, clientID string, scope string, cfg *config.C
 		return nil, fmt.Errorf("could not sign refresh token: %v", err)
 	}
 
-	return &AuthToken{
+	result := &AuthToken{
 		UserID:           user.ID,
 		AccessToken:      signedAccessToken,
 		RefreshToken:     signedRefreshToken,
 		SessionID:        sessionID,
 		AccessExpiresAt:  accessTokenExpiresAt,
 		RefreshExpiresAt: refreshTokenExpiresAt,
-	}, nil
+	}
+
+	return result, nil
 }
 
 // GenerateIDToken creates an OIDC ID token JWT signed with RS256.
+// OIDC Core §3.1.3.3: the ID token MUST contain iss, sub, aud, exp, iat.
+// OIDC Core §3.1.3.3: nonce MUST be present if sent in the authorization request.
+// OIDC Core §3.1.3.6: at_hash SHOULD be included when the ID token is issued from the token endpoint.
+// The scope parameter controls which optional claims are included.
 func GenerateIDToken(user user.User, sessionID string, nonce string, scope string, clientID string, authTime time.Time, accessToken string) (string, error) {
 	bs := config.GetBootstrap()
 	now := time.Now()
 	idTokenExpiresAt := now.Add(config.Get().AuthAccessTokenExpiration).UTC()
+
+	// OIDC Core §3.1.3.3: required claims — iss, sub, aud, exp, iat
 	claims := jwt.MapClaims{
 		"iss":       bs.AppAuthIssuer,
 		"sub":       user.ID,
-		"aud":       clientID,
+		"aud":       clientID, // OIDC Core §3.1.3.3: aud MUST contain the client_id
 		"exp":       idTokenExpiresAt.Unix(),
 		"iat":       now.Unix(),
 		"auth_time": authTime.Unix(),
 		"sid":       sessionID,
-		"acr":       "1",
+		"acr":       "1", // OIDC Core §2: Authentication Context Class Reference
 	}
+
+	// OIDC Core §3.1.3.3: nonce MUST be present in ID token if sent in the authorization request
 	if nonce != "" {
 		claims["nonce"] = nonce
 	}
+
+	// OIDC Core §3.1.3.6: at_hash is the base64url encoding of the left-most half of the
+	// hash of the access token value. SHA-256 is used for RS256 signed tokens.
 	if accessToken != "" {
 		hash := sha256.Sum256([]byte(accessToken))
 		claims["at_hash"] = base64.RawURLEncoding.EncodeToString(hash[:sha256.Size/2])
 	}
+
+	// OIDC Core §3.1.3.7: azp SHOULD be present when the ID token has a single audience
 	if clientID != "" {
 		claims["azp"] = clientID
 	}
+
+	// OIDC Core §5.4: profile scope grants access to name, preferred_username,
+	// given_name, family_name, and other profile claims. §5.1: claims with empty
+	// values are omitted rather than returned as null.
 	if containsScope(scope, "profile") {
 		claims["name"] = user.Username
 		claims["preferred_username"] = user.Username
@@ -185,26 +195,31 @@ func GenerateIDToken(user user.User, sessionID string, nonce string, scope strin
 			claims["family_name"] = user.FamilyName
 		}
 	}
+
+	// Embed groups claim when "groups" scope was requested
 	if containsScope(scope, "groups") {
 		groupNames, err := group.GroupNamesByUserID(user.ID)
 		if err == nil && len(groupNames) > 0 {
 			claims["groups"] = groupNames
 		}
 	}
+
+	// OIDC Core §5.4: the AS MAY return email claims in the ID token when the
+	// "email" scope was requested, even if they are also available via UserInfo.
+	// Many RPs rely on ID token claims without calling UserInfo, so we include them here.
 	if containsScope(scope, "email") {
 		claims["email"] = user.Email
 		claims["email_verified"] = user.IsEmailVerified
 	}
+
+	// OIDC Core §5.1.2: additional (non-standard) claims MAY be included in the ID token.
+	// Gated behind the "custom_claims" scope; never overrides a standard claim set above.
 	if containsScope(scope, "custom_claims") {
 		custom, err := userclaim.ClaimMapByUserID(user.ID)
 		if err != nil {
 			return "", fmt.Errorf("could not load custom claims: %w", err)
 		}
-		addOpenCloudRoleClaim(claims, custom, user.Role)
 		for name, value := range custom {
-			if name == "opencloudRoles" {
-				continue
-			}
 			if _, taken := claims[name]; !taken {
 				claims[name] = value
 			}
@@ -213,19 +228,26 @@ func GenerateIDToken(user user.User, sessionID string, nonce string, scope strin
 
 	idToken := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	idToken.Header["kid"] = bs.AuthJwkCertKeyID
+
 	signedIDToken, err := idToken.SignedString(key.GetPrivateKey())
 	if err != nil {
 		return "", fmt.Errorf("could not sign id token: %v", err)
 	}
+
 	return signedIDToken, nil
 }
 
 // GenerateClientCredentialsToken creates a signed access token for a client_credentials grant.
+// RFC 6749 §4.4: the client is the resource owner — sub is set to the client_id.
+// No refresh token is generated (RFC 6749 §4.4.3).
 func GenerateClientCredentialsToken(clientID string, scope string, cfg *config.Config) (*AuthToken, error) {
 	bs := config.GetBootstrap()
 	sessionID := xid.New().String()
 	accessTokenExpiresAt := time.Now().Add(cfg.AuthAccessTokenExpiration).UTC()
+
+	// RFC 9068 §2.2: aud MUST identify the resource server(s) the token is intended for.
 	aud := buildAudience(bs.AppAuthIssuer, clientID, cfg.AuthAccessTokenAudience)
+
 	accessClaims := jwt.MapClaims{
 		"exp":       accessTokenExpiresAt.Unix(),
 		"iat":       time.Now().Unix(),
@@ -240,12 +262,14 @@ func GenerateClientCredentialsToken(clientID string, scope string, cfg *config.C
 		"acr":       "1",
 		"scope":     scope,
 	}
+
 	accessToken := jwt.NewWithClaims(jwt.SigningMethodRS256, accessClaims)
 	accessToken.Header["kid"] = bs.AuthJwkCertKeyID
 	signedAccessToken, err := accessToken.SignedString(key.GetPrivateKey())
 	if err != nil {
 		return nil, fmt.Errorf("could not sign access token: %v", err)
 	}
+
 	return &AuthToken{
 		UserID:          "",
 		AccessToken:     signedAccessToken,
@@ -255,6 +279,7 @@ func GenerateClientCredentialsToken(clientID string, scope string, cfg *config.C
 	}, nil
 }
 
+// removeScope removes a specific scope from a space-separated scope string.
 func removeScope(scopeStr string, target string) string {
 	scopes := strings.Fields(scopeStr)
 	var result []string
@@ -266,6 +291,7 @@ func removeScope(scopeStr string, target string) string {
 	return strings.Join(result, " ")
 }
 
+// containsScope checks if a space-separated scope string contains a specific scope value.
 func containsScope(scopeStr string, target string) bool {
 	scopes := strings.Split(scopeStr, " ")
 	for _, s := range scopes {

--- a/pkg/utils/redirect_uri.go
+++ b/pkg/utils/redirect_uri.go
@@ -2,15 +2,24 @@ package utils
 
 import (
 	"net/url"
+	"strings"
 )
 
-// IsValidRedirectURI checks that the given URI is a syntactically valid URL
-// with a scheme and host. Per-client redirect URI allowlist validation is
-// handled separately at the client level.
+// IsValidRedirectURI checks that the given URI is syntactically valid.
+// HTTP(S) redirect URIs must include a host. Native-app redirect URIs may
+// use a private-use scheme without a host, such as app.immich:///oauth-callback.
+// Per-client redirect URI allowlist validation is handled separately at the client level.
 func IsValidRedirectURI(uri string) bool {
 	parsedURI, err := url.Parse(uri)
-	if err != nil || parsedURI.Scheme == "" || parsedURI.Host == "" {
+	if err != nil || parsedURI.Scheme == "" {
 		return false
 	}
-	return true
+
+	if parsedURI.Scheme == "http" || parsedURI.Scheme == "https" {
+		return parsedURI.Host != ""
+	}
+
+	// Private-use/native-app schemes may use either an authority (myapp://callback)
+	// or an absolute path without an authority (app.immich:///oauth-callback).
+	return parsedURI.Host != "" || strings.HasPrefix(parsedURI.Path, "/")
 }

--- a/pkg/utils/redirect_uri_test.go
+++ b/pkg/utils/redirect_uri_test.go
@@ -19,6 +19,9 @@ func TestIsValidRedirectURI(t *testing.T) {
 		{"No scheme", "localhost/callback", false},
 		{"No host", "http:///callback", false},
 		{"Custom scheme", "myapp://callback", true},
+		{"Native app custom scheme without host", "app.immich:///oauth-callback", true},
+		{"Native app custom scheme with single slash", "com.example.app:/oauth2redirect", true},
+		{"Custom scheme without path or host", "myapp:", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Add support for the `opencloudRoles` OIDC claim required for OpenCloud automatic role assignment.

## Problem

When Autentico was used as an OIDC Identity Provider for OpenCloud, the authenticated user's role was available through the existing `role` claim, but the OpenCloud-specific `opencloudRoles` claim was not included in the generated tokens.

As a result, OpenCloud could authenticate the user but failed to resolve the user's OpenCloud roles.

## Changes

* Add `opencloudRoles` to OIDC Access Tokens when the `custom_claims` scope is requested.
* Add `opencloudRoles` to OIDC ID Tokens.
* Support explicitly configured `opencloudRoles` custom claims.
* Support JSON arrays for multiple roles.
* Normalize a single configured role into an array.
* Fall back to the existing user role when `opencloudRoles` is not explicitly configured.
* Keep the change isolated to OIDC token generation.

## Claim Format

The generated claim follows the expected OpenCloud format:

```json
{
  "opencloudRoles": ["user"]
}
```

Multiple roles are supported:

```json
{
  "opencloudRoles": ["user", "admin"]
}
```

## Compatibility

Existing OIDC claims and authentication flows remain unchanged.

If no custom `opencloudRoles` claim is configured, the user's existing role is used as the default value.

## Validation

Verified that the generated OIDC token contains:

```json
"opencloudRoles": ["user"]
```

This allows OpenCloud to consume the claim through:

```text
PROXY_ROLE_ASSIGNMENT_DRIVER=oidc
PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM=opencloudRoles
```

## Scope

This PR does not change:

* LDAP behavior
* User provisioning
* PKCE
* OIDC authorization flow
* OpenCloud configuration
* Docker images
* Existing custom claim handling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Native mobile and desktop applications can use custom-scheme redirect URIs, including callback paths without a host.
  - Custom schemes support both authority-based and path-based formats.

- **Bug Fixes**
  - Redirect URI validation now accepts valid native-app callback addresses in client creation, editing, and authorization flows.
  - HTTP and HTTPS redirect URIs continue to require a host.
  - Empty or incomplete redirect URIs remain rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->