### PR TITLE
feat(admin-ui): tooltips + aria-labels on list action buttons

### DIFF
--- a/admin-ui/src/components/users/DeletionRequestsTab.tsx
+++ b/admin-ui/src/components/users/DeletionRequestsTab.tsx
@@ -8,6 +8,7 @@ import {
   Drawer,
   Descriptions,
   Input,
+  Tooltip,
   App,
 } from "antd";
 import { MoreOutlined } from "@ant-design/icons";
@@ -183,7 +184,13 @@ export default function DeletionRequestsTab() {
           }}
           trigger={["click"]}
         >
-          <MoreOutlined style={{ fontSize: 16, cursor: "pointer" }} />
+          <Tooltip title="More actions">
+            <MoreOutlined
+              role="button"
+              aria-label="More actions"
+              style={{ fontSize: 16, cursor: "pointer" }}
+            />
+          </Tooltip>
         </Dropdown>
       ),
     },

--- a/admin-ui/src/components/users/UserClaimsDrawer.tsx
+++ b/admin-ui/src/components/users/UserClaimsDrawer.tsx
@@ -7,6 +7,7 @@ import {
   Space,
   Typography,
   Popconfirm,
+  Tooltip,
   App,
 } from "antd";
 import { DeleteOutlined, PlusOutlined } from "@ant-design/icons";
@@ -78,20 +79,22 @@ export default function UserClaimsDrawer({
       key: "actions",
       width: 50,
       render: (_, record) => (
-        <Popconfirm
-          title="Remove this claim?"
-          onConfirm={() => handleDelete(record.name)}
-          okText="Remove"
-          okButtonProps={{ danger: true }}
-        >
-          <Button
-            type="text"
-            size="small"
-            danger
-            aria-label={`Remove claim ${record.name}`}
-            icon={<DeleteOutlined />}
-          />
-        </Popconfirm>
+        <Tooltip title="Remove claim">
+          <Popconfirm
+            title="Remove this claim?"
+            onConfirm={() => handleDelete(record.name)}
+            okText="Remove"
+            okButtonProps={{ danger: true }}
+          >
+            <Button
+              type="text"
+              size="small"
+              danger
+              aria-label={`Remove claim ${record.name}`}
+              icon={<DeleteOutlined />}
+            />
+          </Popconfirm>
+        </Tooltip>
       ),
     },
   ];

--- a/admin-ui/src/components/users/UserGroupsDrawer.tsx
+++ b/admin-ui/src/components/users/UserGroupsDrawer.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Drawer, Select, Table, Button, Space, Typography, Popconfirm, App } from "antd";
+import { Drawer, Select, Table, Button, Space, Typography, Popconfirm, Tooltip, App } from "antd";
 import { UserDeleteOutlined, PlusOutlined } from "@ant-design/icons";
 import type { ColumnsType } from "antd/es/table";
 import { useGroups, useAddMember, useRemoveMember } from "../../hooks/useGroups";
@@ -68,14 +68,22 @@ export default function UserGroupsDrawer({ open, userId, username, onClose }: Us
       key: "actions",
       width: 50,
       render: (_, record) => (
-        <Popconfirm
-          title="Remove from this group?"
-          onConfirm={() => handleRemove(record.id)}
-          okText="Remove"
-          okButtonProps={{ danger: true }}
-        >
-          <Button type="text" size="small" danger icon={<UserDeleteOutlined />} />
-        </Popconfirm>
+        <Tooltip title="Remove from group">
+          <Popconfirm
+            title="Remove from this group?"
+            onConfirm={() => handleRemove(record.id)}
+            okText="Remove"
+            okButtonProps={{ danger: true }}
+          >
+            <Button
+              type="text"
+              size="small"
+              danger
+              aria-label="Remove from group"
+              icon={<UserDeleteOutlined />}
+            />
+          </Popconfirm>
+        </Tooltip>
       ),
     },
   ];

--- a/admin-ui/src/components/users/UserSessionsDrawer.tsx
+++ b/admin-ui/src/components/users/UserSessionsDrawer.tsx
@@ -6,6 +6,7 @@ import {
   Space,
   Popconfirm,
   Typography,
+  Tooltip,
   App,
 } from "antd";
 import { LogoutOutlined } from "@ant-design/icons";
@@ -105,20 +106,23 @@ export default function UserSessionsDrawer({
       key: "actions",
       width: 50,
       render: (_, record) => (
-        <Popconfirm
-          title="Force sign out this device?"
-          description="This will revoke all sessions and tokens from this device."
-          onConfirm={() => handleForceLogout(record.id)}
-          okText="Sign Out"
-          okButtonProps={{ danger: true }}
-        >
-          <Button
-            type="text"
-            size="small"
-            danger
-            icon={<LogoutOutlined />}
-          />
-        </Popconfirm>
+        <Tooltip title="Force sign out device">
+          <Popconfirm
+            title="Force sign out this device?"
+            description="This will revoke all sessions and tokens from this device."
+            onConfirm={() => handleForceLogout(record.id)}
+            okText="Sign Out"
+            okButtonProps={{ danger: true }}
+          >
+            <Button
+              type="text"
+              size="small"
+              danger
+              aria-label="Force sign out device"
+              icon={<LogoutOutlined />}
+            />
+          </Popconfirm>
+        </Tooltip>
       ),
     },
   ];

--- a/admin-ui/src/pages/AuditLogPage.tsx
+++ b/admin-ui/src/pages/AuditLogPage.tsx
@@ -11,6 +11,7 @@ import {
   Drawer,
   Descriptions,
   DatePicker,
+  Tooltip,
 } from "antd";
 import { EyeOutlined } from "@ant-design/icons";
 import type { ColumnsType, TablePaginationConfig } from "antd/es/table";
@@ -268,12 +269,15 @@ export default function AuditLogPage() {
       key: "actions",
       width: 50,
       render: (_: unknown, record: AuditLogEntry) => (
-        <Button
-          type="text"
-          size="small"
-          icon={<EyeOutlined />}
-          onClick={() => setSelectedEntry(record)}
-        />
+        <Tooltip title="View details">
+          <Button
+            type="text"
+            size="small"
+            aria-label="View audit entry details"
+            icon={<EyeOutlined />}
+            onClick={() => setSelectedEntry(record)}
+          />
+        </Tooltip>
       ),
     },
   ];

--- a/admin-ui/src/pages/ClientsPage.tsx
+++ b/admin-ui/src/pages/ClientsPage.tsx
@@ -8,6 +8,7 @@ import {
   Space,
   Alert,
   Input,
+  Tooltip,
 } from "antd";
 import {
   PlusOutlined,
@@ -177,18 +178,24 @@ export default function ClientsPage() {
       key: "actions",
       render: (_, record) => (
         <Space>
-          <Button
-            type="text"
-            size="small"
-            icon={<EyeOutlined />}
-            onClick={() => setDetailClient(record)}
-          />
-          <Button
-            type="text"
-            size="small"
-            icon={<EditOutlined />}
-            onClick={() => setEditClient(record)}
-          />
+          <Tooltip title="View details">
+            <Button
+              type="text"
+              size="small"
+              aria-label="View client details"
+              icon={<EyeOutlined />}
+              onClick={() => setDetailClient(record)}
+            />
+          </Tooltip>
+          <Tooltip title="Edit client">
+            <Button
+              type="text"
+              size="small"
+              aria-label="Edit client"
+              icon={<EditOutlined />}
+              onClick={() => setEditClient(record)}
+            />
+          </Tooltip>
         </Space>
       ),
     },

--- a/admin-ui/src/pages/FederationPage.tsx
+++ b/admin-ui/src/pages/FederationPage.tsx
@@ -8,6 +8,7 @@ import {
   Popconfirm,
   Alert,
   Input,
+  Tooltip,
   App,
 } from "antd";
 import {
@@ -163,21 +164,32 @@ export default function FederationPage() {
       width: 100,
       render: (_, record) => (
         <Space>
-          <Popconfirm
-            title="Delete this provider?"
-            description="Users who signed in via this provider will keep their accounts but won't be able to log in with it again."
-            onConfirm={() => handleDelete(record.id)}
-            okText="Delete"
-            okButtonProps={{ danger: true }}
-          >
-            <Button type="text" size="small" danger icon={<DeleteOutlined />} />
-          </Popconfirm>
-          <Button
-            type="text"
-            size="small"
-            icon={<EditOutlined />}
-            onClick={() => setEditProvider(record)}
-          />
+          <Tooltip title="Delete provider">
+            <Popconfirm
+              title="Delete this provider?"
+              description="Users who signed in via this provider will keep their accounts but won't be able to log in with it again."
+              onConfirm={() => handleDelete(record.id)}
+              okText="Delete"
+              okButtonProps={{ danger: true }}
+            >
+              <Button
+                type="text"
+                size="small"
+                danger
+                aria-label="Delete provider"
+                icon={<DeleteOutlined />}
+              />
+            </Popconfirm>
+          </Tooltip>
+          <Tooltip title="Edit provider">
+            <Button
+              type="text"
+              size="small"
+              aria-label="Edit provider"
+              icon={<EditOutlined />}
+              onClick={() => setEditProvider(record)}
+            />
+          </Tooltip>
         </Space>
       ),
     },

--- a/admin-ui/src/pages/GroupsPage.tsx
+++ b/admin-ui/src/pages/GroupsPage.tsx
@@ -11,6 +11,7 @@ import {
   Input,
   AutoComplete,
   Tag,
+  Tooltip,
   App,
 } from "antd";
 import {
@@ -133,19 +134,22 @@ function GroupMembersView({
       key: "actions",
       width: 50,
       render: (_, record) => (
-        <Popconfirm
-          title="Remove this member?"
-          onConfirm={() => handleRemove(record.user_id)}
-          okText="Remove"
-          okButtonProps={{ danger: true }}
-        >
-          <Button
-            type="text"
-            size="small"
-            danger
-            icon={<UserDeleteOutlined />}
-          />
-        </Popconfirm>
+        <Tooltip title="Remove member">
+          <Popconfirm
+            title="Remove this member?"
+            onConfirm={() => handleRemove(record.user_id)}
+            okText="Remove"
+            okButtonProps={{ danger: true }}
+          >
+            <Button
+              type="text"
+              size="small"
+              danger
+              aria-label="Remove member"
+              icon={<UserDeleteOutlined />}
+            />
+          </Popconfirm>
+        </Tooltip>
       ),
     },
   ];
@@ -347,38 +351,47 @@ export default function GroupsPage() {
       width: 120,
       render: (_, record) => (
         <Space>
-          <Popconfirm
-            title="Delete this group?"
-            description="All memberships will be removed."
-            onConfirm={() => handleDelete(record.id)}
-            okText="Delete"
-            okButtonProps={{ danger: true }}
-          >
+          <Tooltip title="Delete group">
+            <Popconfirm
+              title="Delete this group?"
+              description="All memberships will be removed."
+              onConfirm={() => handleDelete(record.id)}
+              okText="Delete"
+              okButtonProps={{ danger: true }}
+            >
+              <Button
+                type="text"
+                size="small"
+                danger
+                aria-label="Delete group"
+                icon={<DeleteOutlined />}
+              />
+            </Popconfirm>
+          </Tooltip>
+          <Tooltip title="Manage members">
             <Button
               type="text"
               size="small"
-              danger
-              icon={<DeleteOutlined />}
+              aria-label="Manage group members"
+              icon={<TeamOutlined />}
+              onClick={() => setMembersGroup(record)}
             />
-          </Popconfirm>
-          <Button
-            type="text"
-            size="small"
-            icon={<TeamOutlined />}
-            onClick={() => setMembersGroup(record)}
-          />
-          <Button
-            type="text"
-            size="small"
-            icon={<EditOutlined />}
-            onClick={() => {
-              setEditGroup(record);
-              editForm.setFieldsValue({
-                name: record.name,
-                description: record.description,
-              });
-            }}
-          />
+          </Tooltip>
+          <Tooltip title="Edit group">
+            <Button
+              type="text"
+              size="small"
+              aria-label="Edit group"
+              icon={<EditOutlined />}
+              onClick={() => {
+                setEditGroup(record);
+                editForm.setFieldsValue({
+                  name: record.name,
+                  description: record.description,
+                });
+              }}
+            />
+          </Tooltip>
         </Space>
       ),
     },

--- a/admin-ui/src/pages/SessionsPage.tsx
+++ b/admin-ui/src/pages/SessionsPage.tsx
@@ -12,6 +12,7 @@ import {
   Drawer,
   Descriptions,
   DatePicker,
+  Tooltip,
   App,
 } from "antd";
 import {
@@ -221,26 +222,32 @@ function SessionsView({
       render: (_, record) => (
         <Space>
           {record.status === "active" && (
-            <Popconfirm
-              title="Deactivate this session?"
-              onConfirm={() => handleDeactivate(record.id)}
-              okText="Deactivate"
-              okButtonProps={{ danger: true }}
-            >
-              <Button
-                type="text"
-                size="small"
-                danger
-                icon={<DeleteOutlined />}
-              />
-            </Popconfirm>
+            <Tooltip title="Deactivate session">
+              <Popconfirm
+                title="Deactivate this session?"
+                onConfirm={() => handleDeactivate(record.id)}
+                okText="Deactivate"
+                okButtonProps={{ danger: true }}
+              >
+                <Button
+                  type="text"
+                  size="small"
+                  danger
+                  aria-label="Deactivate session"
+                  icon={<DeleteOutlined />}
+                />
+              </Popconfirm>
+            </Tooltip>
           )}
-          <Button
-            type="text"
-            size="small"
-            icon={<InfoCircleOutlined />}
-            onClick={() => setDetailSession(record)}
-          />
+          <Tooltip title="View details">
+            <Button
+              type="text"
+              size="small"
+              aria-label="View session details"
+              icon={<InfoCircleOutlined />}
+              onClick={() => setDetailSession(record)}
+            />
+          </Tooltip>
         </Space>
       ),
     },
@@ -532,32 +539,41 @@ export default function SessionsPage() {
       width: 120,
       render: (_, record) => (
         <Space>
-          <Popconfirm
-            title="Force sign out this device?"
-            description="This will revoke all sessions and tokens from this device."
-            onConfirm={() => handleForceLogout(record.id)}
-            okText="Sign Out"
-            okButtonProps={{ danger: true }}
-          >
+          <Tooltip title="Force sign out device">
+            <Popconfirm
+              title="Force sign out this device?"
+              description="This will revoke all sessions and tokens from this device."
+              onConfirm={() => handleForceLogout(record.id)}
+              okText="Sign Out"
+              okButtonProps={{ danger: true }}
+            >
+              <Button
+                type="text"
+                size="small"
+                danger
+                aria-label="Force sign out device"
+                icon={<LogoutOutlined />}
+              />
+            </Popconfirm>
+          </Tooltip>
+          <Tooltip title="View OAuth sessions">
             <Button
               type="text"
               size="small"
-              danger
-              icon={<LogoutOutlined />}
+              aria-label="View OAuth sessions for device"
+              icon={<UnorderedListOutlined />}
+              onClick={() => setSessionsIdp(record)}
             />
-          </Popconfirm>
-          <Button
-            type="text"
-            size="small"
-            icon={<UnorderedListOutlined />}
-            onClick={() => setSessionsIdp(record)}
-          />
-          <Button
-            type="text"
-            size="small"
-            icon={<InfoCircleOutlined />}
-            onClick={() => setDetailSession(record)}
-          />
+          </Tooltip>
+          <Tooltip title="View details">
+            <Button
+              type="text"
+              size="small"
+              aria-label="View device details"
+              icon={<InfoCircleOutlined />}
+              onClick={() => setDetailSession(record)}
+            />
+          </Tooltip>
         </Space>
       ),
     },

--- a/admin-ui/src/pages/TokensPage.tsx
+++ b/admin-ui/src/pages/TokensPage.tsx
@@ -11,6 +11,7 @@ import {
   Descriptions,
   DatePicker,
   Alert,
+  Tooltip,
   App,
 } from "antd";
 import { DeleteOutlined, InfoCircleOutlined } from "@ant-design/icons";
@@ -240,26 +241,32 @@ export default function TokensPage() {
       render: (_, record) => (
         <Space>
           {record.status === "active" && (
-            <Popconfirm
-              title="Revoke this token?"
-              onConfirm={() => handleRevoke(record.id)}
-              okText="Revoke"
-              okButtonProps={{ danger: true }}
-            >
-              <Button
-                type="text"
-                size="small"
-                danger
-                icon={<DeleteOutlined />}
-              />
-            </Popconfirm>
+            <Tooltip title="Revoke token">
+              <Popconfirm
+                title="Revoke this token?"
+                onConfirm={() => handleRevoke(record.id)}
+                okText="Revoke"
+                okButtonProps={{ danger: true }}
+              >
+                <Button
+                  type="text"
+                  size="small"
+                  danger
+                  aria-label="Revoke token"
+                  icon={<DeleteOutlined />}
+                />
+              </Popconfirm>
+            </Tooltip>
           )}
-          <Button
-            type="text"
-            size="small"
-            icon={<InfoCircleOutlined />}
-            onClick={() => setDetailToken(record)}
-          />
+          <Tooltip title="View details">
+            <Button
+              type="text"
+              size="small"
+              aria-label="View token details"
+              icon={<InfoCircleOutlined />}
+              onClick={() => setDetailToken(record)}
+            />
+          </Tooltip>
         </Space>
       ),
     },

--- a/admin-ui/src/pages/UsersPage.tsx
+++ b/admin-ui/src/pages/UsersPage.tsx
@@ -286,53 +286,75 @@ export default function UsersPage() {
       key: "actions",
       render: (_, record) => (
         <Space>
-          <Popconfirm
-            title="Deactivate this user?"
-            description="The user will no longer be able to log in."
-            onConfirm={() => handleDelete(record.id!)}
-            okText="Deactivate"
-            okButtonProps={{ danger: true }}
-          >
-            <Button type="text" size="small" danger icon={<StopOutlined />} />
-          </Popconfirm>
-          <Button
-            type="text"
-            size="small"
-            icon={<TeamOutlined />}
-            onClick={() => setGroupsUser(record)}
-          />
-          <Button
-            type="text"
-            size="small"
-            icon={<IdcardOutlined />}
-            aria-label={`Custom claims for ${record.username}`}
-            onClick={() => setClaimsUser(record)}
-          />
-          <Button
-            type="text"
-            size="small"
-            icon={<LaptopOutlined />}
-            onClick={() => setSessionsUser(record)}
-          />
-          <Button
-            type="text"
-            size="small"
-            icon={<EditOutlined />}
-            onClick={() => setEditUser(record)}
-          />
-          {isLocked(record) && (
+          <Tooltip title="Deactivate user">
             <Popconfirm
-              title="Unlock this user?"
-              description="This will reset failed login attempts and remove the lockout."
-              onConfirm={() => handleUnlock(record.id!)}
-              okText="Unlock"
+              title="Deactivate this user?"
+              description="The user will no longer be able to log in."
+              onConfirm={() => handleDelete(record.id!)}
+              okText="Deactivate"
+              okButtonProps={{ danger: true }}
             >
               <Button
                 type="text"
                 size="small"
-                icon={<UnlockOutlined />}
+                danger
+                aria-label="Deactivate user"
+                icon={<StopOutlined />}
               />
             </Popconfirm>
+          </Tooltip>
+          <Tooltip title="Manage groups">
+            <Button
+              type="text"
+              size="small"
+              aria-label="Manage user groups"
+              icon={<TeamOutlined />}
+              onClick={() => setGroupsUser(record)}
+            />
+          </Tooltip>
+          <Tooltip title="Custom claims">
+            <Button
+              type="text"
+              size="small"
+              icon={<IdcardOutlined />}
+              aria-label={`Custom claims for ${record.username}`}
+              onClick={() => setClaimsUser(record)}
+            />
+          </Tooltip>
+          <Tooltip title="View sessions">
+            <Button
+              type="text"
+              size="small"
+              aria-label="View user sessions"
+              icon={<LaptopOutlined />}
+              onClick={() => setSessionsUser(record)}
+            />
+          </Tooltip>
+          <Tooltip title="Edit user">
+            <Button
+              type="text"
+              size="small"
+              aria-label="Edit user"
+              icon={<EditOutlined />}
+              onClick={() => setEditUser(record)}
+            />
+          </Tooltip>
+          {isLocked(record) && (
+            <Tooltip title="Unlock user">
+              <Popconfirm
+                title="Unlock this user?"
+                description="This will reset failed login attempts and remove the lockout."
+                onConfirm={() => handleUnlock(record.id!)}
+                okText="Unlock"
+              >
+                <Button
+                  type="text"
+                  size="small"
+                  aria-label="Unlock user"
+                  icon={<UnlockOutlined />}
+                />
+              </Popconfirm>
+            </Tooltip>
           )}
         </Space>
       ),


### PR DESCRIPTION
## What

Every icon-only action button in the admin UI lists (Clients, Users, Groups, Sessions, Tokens, Federation, Audit Log) and the user drawers (groups, sessions, claims, deletion requests) had no hover text and no accessible name, making it hard to tell what each icon does.

Each button is now wrapped in an `antd` `Tooltip` and given an `aria-label`. Button sizes are unchanged (`size="small"` kept).

## Files

- `pages/`: ClientsPage, UsersPage, GroupsPage, SessionsPage, TokensPage, FederationPage, AuditLogPage
- `components/users/`: UserClaimsDrawer, UserSessionsDrawer, UserGroupsDrawer, DeletionRequestsTab

## Testing

- `pnpm build` (tsc -b + vite build) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nsv3YMyNPV2dJPrAo8iEUD